### PR TITLE
fix parsing of nil values for tax_number

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -113,7 +113,7 @@ public class Invoice extends RecurlyObject {
         return vatNumber;
     }
 
-    public void setVatNumber(final String varNumber) {
+    public void setVatNumber(final Object varNumber) {
         this.vatNumber = stringOrNull(varNumber);
     }
 


### PR DESCRIPTION
if recurly sends nil values it can be handled now properly
