### PR TITLE
Make Address zip consistent with BillingInfo zip 

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Address.java
+++ b/src/main/java/com/ning/billing/recurly/model/Address.java
@@ -35,7 +35,7 @@ public class Address extends RecurlyObject {
     private String state;
 
     @XmlElement(name = "zip")
-    private Integer zip;
+    private String zip;
 
     @XmlElement(name = "country")
     private String country;
@@ -75,12 +75,12 @@ public class Address extends RecurlyObject {
         this.state = stringOrNull(state);
     }
 
-    public Integer getZip() {
+    public String getZip() {
         return zip;
     }
 
     public void setZip(final Object zip) {
-        this.zip = integerOrNull(zip);
+        this.zip = stringOrNull(zip);
     }
 
     public String getCountry() {

--- a/src/test/java/com/ning/billing/recurly/model/TestAccount.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccount.java
@@ -46,7 +46,7 @@ public class TestAccount extends TestModelBase {
                                    "      <address2 nil=\"nil\"></address2>\n" +
                                    "      <city>San Francisco</city>\n" +
                                    "      <state>CA</state>\n" +
-                                   "      <zip>94105</zip>\n" +
+                                   "      <zip>94105-1804</zip>\n" +
                                    "      <country>US</country>\n" +
                                    "      <phone nil=\"nil\"></phone>\n" +
                                    "  </address>" +
@@ -67,7 +67,7 @@ public class TestAccount extends TestModelBase {
         Assert.assertNull(account.getAddress().getAddress2());
         Assert.assertEquals(account.getAddress().getCity(), "San Francisco");
         Assert.assertEquals(account.getAddress().getState(), "CA");
-        Assert.assertEquals(account.getAddress().getZip(), (Integer) 94105);
+        Assert.assertEquals(account.getAddress().getZip(), "94105-1804");
         Assert.assertEquals(account.getAddress().getCountry(), "US");
         Assert.assertNull(account.getAddress().getPhone());
     }


### PR DESCRIPTION
Treat Address.zip as a string to support dashes and international postal codes.
