### PR TITLE
Support deserialization of a pending subscription.

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -60,6 +60,9 @@ public class Subscription extends AbstractSubscription {
     @XmlElement(name = "trial_ends_at")
     private DateTime trialEndsAt;
 
+    @XmlElement(name = "pending_subscription")
+    private Subscription pendingSubscription;
+
     @XmlElement(name = "starts_at")
     private DateTime startsAt;
 
@@ -172,6 +175,14 @@ public class Subscription extends AbstractSubscription {
         this.trialEndsAt = dateTimeOrNull(trialEndsAt);
     }
 
+    public Subscription getPendingSubscription() {
+        return pendingSubscription;
+    }
+
+    public void setPendingSubscription(final Subscription pendingSubscription) {
+        this.pendingSubscription = pendingSubscription;
+    }
+
     public DateTime getStartsAt() {
         return startsAt;
     }
@@ -226,6 +237,7 @@ public class Subscription extends AbstractSubscription {
         sb.append(", trialEndsAt=").append(trialEndsAt);
         sb.append(", startsAt=").append(startsAt);
         sb.append(", addOns=").append(addOns);
+        sb.append(", pendingSubscription=").append(pendingSubscription);
         sb.append('}');
         return sb.toString();
     }
@@ -290,7 +302,9 @@ public class Subscription extends AbstractSubscription {
         if (startsAt != null ? !startsAt.equals(that.startsAt) : that.startsAt != null) {
             return false;
         }
-
+        if (pendingSubscription != null ? !pendingSubscription.equals(that.pendingSubscription) : that.pendingSubscription != null) {
+            return false;
+        }
         if (collectionMethod != null ? !collectionMethod.equals(that.collectionMethod) : that.collectionMethod != null) {
             return false;
         }
@@ -323,6 +337,7 @@ public class Subscription extends AbstractSubscription {
         result = 31 * result + (trialStartedAt != null ? trialStartedAt.hashCode() : 0);
         result = 31 * result + (trialEndsAt != null ? trialEndsAt.hashCode() : 0);
         result = 31 * result + (addOns != null ? addOns.hashCode() : 0);
+        result = 31 * result + (pendingSubscription != null ? pendingSubscription.hashCode() : 0);
         result = 31 * result + (startsAt != null ? startsAt.hashCode() : 0);
         result = 31 * result + (collectionMethod != null ? collectionMethod.hashCode() : 0);
         result = 31 * result + (netTerms != null ? netTerms.hashCode() : 0);

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -55,10 +55,21 @@ public class TestSubscription extends TestModelBase {
                                         "  <po_number>PO19384</po_number>\n" +
                                         "  <subscription_add_ons type=\"array\">\n" +
                                         "  </subscription_add_ons>\n" +
+                                        "  <pending_subscription type=\"subscription\">\n" +
+                                        "    <plan href=\"https://api.recurly.com/v2/plans/silver\">\n" +
+                                        "      <plan_code>silver</plan_code>\n" +
+                                        "      <name>Silver plan</name>\n" +
+                                        "    </plan>\n" +
+                                        "    <unit_amount_in_cents type=\"integer\">400</unit_amount_in_cents>\n" +
+                                        "    <quantity type=\"integer\">1</quantity>\n" +
+                                        "    <subscription_add_ons type=\"array\">\n" +
+                                        "    </subscription_add_ons>\n" +
+                                        "  </pending_subscription>\n" +
                                         "</subscription>";
 
         final Subscription subscription = verifySubscription(subscriptionData);
         verifyPaginationData(subscription);
+        verifyPendingSubscription(subscription);
         Assert.assertEquals(subscription.getAddOns().size(), 0);
     }
 
@@ -151,5 +162,14 @@ public class TestSubscription extends TestModelBase {
         // Verify nested attributes
         Assert.assertEquals(subscription.getAccount().getHref(), "https://api.recurly.com/v2/accounts/1");
         Assert.assertEquals(subscription.getAccount().getAccountCode(), "1");
+    }
+
+    private void verifyPendingSubscription(final Subscription subscription) {
+        Subscription pending = subscription.getPendingSubscription();
+        Assert.assertEquals(pending.getPlan().getPlanCode(), "silver");
+        Assert.assertEquals(pending.getPlan().getName(), "Silver plan");
+        Assert.assertEquals(pending.getUnitAmountInCents(), (Integer) 400);
+        Assert.assertEquals(pending.getQuantity(), (Integer) 1);
+        Assert.assertEquals(pending.getAddOns().size(), 0);
     }
 }


### PR DESCRIPTION
When subscription changes are scheduled at renewal (not immediately), `<subscription>` element has a child `<pending_subscription>` element, though Recurly API Document refers this only slightly (see http://docs.recurly.com/api/subscriptions).

I confirmed following xml was received from Recurly.

``` xml
<subscription href="https://api.recurly.com/v2/subscriptions/...">
  ...
  <pending_subscription type="subscription">
    <plan href="https://api.recurly.com/v2/plans/XXXX">
      <plan_code>XXXX</plan_code>
      <name>Some plan name</name>
    </plan>
    <unit_amount_in_cents type="integer">1900</unit_amount_in_cents>
    <quantity type="integer">1</quantity>
    <subscription_add_ons type="array">
    </subscription_add_ons>
  </pending_subscription>
```

Because I want to handle pending subscriptions, I implemented deserialization logic of a `<pending_subscription>` element. Please review and merge this modification if possible.

Thanks
