### PR TITLE
Void Notification Parsing Issues

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/push/Notification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/Notification.java
@@ -39,7 +39,7 @@ public abstract class Notification extends RecurlyObject {
         FailedPaymentNotification(com.ning.billing.recurly.model.push.payment.FailedPaymentNotification.class),
         SuccessfulPaymentNotification(com.ning.billing.recurly.model.push.payment.SuccessfulPaymentNotification.class),
         SuccessfulRefundNotification(com.ning.billing.recurly.model.push.payment.SuccessfulRefundNotification.class),
-        VoidedPaymentNotification(com.ning.billing.recurly.model.push.payment.VoidedPaymentNotification.class),
+        VoidPaymentNotification(com.ning.billing.recurly.model.push.payment.VoidPaymentNotification.class),
         CanceledSubscriptionNotification(com.ning.billing.recurly.model.push.subscription.CanceledSubscriptionNotification.class),
         ExpiredSubscriptionNotification(com.ning.billing.recurly.model.push.subscription.ExpiredSubscriptionNotification.class),
         NewSubscriptionNotification(com.ning.billing.recurly.model.push.subscription.NewSubscriptionNotification.class),

--- a/src/main/java/com/ning/billing/recurly/model/push/payment/VoidPaymentNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/payment/VoidPaymentNotification.java
@@ -19,9 +19,9 @@ package com.ning.billing.recurly.model.push.payment;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "void_payment_notification")
-public class VoidedPaymentNotification extends PaymentNotification {
+public class VoidPaymentNotification extends PaymentNotification {
 
-    public static VoidedPaymentNotification read(final String payload) {
-        return read(payload, VoidedPaymentNotification.class);
+    public static VoidPaymentNotification read(final String payload) {
+        return read(payload, VoidPaymentNotification.class);
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
@@ -34,7 +34,7 @@ import com.ning.billing.recurly.model.push.payment.PaymentNotification;
 import com.ning.billing.recurly.model.push.payment.PushTransaction;
 import com.ning.billing.recurly.model.push.payment.SuccessfulPaymentNotification;
 import com.ning.billing.recurly.model.push.payment.SuccessfulRefundNotification;
-import com.ning.billing.recurly.model.push.payment.VoidedPaymentNotification;
+import com.ning.billing.recurly.model.push.payment.VoidPaymentNotification;
 import com.ning.billing.recurly.model.push.subscription.CanceledSubscriptionNotification;
 import com.ning.billing.recurly.model.push.subscription.ExpiredSubscriptionNotification;
 import com.ning.billing.recurly.model.push.subscription.NewSubscriptionNotification;
@@ -262,8 +262,8 @@ public class TestNotification extends TestModelBase {
     }
 
     @Test(groups = "fast")
-    public void testVoidedPaymentNotification() {
-        deserialize(VoidedPaymentNotification.class);
+    public void testVoidPaymentNotification() {
+        deserialize(VoidPaymentNotification.class);
     }
 
     @Test(groups = "fast")

--- a/src/test/java/com/ning/billing/recurly/model/push/TestVoidNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestVoidNotification.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model.push;
+
+import com.ning.billing.recurly.model.TestModelBase;
+import com.ning.billing.recurly.model.push.payment.VoidPaymentNotification;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+// See http://docs.recurly.com/api/push-notifications
+public class TestVoidNotification extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        final String voidData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                "<void_payment_notification>\n" +
+                                "  <account>\n" +
+                                "    <account_code>1</account_code>\n" +
+                                "    <username nil=\"true\"></username>\n" +
+                                "    <email>verena@example.com</email>\n" +
+                                "    <first_name>Verena</first_name>\n" +
+                                "    <last_name>Example</last_name>\n" +
+                                "    <company_name nil=\"true\"></company_name>\n" +
+                                "  </account>\n" +
+                                "  <transaction>\n" +
+                                "    <id>4997ace0f57341adb3e857f9f7d15de8</id>\n" +
+                                "    <invoice_id>ffc64d71d4b5404e93f13aac9c63b007</invoice_id>\n" +
+                                "    <invoice_number_prefix></invoice_number_prefix>\n" +
+                                "    <invoice_number type=\"integer\">2059</invoice_number>\n" +
+                                "    <subscription_id>1974a098jhlkjasdfljkha898326881c</subscription_id>\n" +
+                                "    <action>purchase</action>\n" +
+                                "    <date type=\"datetime\">2010-10-05T23:00:50Z</date>\n" +
+                                "    <amount_in_cents type=\"integer\">235</amount_in_cents>\n" +
+                                "    <status>void</status>\n" +
+                                "    <message>Test Gateway: Successful test transaction</message>\n" +
+                                "    <reference></reference>\n" +
+                                "    <source>subscription</source>\n" +
+                                "    <cvv_result code=\"M\">Match</cvv_result>\n" +
+                                "    <avs_result code=\"D\">Street address and postal code match.</avs_result>\n" +
+                                "    <avs_result_street></avs_result_street>\n" +
+                                "    <avs_result_postal></avs_result_postal>\n" +
+                                "    <test type=\"boolean\">true</test>\n" +
+                                "    <voidable type=\"boolean\">false</voidable>\n" +
+                                "    <refundable type=\"boolean\">false</refundable>\n" +
+                                "  </transaction>\n" +
+                                "</void_payment_notification>";
+
+        Notification.Type detected = Notification.detect(voidData);
+        Assert.assertEquals(detected.getJavaType(), VoidPaymentNotification.class);
+
+        final VoidPaymentNotification voidPaymentNotification = Notification.read(voidData, VoidPaymentNotification.class);
+        Assert.assertNotNull(voidPaymentNotification);
+    }
+
+}


### PR DESCRIPTION
Refactored voidedNotification to voidNotification to fit recurlys object.  Also fixed ability to parse the void_payment_notification webhook.

This PR address:
https://github.com/killbilling/recurly-java-library/issues/75