### PR TITLE
Added invoice webhooks

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/push/Notification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/Notification.java
@@ -45,7 +45,11 @@ public abstract class Notification extends RecurlyObject {
         NewSubscriptionNotification(com.ning.billing.recurly.model.push.subscription.NewSubscriptionNotification.class),
         ReactivatedAccountNotification(com.ning.billing.recurly.model.push.subscription.ReactivatedAccountNotification.class),
         RenewedSubscriptionNotification(com.ning.billing.recurly.model.push.subscription.RenewedSubscriptionNotification.class),
-        UpdatedSubscriptionNotification(com.ning.billing.recurly.model.push.subscription.UpdatedSubscriptionNotification.class),;
+        UpdatedSubscriptionNotification(com.ning.billing.recurly.model.push.subscription.UpdatedSubscriptionNotification.class),
+        ClosedInvoiceNotification(com.ning.billing.recurly.model.push.invoice.ClosedInvoiceNotification.class),
+        NewInvoiceNotification(com.ning.billing.recurly.model.push.invoice.NewInvoiceNotification.class),
+        PastDueInvoiceNotification(com.ning.billing.recurly.model.push.invoice.PastDueInvoiceNotification.class),
+        ProcessingInvoiceNotification(com.ning.billing.recurly.model.push.invoice.ProcessingInvoiceNotification.class);
 
         private Class<? extends Notification> javaType;
 

--- a/src/main/java/com/ning/billing/recurly/model/push/invoice/ClosedInvoiceNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/invoice/ClosedInvoiceNotification.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model.push.invoice;
+
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "closed_invoice_notification")
+public class ClosedInvoiceNotification extends InvoiceNotification {
+
+  public static ClosedInvoiceNotification read(final String payload) {
+    return read(payload, ClosedInvoiceNotification.class);
+  }
+
+}

--- a/src/main/java/com/ning/billing/recurly/model/push/invoice/InvoiceNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/invoice/InvoiceNotification.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model.push.invoice;
+
+import com.ning.billing.recurly.model.push.account.AccountNotification;
+
+import javax.xml.bind.annotation.XmlElement;
+
+public abstract class InvoiceNotification extends AccountNotification {
+
+    @XmlElement(name = "invoice")
+    private PushInvoice invoice;
+
+    public PushInvoice getInvoice() {
+        return invoice;
+    }
+
+    public void setInvoice(PushInvoice invoice) {
+        this.invoice = invoice;
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/push/invoice/NewInvoiceNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/invoice/NewInvoiceNotification.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model.push.invoice;
+
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "new_invoice_notification")
+public class NewInvoiceNotification extends InvoiceNotification {
+
+  public static NewInvoiceNotification read(final String payload) {
+    return read(payload, NewInvoiceNotification.class);
+  }
+
+}

--- a/src/main/java/com/ning/billing/recurly/model/push/invoice/PastDueInvoiceNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/invoice/PastDueInvoiceNotification.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model.push.invoice;
+
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "past_due_invoice_notification")
+public class PastDueInvoiceNotification extends InvoiceNotification {
+
+  public static PastDueInvoiceNotification read(final String payload) {
+    return read(payload, PastDueInvoiceNotification.class);
+  }
+
+}

--- a/src/main/java/com/ning/billing/recurly/model/push/invoice/ProcessingInvoiceNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/invoice/ProcessingInvoiceNotification.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model.push.invoice;
+
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "processing_invoice_notification")
+public class ProcessingInvoiceNotification extends InvoiceNotification {
+
+  public static ProcessingInvoiceNotification read(final String payload) {
+    return read(payload, ProcessingInvoiceNotification.class);
+  }
+
+}

