### PR TITLE
Replaces "api.recurly.com" w/ ":subdomain.recurly.com" for easier troubleshooting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Development
 1. Make sure you can build the project by running the smoke tests: `mvn clean test`
 2. Go to [recurly.com](http://recurly.com/) and create an account. This account will be used as a sandbox environment for testing.
 3. In your Recurly account, click on **API Credentials** (bottom of the left menu), click the **Enable API Access** button and write down your API Key.
-4. Verify the setup by running the recurly-java-library integration tests (make sure to update your API Key): `mvn clean test -Pintegration -Dkillbill.payment.recurly.apiKey=1234567689abcdef`
+4. Verify the setup by running the recurly-java-library integration tests (make sure to update your API Key and Subdomain): `mvn clean test -Pintegration -Dkillbill.payment.recurly.apiKey=1234567689abcdef -Dkillbill.payment.recurly.subDomain=mycompany`
 5. Go to your Recurly account, you should see some data (e.g. account created).
 6. Congrats! You're all set!
 

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -127,9 +127,13 @@ public class RecurlyClient {
     private final String key;
     private final String baseUrl;
     private AsyncHttpClient client;
-
+    
     public RecurlyClient(final String apiKey) {
-        this(apiKey, "api.recurly.com", 443, "v2");
+        this(apiKey, "api");
+    }
+
+    public RecurlyClient(final String apiKey, final String subDomain) {
+        this(apiKey, subDomain + ".recurly.com", 443, "v2");
     }
 
     public RecurlyClient(final String apiKey, final String host, final int port, final String version) {

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -56,6 +56,7 @@ public class TestRecurlyClient {
 
     public static final String RECURLY_PAGE_SIZE = "recurly.page.size";
     public static final String KILLBILL_PAYMENT_RECURLY_API_KEY = "killbill.payment.recurly.apiKey";
+    public static final String KILLBILL_PAYMENT_RECURLY_SUBDOMAIN = "killbill.payment.recurly.subDomain";
     public static final String KILLBILL_PAYMENT_RECURLY_DEFAULT_CURRENCY_KEY = "killbill.payment.recurly.currency";
 
     // Default to USD for all tests, which is expected to be supported by Recurly by default
@@ -67,12 +68,19 @@ public class TestRecurlyClient {
     @BeforeMethod(groups = {"integration", "enterprise"})
     public void setUp() throws Exception {
         final String apiKey = System.getProperty(KILLBILL_PAYMENT_RECURLY_API_KEY);
+        String subDomainTemp = System.getProperty(KILLBILL_PAYMENT_RECURLY_SUBDOMAIN);
         if (apiKey == null) {
             Assert.fail("You need to set your Recurly api key to run integration tests:" +
                         " -Dkillbill.payment.recurly.apiKey=...");
         }
+        
+        if (subDomainTemp == null) {
+          subDomainTemp = "api";
+        }
+        
+        final String subDomain = subDomainTemp;
 
-        recurlyClient = new RecurlyClient(apiKey);
+        recurlyClient = new RecurlyClient(apiKey, subDomain);
         recurlyClient.open();
     }
 

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClientUserAgent.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClientUserAgent.java
@@ -31,7 +31,7 @@ public class TestRecurlyClientUserAgent {
 
     @BeforeMethod(groups = "fast")
     public void setUp() throws Exception {
-        recurlyClient = new RecurlyClient(UUID.randomUUID().toString());
+        recurlyClient = new RecurlyClient(UUID.randomUUID().toString(), "api");
     }
 
     @Test(groups = "fast")


### PR DESCRIPTION
Recurly API requests should be made to ":subdomain.recurly.com" rather than "api.recurly.com". This allows for easier troubleshooting.