### PR TITLE
Implement Subscription/Subscription Update Preview API calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,7 @@
                     <!--
                       | Apple's JVM sometimes requires more memory
                     -->
+		    <additionalparam>-Xdoclint:none</additionalparam>
                     <additionalJOption>-J-Xmx1024m</additionalJOption>
                     <source>1.6</source>
                     <encoding>UTF-8</encoding>

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -249,6 +249,20 @@ public class RecurlyClient {
         return doPOST(Subscription.SUBSCRIPTION_RESOURCE,
                       subscription, Subscription.class);
     }
+	
+    /**
+     * Preview a subscription
+     * <p/>
+     * Previews a subscription for an account.
+     *
+     * @param subscription Subscription object
+     * @return the newly created Subscription object on success, null otherwise
+     */
+    public Subscription previewSubscription(final Subscription subscription) {
+        return doPOST(Subscription.SUBSCRIPTION_RESOURCE
+					  + "/preview",
+                      subscription, Subscription.class);
+    }
 
     /**
      * Get a particular {@link Subscription} by it's UUID
@@ -316,7 +330,7 @@ public class RecurlyClient {
     /**
      * Update a particular {@link Subscription} by it's UUID
      * <p/>
-     * Returns information about a single account.
+     * Returns information about a single subscription.
      *
      * @param uuid UUID of the subscription to update
      * @return Subscription the updated subscription
@@ -324,6 +338,21 @@ public class RecurlyClient {
     public Subscription updateSubscription(final String uuid, final SubscriptionUpdate subscriptionUpdate) {
         return doPUT(Subscriptions.SUBSCRIPTIONS_RESOURCE
                      + "/" + uuid,
+                     subscriptionUpdate,
+                     Subscription.class);
+    }
+	
+    /**
+     * Preview an update to a particular {@link Subscription} by it's UUID
+     * <p/>
+     * Returns information about a single subscription.
+     *
+     * @param uuid UUID of the subscription to preview and update for
+     * @return Subscription the updated subscription preview
+     */
+    public Subscription updateSubscriptionPreview(final String uuid, final SubscriptionUpdate subscriptionUpdate) {
+        return doPOST(Subscriptions.SUBSCRIPTIONS_RESOURCE
+                     + "/" + uuid + "/preview",
                      subscriptionUpdate,
                      Subscription.class);
     }

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -347,7 +347,7 @@ public class RecurlyClient {
      * <p/>
      * Returns information about a single subscription.
      *
-     * @param uuid UUID of the subscription to preview and update for
+     * @param uuid UUID of the subscription to preview an update for
      * @return Subscription the updated subscription preview
      */
     public Subscription updateSubscriptionPreview(final String uuid, final SubscriptionUpdate subscriptionUpdate) {

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -423,13 +423,27 @@ public class TestRecurlyClient {
             // Create a plan
             final Plan plan = recurlyClient.createPlan(planData);
 
-            // Subscribe the user to the plan
+            // Set up a subscription
             final Subscription subscriptionData = new Subscription();
             subscriptionData.setPlanCode(plan.getPlanCode());
             subscriptionData.setAccount(accountData);
             subscriptionData.setCurrency(CURRENCY);
             subscriptionData.setUnitAmountInCents(1242);
             final DateTime creationDateTime = new DateTime(DateTimeZone.UTC);
+			
+			// Preview the user subscribing to the plan
+			final Subscription subscriptionPreview = recurlyClient.previewSubscription(subscriptionData);
+				
+			// Test the subscription preview
+            Assert.assertNotNull(subscriptionPreview);
+            Assert.assertEquals(subscriptionPreview.getCurrency(), subscriptionData.getCurrency());
+            if (null == subscriptionData.getQuantity()) {
+                Assert.assertEquals(subscriptionPreview.getQuantity(), new Integer(1));
+            } else {
+                Assert.assertEquals(subscriptionPreview.getQuantity(), subscriptionData.getQuantity());
+            }
+			
+			// Subscribe the user to the plan
             final Subscription subscription = recurlyClient.createSubscription(subscriptionData);
 
             // Test subscription creation
@@ -681,12 +695,22 @@ public class TestRecurlyClient {
             final DateTime creationDateTime = new DateTime(DateTimeZone.UTC);
             final Subscription subscription = recurlyClient.createSubscription(subscriptionData);
 
-            // Test subscription creation
             Assert.assertNotNull(subscription);
-
+			
+			// Set subscription update info.			
             final SubscriptionUpdate subscriptionUpdateData = new SubscriptionUpdate();
             subscriptionUpdateData.setTimeframe(SubscriptionUpdate.Timeframe.now);
             subscriptionUpdateData.setPlanCode(plan2.getPlanCode());
+			
+			// Preview the subscription update
+	        final Subscription subscriptionUpdatedPreview = recurlyClient.updateSubscriptionPreview(subscription.getUuid(), subscriptionUpdateData);
+            
+			Assert.assertNotNull(subscriptionUpdatedPreview);
+            Assert.assertEquals(subscription.getUuid(), subscriptionUpdatedPreview.getUuid());
+            Assert.assertNotEquals(subscription.getPlan(), subscriptionUpdatedPreview.getPlan());
+            Assert.assertEquals(plan2.getPlanCode(), subscriptionUpdatedPreview.getPlan().getPlanCode());
+			
+			//Update the subscription
             final Subscription subscriptionUpdated = recurlyClient.updateSubscription(subscription.getUuid(), subscriptionUpdateData);
 
             Assert.assertNotNull(subscriptionUpdated);


### PR DESCRIPTION
The RecurlyClient class is missing the ability to [preview a new subscription](https://docs.recurly.com/api/subscriptions#preview-sub) or to [preview a change to an existing subscription] (https://docs.recurly.com/api/subscriptions#preview-sub). Since these API calls return the same type of response as the [createSubscription](https://github.com/cgerrior/recurly-java-library/blob/master/src/main/java/com/ning/billing/recurly/RecurlyClient.java#L248) and [updateSubscription](https://github.com/cgerrior/recurly-java-library/blob/master/src/main/java/com/ning/billing/recurly/RecurlyClient.java#L324) methods do currently, I essentially copied those and modified the URL that is called appropriately.