--- a/src/main/java/com/ning/billing/recurly/model/push/invoice/PushInvoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/invoice/PushInvoice.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model.push.invoice;
+
+import com.ning.billing.recurly.model.Invoice;
+import org.joda.time.DateTime;
+
+import javax.xml.bind.annotation.XmlElement;
+
+public class PushInvoice extends Invoice {
+
+    @XmlElement(name = "subscription_id")
+    private String subscriptionId;
+
+    @XmlElement(name = "invoice_number_prefix")
+    private String invoiceNumberPrefix;
+
+    @XmlElement(name = "date")
+    private DateTime date;
+
+    @XmlElement(name = "closed_at")
+    private DateTime closedAt;
+
+    public void setSubscriptionId(Object subscriptionId) {
+        this.subscriptionId = stringOrNull(subscriptionId);
+    }
+
+    public String getSubscriptionId() {
+        return subscriptionId;
+    }
+
+    public String getInvoiceNumberPrefix() {
+        return invoiceNumberPrefix;
+    }
+
+    public void setInvoiceNumberPrefix(Object invoiceNumberPrefix) {
+        this.invoiceNumberPrefix = stringOrNull(invoiceNumberPrefix);
+    }
+
+    public DateTime getDate() {
+        return date;
+    }
+
+    public void setDate(Object date) {
+        this.date = dateTimeOrNull(date);
+    }
+
+    public DateTime getClosedAt() {
+        return closedAt;
+    }
+
+    public void setClosedAt(Object closedAt) {
+        this.closedAt = dateTimeOrNull(closedAt);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PushInvoice)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        final PushInvoice that = (PushInvoice) o;
+
+        if (subscriptionId != null ? !subscriptionId.equals(that.subscriptionId) : that.subscriptionId != null) {
+            return false;
+        }
+
+        if (invoiceNumberPrefix != null ? !invoiceNumberPrefix.equals(that.invoiceNumberPrefix) : that.invoiceNumberPrefix != null) {
+            return false;
+        }
+
+        if (date != null ? !date.equals(that.date) : that.date != null) {
+            return false;
+        }
+
+        if (closedAt != null ? !closedAt.equals(that.closedAt) : that.closedAt != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (subscriptionId != null ? subscriptionId.hashCode() : 0);
+        result = 31 * result + (invoiceNumberPrefix != null ? invoiceNumberPrefix.hashCode() : 0);
+        result = 31 * result + (date != null ? date.hashCode() : 0);
+        result = 31 * result + (closedAt != null ? closedAt.hashCode() : 0);
+        return result;
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/push/invoice/PushInvoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/invoice/PushInvoice.java
@@ -35,19 +35,19 @@ public class PushInvoice extends Invoice {
     @XmlElement(name = "closed_at")
     private DateTime closedAt;
 
-    public void setSubscriptionId(Object subscriptionId) {
-        this.subscriptionId = stringOrNull(subscriptionId);
-    }
-
     public String getSubscriptionId() {
         return subscriptionId;
+    }
+
+    public void setSubscriptionId(final Object subscriptionId) {
+        this.subscriptionId = stringOrNull(subscriptionId);
     }
 
     public String getInvoiceNumberPrefix() {
         return invoiceNumberPrefix;
     }
 
-    public void setInvoiceNumberPrefix(Object invoiceNumberPrefix) {
+    public void setInvoiceNumberPrefix(final Object invoiceNumberPrefix) {
         this.invoiceNumberPrefix = stringOrNull(invoiceNumberPrefix);
     }
 
@@ -55,7 +55,7 @@ public class PushInvoice extends Invoice {
         return date;
     }
 
-    public void setDate(Object date) {
+    public void setDate(final Object date) {
         this.date = dateTimeOrNull(date);
     }
 
@@ -63,7 +63,7 @@ public class PushInvoice extends Invoice {
         return closedAt;
     }
 
-    public void setClosedAt(Object closedAt) {
+    public void setClosedAt(final Object closedAt) {
         this.closedAt = dateTimeOrNull(closedAt);
     }
 

--- a/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
@@ -16,6 +16,7 @@
 
 package com.ning.billing.recurly.model.push;
 
+import com.ning.billing.recurly.model.push.invoice.*;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,6 +100,22 @@ public class TestNotification extends TestModelBase {
                                                   "  <refundable type=\"boolean\">true</refundable>\n" +
                                                   "</transaction>";
 
+    private static final String INVOICEDATA = "<invoice>\n" +
+                                              "  <uuid>ffc64d71d4b5404e93f13aac9c63b007</uuid>\n" +
+                                              "  <subscription_id nil=\"true\"></subscription_id>\n" +
+                                              "  <state>collected</state>\n" +
+                                              "  <invoice_number_prefix></invoice_number_prefix>\n" +
+                                              "  <invoice_number type=\"integer\">1000</invoice_number>\n" +
+                                              "  <po_number></po_number>\n" +
+                                              "  <vat_number></vat_number>\n" +
+                                              "  <total_in_cents type=\"integer\">1100</total_in_cents>\n" +
+                                              "  <currency>USD</currency>\n" +
+                                              "  <date type=\"datetime\">2014-01-01T20:20:29Z</date>\n" +
+                                              "  <closed_at type=\"datetime\">2014-01-01T20:24:02Z</closed_at>\n" +
+                                              "  <net_terms type=\"integer\">0</net_terms>\n" +
+                                              "  <collection_method>automatic</collection_method>\n" +
+                                              "</invoice>";
+
     private <T extends Notification> void deserialize(final Class<T> clazz) {
 
         final String xmlElement = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, clazz.getSimpleName());
@@ -106,7 +123,7 @@ public class TestNotification extends TestModelBase {
                 .append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
                 .append("<").append(xmlElement).append(">\n");
 
-        boolean isAccount = false, isSubscription = false, isPayment = false;
+        boolean isAccount = false, isSubscription = false, isPayment = false, isInvoice = false;
 
         if (AccountNotification.class.isAssignableFrom(clazz)) {
             notificationDataBuilder.append(ACCOUNTDATA).append("\n");
@@ -121,6 +138,11 @@ public class TestNotification extends TestModelBase {
         if (PaymentNotification.class.isAssignableFrom(clazz)) {
             notificationDataBuilder.append(TRANSACTIONDATA).append("\n");
             isPayment = true;
+        }
+
+        if(InvoiceNotification.class.isAssignableFrom(clazz)) {
+            notificationDataBuilder.append(INVOICEDATA).append("\n");
+            isInvoice = true;
         }
 
         notificationDataBuilder.append("</").append(xmlElement).append(">");
@@ -141,6 +163,9 @@ public class TestNotification extends TestModelBase {
         }
         if (isPayment) {
             testPaymentNotification((PaymentNotification) notification);
+        }
+        if (isInvoice) {
+            testInvoiceNotification((InvoiceNotification) notification);
         }
         log.info("{} deserialized", clazz.getSimpleName());
     }
@@ -206,6 +231,24 @@ public class TestNotification extends TestModelBase {
         Assert.assertEquals(avs.getMessage(), "Street address and postal code match.");
     }
 
+    private void testInvoiceNotification(final InvoiceNotification invoiceNotification) {
+        PushInvoice invoice = invoiceNotification.getInvoice();
+        Assert.assertNotNull(invoice);
+        Assert.assertEquals(invoice.getUuid(), "ffc64d71d4b5404e93f13aac9c63b007");
+        Assert.assertNull(invoice.getSubscriptionId());
+        Assert.assertEquals(invoice.getState(), "collected");
+        Assert.assertNull(invoice.getInvoiceNumberPrefix());
+        Assert.assertEquals(invoice.getInvoiceNumber(), new Integer(1000));
+        Assert.assertNull(invoice.getPoNumber());
+        Assert.assertNull(invoice.getVatNumber());
+        Assert.assertEquals(invoice.getTotalInCents(), new Integer(1100));
+        Assert.assertEquals(invoice.getCurrency(), "USD");
+        Assert.assertEquals(invoice.getDate(), new DateTime("2014-01-01T20:20:29Z"));
+        Assert.assertEquals(invoice.getClosedAt(), new DateTime("2014-01-01T20:24:02Z"));
+        Assert.assertEquals(invoice.getNetTerms(), new Integer(0));
+        Assert.assertEquals(invoice.getCollectionMethod(), "automatic");
+    }
+
     @Test(groups = "fast")
     public void testNewAccountNotification() {
         deserialize(NewAccountNotification.class);
@@ -269,5 +312,25 @@ public class TestNotification extends TestModelBase {
     @Test(groups = "fast")
     public void testSuccessfulRefundNotification() {
         deserialize(SuccessfulRefundNotification.class);
+    }
+
+    @Test(groups = "fast")
+    public void testClosedInvoiceNotification() {
+        deserialize(ClosedInvoiceNotification.class);
+    }
+
+    @Test(groups = "fast")
+    public void testNewInvoiceNotification() {
+        deserialize(NewInvoiceNotification.class);
+    }
+
+    @Test(groups = "fast")
+    public void testPastDueInvoiceNotification() {
+        deserialize(PastDueInvoiceNotification.class);
+    }
+
+    @Test(groups = "fast")
+    public void testProcessingInvoiceNotification() {
+        deserialize(ProcessingInvoiceNotification.class);
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/push/invoice/TestCloseInvoiceNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/invoice/TestCloseInvoiceNotification.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model.push.invoice;
+
+import com.ning.billing.recurly.model.TestModelBase;
+import com.ning.billing.recurly.model.push.Notification;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+// See http://docs.recurly.com/api/push-notifications
+public class TestCloseInvoiceNotification extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        final String voidData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                "<closed_invoice_notification>\n" +
+                                "  <account>\n" +
+                                "    <account_code>1</account_code>\n" +
+                                "    <username nil=\"true\"></username>\n" +
+                                "    <email>verena@example.com</email>\n" +
+                                "    <first_name>Verana</first_name>\n" +
+                                "    <last_name>Example</last_name>\n" +
+                                "    <company_name nil=\"true\"></company_name>\n" +
+                                "  </account>\n" +
+                                "  <invoice>\n" +
+                                "    <uuid>ffc64d71d4b5404e93f13aac9c63b007</uuid>\n" +
+                                "    <subscription_id nil=\"true\"></subscription_id>\n" +
+                                "    <state>collected</state>\n" +
+                                "    <invoice_number_prefix></invoice_number_prefix>\n" +
+                                "    <invoice_number type=\"integer\">1000</invoice_number>\n" +
+                                "    <po_number></po_number>\n" +
+                                "    <vat_number></vat_number>\n" +
+                                "    <total_in_cents type=\"integer\">1100</total_in_cents>\n" +
+                                "    <currency>USD</currency>\n" +
+                                "    <date type=\"datetime\">2014-01-01T20:20:29Z</date>\n" +
+                                "    <closed_at type=\"datetime\">2014-01-01T20:24:02Z</closed_at>\n" +
+                                "    <net_terms type=\"integer\">0</net_terms>\n" +
+                                "    <collection_method>automatic</collection_method>\n" +
+                                "  </invoice>\n" +
+                                "</closed_invoice_notification>";
+
+        Notification.Type detected = Notification.detect(voidData);
+        Assert.assertEquals(detected.getJavaType(), ClosedInvoiceNotification.class);
+
+        final ClosedInvoiceNotification notification = Notification.read(voidData, ClosedInvoiceNotification.class);
+        Assert.assertNotNull(notification);
+    }
+
+}

--- a/src/test/java/com/ning/billing/recurly/model/push/invoice/TestNewInvoiceNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/invoice/TestNewInvoiceNotification.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model.push.invoice;
+
+import com.ning.billing.recurly.model.TestModelBase;
+import com.ning.billing.recurly.model.push.Notification;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+// See http://docs.recurly.com/api/push-notifications
+public class TestNewInvoiceNotification extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        final String voidData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                "<new_invoice_notification>\n" +
+                                "  <account>\n" +
+                                "    <account_code>1</account_code>\n" +
+                                "    <username nil=\"true\"></username>\n" +
+                                "    <email>verena@example.com</email>\n" +
+                                "    <first_name>Verana</first_name>\n" +
+                                "    <last_name>Example</last_name>\n" +
+                                "    <company_name nil=\"true\"></company_name>\n" +
+                                "  </account>\n" +
+                                "  <invoice>\n" +
+                                "    <uuid>ffc64d71d4b5404e93f13aac9c63b007</uuid>\n" +
+                                "    <subscription_id nil=\"true\"></subscription_id>\n" +
+                                "    <state>open</state>\n" +
+                                "    <invoice_number_prefix></invoice_number_prefix>\n" +
+                                "    <invoice_number type=\"integer\">1000</invoice_number>\n" +
+                                "    <po_number></po_number>\n" +
+                                "    <vat_number></vat_number>\n" +
+                                "    <total_in_cents type=\"integer\">1000</total_in_cents>\n" +
+                                "    <currency>USD</currency>\n" +
+                                "    <date type=\"datetime\">2014-01-01T20:21:44Z</date>\n" +
+                                "    <closed_at type=\"datetime\" nil=\"true\"></closed_at>\n" +
+                                "    <net_terms type=\"integer\">0</net_terms>\n" +
+                                "    <collection_method>automatic</collection_method>\n" +
+                                "  </invoice>\n" +
+                                "</new_invoice_notification>";
+
+        Notification.Type detected = Notification.detect(voidData);
+        Assert.assertEquals(detected.getJavaType(), NewInvoiceNotification.class);
+
+        final NewInvoiceNotification notification = Notification.read(voidData, NewInvoiceNotification.class);
+        Assert.assertNotNull(notification);
+    }
+
+}

--- a/src/test/java/com/ning/billing/recurly/model/push/invoice/TestPastDueInvoiceNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/invoice/TestPastDueInvoiceNotification.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model.push.invoice;
+
+import com.ning.billing.recurly.model.TestModelBase;
+import com.ning.billing.recurly.model.push.Notification;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+// See http://docs.recurly.com/api/push-notifications
+public class TestPastDueInvoiceNotification extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        final String voidData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                "<past_due_invoice_notification>\n" +
+                                "  <account>\n" +
+                                "    <account_code>1</account_code>\n" +
+                                "    <username nil=\"true\"></username>\n" +
+                                "    <email>verena@example.com</email>\n" +
+                                "    <first_name>Verana</first_name>\n" +
+                                "    <last_name>Example</last_name>\n" +
+                                "    <company_name nil=\"true\"></company_name>\n" +
+                                "  </account>\n" +
+                                "  <invoice>\n" +
+                                "    <uuid>ffc64d71d4b5404e93f13aac9c63b007</uuid>\n" +
+                                "    <subscription_id nil=\"true\"></subscription_id>\n" +
+                                "    <state>past_due</state>\n" +
+                                "    <invoice_number_prefix></invoice_number_prefix>\n" +
+                                "    <invoice_number type=\"integer\">1000</invoice_number>\n" +
+                                "    <po_number></po_number>\n" +
+                                "    <vat_number></vat_number>\n" +
+                                "    <total_in_cents type=\"integer\">1100</total_in_cents>\n" +
+                                "    <currency>USD</currency>\n" +
+                                "    <date type=\"datetime\">2014-01-01T20:20:29Z</date>\n" +
+                                "    <closed_at type=\"datetime\">2014-01-01T20:24:02Z</closed_at>\n" +
+                                "    <net_terms type=\"integer\">0</net_terms>\n" +
+                                "    <collection_method>automatic</collection_method>\n" +
+                                "  </invoice>\n" +
+                                "</past_due_invoice_notification>";
+
+        Notification.Type detected = Notification.detect(voidData);
+        Assert.assertEquals(detected.getJavaType(), PastDueInvoiceNotification.class);
+
+        final PastDueInvoiceNotification notification = Notification.read(voidData, PastDueInvoiceNotification.class);
+        Assert.assertNotNull(notification);
+    }
+
+}

--- a/src/test/java/com/ning/billing/recurly/model/push/invoice/TestProcessingInvoiceNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/invoice/TestProcessingInvoiceNotification.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model.push.invoice;
+
+import com.ning.billing.recurly.model.TestModelBase;
+import com.ning.billing.recurly.model.push.Notification;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+// See http://docs.recurly.com/api/push-notifications
+public class TestProcessingInvoiceNotification extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        final String voidData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                "<processing_invoice_notification>\n" +
+                                "  <account>\n" +
+                                "    <account_code>1</account_code>\n" +
+                                "    <username nil=\"true\"></username>\n" +
+                                "    <email>verena@example.com</email>\n" +
+                                "    <first_name>Verana</first_name>\n" +
+                                "    <last_name>Example</last_name>\n" +
+                                "    <company_name nil=\"true\"></company_name>\n" +
+                                "  </account>\n" +
+                                "  <invoice>\n" +
+                                "    <uuid>ffc64d71d4b5404e93f13aac9c63b007</uuid>\n" +
+                                "    <subscription_id nil=\"true\"></subscription_id>\n" +
+                                "    <state>processing</state>\n" +
+                                "    <invoice_number_prefix></invoice_number_prefix>\n" +
+                                "    <invoice_number type=\"integer\">1000</invoice_number>\n" +
+                                "    <po_number></po_number>\n" +
+                                "    <vat_number></vat_number>\n" +
+                                "    <total_in_cents type=\"integer\">1000</total_in_cents>\n" +
+                                "    <currency>USD</currency>\n" +
+                                "    <date type=\"datetime\">2014-01-01T20:21:44Z</date>\n" +
+                                "    <closed_at type=\"datetime\" nil=\"true\"></closed_at>\n" +
+                                "    <net_terms type=\"integer\">0</net_terms>\n" +
+                                "    <collection_method>automatic</collection_method>\n" +
+                                "  </invoice>\n" +
+                                "</processing_invoice_notification>";
+
+        Notification.Type detected = Notification.detect(voidData);
+        Assert.assertEquals(detected.getJavaType(), ProcessingInvoiceNotification.class);
+
+        final ProcessingInvoiceNotification notification = Notification.read(voidData, ProcessingInvoiceNotification.class);
+        Assert.assertNotNull(notification);
+    }
+
+}


### PR DESCRIPTION
As per the docs (https://docs.recurly.com/api/push-notifications), there are invoice webhooks:  "Recurly will send you the proper invoice notifications when your application creates or updates an invoice state." 

This pull request adds those mappings in as well as adding tests for both the invoice section of the xml, as well as tests for each type of complete invoice webhook.