### PR TITLE
adds sub notes

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -57,6 +57,7 @@ import com.ning.billing.recurly.model.Redemption;
 import com.ning.billing.recurly.model.RefundOption;
 import com.ning.billing.recurly.model.Subscription;
 import com.ning.billing.recurly.model.SubscriptionUpdate;
+import com.ning.billing.recurly.model.SubscriptionNotes;
 import com.ning.billing.recurly.model.Subscriptions;
 import com.ning.billing.recurly.model.Transaction;
 import com.ning.billing.recurly.model.Transactions;
@@ -287,10 +288,10 @@ public class RecurlyClient {
     /**
      * Get a particular {@link Subscription} by it's UUID
      * <p/>
-     * Returns information about a single account.
+     * Returns information about a single subscription.
      *
      * @param uuid UUID of the subscription to lookup
-     * @return Subscriptions for the specified user
+     * @return Subscription
      */
     public Subscription getSubscription(final String uuid) {
         return doGET(Subscriptions.SUBSCRIPTIONS_RESOURCE
@@ -376,6 +377,21 @@ public class RecurlyClient {
                       + "/" + uuid + "/preview",
                       subscriptionUpdate,
                       Subscription.class);
+    }
+    
+    
+    /**
+     * Update to a particular {@link Subscription}'s notes by it's UUID
+     * <p/>
+     * Returns information about a single subscription.
+     *
+     * @param uuid UUID of the subscription to preview an update for
+     * @param subscriptionNotes SubscriptionNotes object
+     * @return Subscription the updated subscription 
+     */
+    public Subscription updateSubscriptionNotes(final String uuid, final SubscriptionNotes subscriptionNotes) {
+      return doPUT(SubscriptionNotes.SUBSCRIPTION_RESOURCE + "/" + uuid + "/notes",
+                   subscriptionNotes, Subscription.class);
     }
 
     /**

--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -82,6 +82,12 @@ public class Subscription extends AbstractSubscription {
     //Purchase Order Number
     @XmlElement(name = "po_number")
     private String poNumber;
+    
+    @XmlElement(name = "terms_and_conditions")
+    private String termsAndConditions;
+    
+    @XmlElement(name = "customer_notes")
+    private String customerNotes;
 
     @XmlElement(name = "first_renewal_date")
     private DateTime firstRenewalDate;
@@ -208,7 +214,6 @@ public class Subscription extends AbstractSubscription {
         this.startsAt = dateTimeOrNull(startsAt);
     }
 
-
     public String getCollectionMethod() {
         return collectionMethod;
     }
@@ -235,6 +240,22 @@ public class Subscription extends AbstractSubscription {
 
     public DateTime getFirstRenewalDate() {
         return firstRenewalDate;
+    }
+    
+    public String getCustomerNotes() {
+        return customerNotes;
+    }
+
+    public void setCustomerNotes(Object customerNotes) {
+        this.customerNotes = stringOrNull(customerNotes);
+    }
+    
+    public String getTermsAndConditions() {
+        return termsAndConditions;
+    }
+
+    public void setTermsAndConditions(Object termsAndConditions) {
+        this.termsAndConditions = stringOrNull(termsAndConditions);
     }
 
     public void setFirstRenewalDate(final Object firstRenewalDate) {

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionNotes.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionNotes.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+
+public class SubscriptionNotes extends AbstractSubscription {
+
+    @XmlElement(name = "terms_and_conditions")
+    private String termsAndConditions;
+    
+    @XmlElement(name = "customer_notes")
+    private String customerNotes;
+    
+    @XmlElement(name = "vat_reverse_charge_notes")
+    private String vatReverseChargeNotes;    
+
+    public String getTermsAndConditions() {
+        return termsAndConditions;
+    }
+
+    public void setTermsAndConditions(final Object termsAndConditions) {
+        this.termsAndConditions = stringOrNull(termsAndConditions);
+    }
+    
+    public String getCustomerNotes() {
+        return customerNotes;
+    }
+
+    public void setCustomerNotes(final Object customerNotes) {
+        this.customerNotes = stringOrNull(customerNotes);
+    }
+    
+    public String getVatReverseChargeNotes() {
+        return vatReverseChargeNotes;
+    }
+
+    public void setVatReverseChargeNotes(final Object getVatReverseChargeNotes) {
+        this.vatReverseChargeNotes = stringOrNull(vatReverseChargeNotes);
+    }
+    
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("Subscription{");
+        sb.append("termsAndConditions=").append(termsAndConditions).append('\'');
+        sb.append(", customerNotes=").append(customerNotes).append('\'');
+        sb.append(", vatReverseChargeNotes=").append(vatReverseChargeNotes).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        final SubscriptionNotes that = (SubscriptionNotes) o;
+
+        if (termsAndConditions != null ? !termsAndConditions.equals(that.termsAndConditions) : that.termsAndConditions != null) {
+            return false;
+        }
+        
+        if (customerNotes != null ? !customerNotes.equals(that.customerNotes) : that.customerNotes != null) {
+            return false;
+        }
+        
+        if (vatReverseChargeNotes != null ? !vatReverseChargeNotes.equals(that.vatReverseChargeNotes) : that.vatReverseChargeNotes != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (termsAndConditions != null ? termsAndConditions.hashCode() : 0);
+        result = 31 * result + (customerNotes != null ? customerNotes.hashCode() : 0);
+        result = 31 * result + (vatReverseChargeNotes != null ? vatReverseChargeNotes.hashCode() : 0);             
+        return result;
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -47,6 +47,7 @@ import com.ning.billing.recurly.model.RefundOption;
 import com.ning.billing.recurly.model.Subscription;
 import com.ning.billing.recurly.model.SubscriptionAddOns;
 import com.ning.billing.recurly.model.SubscriptionUpdate;
+import com.ning.billing.recurly.model.SubscriptionNotes;
 import com.ning.billing.recurly.model.Subscriptions;
 import com.ning.billing.recurly.model.Transaction;
 import com.ning.billing.recurly.model.Transactions;
@@ -441,6 +442,9 @@ public class TestRecurlyClient {
             subscriptionData.setUnitAmountInCents(1242);
             // Apply a coupon at the time of subscription creation
             subscriptionData.setCouponCode(couponData.getCouponCode());
+            // Create some notes on the subscription
+            subscriptionData.setCustomerNotes("Customer Notes");
+            subscriptionData.setTermsAndConditions("Terms and Conditions");
             final DateTime creationDateTime = new DateTime(DateTimeZone.UTC);
 
             // Preview the user subscribing to the plan
@@ -499,6 +503,19 @@ public class TestRecurlyClient {
             final Redemption redemption = recurlyClient.getCouponRedemptionByAccount(account.getAccountCode());
             Assert.assertNotNull(redemption);
             Assert.assertEquals(redemption.getCoupon().getCouponCode(), couponData.getCouponCode());
+            
+            // Update the subscription's notes
+            final SubscriptionNotes subscriptionNotesData = new SubscriptionNotes();
+            subscriptionNotesData.setTermsAndConditions("New Terms and Conditions");
+            subscriptionNotesData.setCustomerNotes("New Customer Notes");
+                      
+            recurlyClient.updateSubscriptionNotes(subscription.getUuid(), subscriptionNotesData);
+            final Subscription subscriptionWithNotes = recurlyClient.getSubscription(subscription.getUuid());
+              
+            // Verify that the notes were updated
+            Assert.assertNotNull(subscriptionWithNotes);
+            Assert.assertEquals(subscriptionWithNotes.getTermsAndConditions(), subscriptionNotesData.getTermsAndConditions());
+            Assert.assertEquals(subscriptionWithNotes.getCustomerNotes(), subscriptionNotesData.getCustomerNotes());
 
             // Cancel a Subscription
             recurlyClient.cancelSubscription(subscription);


### PR DESCRIPTION
Adds the ability to define subscription notes (for purposes of customer communication) for a new subscription. Also allows you to [update an existing subscription's notes](https://docs.recurly.com/api/subscriptions#update-subscription-notes).