### PR TITLE
change type for vat number to string

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -41,7 +41,7 @@ public class Invoice extends RecurlyObject {
     private Integer poNumber;
 
     @XmlElement(name = "vat_number")
-    private Integer varNumber;
+    private String varNumber;
 
     @XmlElement(name = "subtotal_in_cents")
     private Integer subtotalInCents;
@@ -109,12 +109,12 @@ public class Invoice extends RecurlyObject {
         this.poNumber = integerOrNull(poNumber);
     }
 
-    public Integer getVarNumber() {
+    public String getVarNumber() {
         return varNumber;
     }
 
-    public void setVarNumber(final Object varNumber) {
-        this.varNumber = integerOrNull(varNumber);
+    public void setVarNumber(final String varNumber) {
+        this.varNumber = stringOrNull(varNumber);
     }
 
     public Integer getSubtotalInCents() {


### PR DESCRIPTION
Hey,

vat numbers are in germany integers but in most other countries not. (can you please release this fix asap?)

BR

Andreas
