### PR TITLE
Protect against null error object

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyAPIException.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyAPIException.java
@@ -23,7 +23,7 @@ public class RecurlyAPIException extends RuntimeException {
     private final RecurlyAPIError recurlyError;
 
     public RecurlyAPIException(final RecurlyAPIError recurlyError) {
-        super(recurlyError.toString());
+        super(recurlyError.toString()==null? "Unspecified API Error" : recurlyError.toString());
         this.recurlyError = recurlyError;
     }
 


### PR DESCRIPTION
In certain situations, library fails to parse the recurly error message (example below). This will lead to a null RecurlyAPIError object (which is fine) and an NPE in the RecurlyAPIException ctr - which is not.
This fix just guards against this, so that we have a reasonable RecurlyAPIException, and not an NPE.

Example:
RecurlyClient@832 inits recurlyError with null. An exception in line 834 would lead to an NPE in line 838.
