### PR TITLE
Issue 79 - Fixed Transaction Mappings

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/AbstractTransaction.java
+++ b/src/main/java/com/ning/billing/recurly/model/AbstractTransaction.java
@@ -18,9 +18,54 @@ package com.ning.billing.recurly.model;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.Map;
 
 @XmlRootElement(name = "transaction")
 public class AbstractTransaction extends RecurlyObject {
+
+    public static class VerificationResult {
+
+        private String code;
+
+        private String message;
+
+        public VerificationResult() {
+        }
+
+        public VerificationResult(final String code, final String message) {
+            this.code = code;
+            this.message = message;
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public void setCode(final String code) {
+            this.code = code;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(final String message) {
+            this.message = message;
+        }
+
+        public static VerificationResult as(final Object object) {
+            if (isNull(object)) {
+                return null;
+            }
+
+            if (object instanceof Map) {
+                final Map map = (Map) object;
+                return new VerificationResult(stringOrNull(map.get("code")), stringOrNull(map.get("")));
+            }
+
+            return new VerificationResult(null, object.toString());
+        }
+    }
 
     @XmlElement(name = "action")
     protected String action;
@@ -45,6 +90,24 @@ public class AbstractTransaction extends RecurlyObject {
 
     @XmlElement(name = "transaction_error")
     private TransactionError transactionError;
+
+    @XmlElement(name = "source")
+    private String source;
+
+    @XmlElement(name = "ip_address")
+    private String ipAddress;
+
+    @XmlElement(name = "cvv_result")
+    private VerificationResult cvvResult;
+
+    @XmlElement(name = "avs_result")
+    private VerificationResult avsResult;
+
+    @XmlElement(name = "avs_result_street")
+    private String avsResultStreet;
+
+    @XmlElement(name = "avs_result_postal")
+    private String avsResultPostal;
 
     public String getAction() {
         return action;
@@ -110,6 +173,54 @@ public class AbstractTransaction extends RecurlyObject {
         this.transactionError = transactionError;
     }
 
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(final Object source) {
+        this.source = stringOrNull(source);
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(final Object ipAddress) {
+        this.ipAddress = stringOrNull(ipAddress);
+    }
+
+    public VerificationResult getCvvResult() {
+        return cvvResult;
+    }
+
+    public void setCvvResult(final Object cvvResult) {
+        this.cvvResult = VerificationResult.as(cvvResult);
+    }
+
+    public VerificationResult getAvsResult() {
+        return avsResult;
+    }
+
+    public void setAvsResult(final Object avsResult) {
+        this.avsResult = VerificationResult.as(avsResult);
+    }
+
+    public String getAvsResultStreet() {
+        return avsResultStreet;
+    }
+
+    public void setAvsResultStreet(final Object avsResultStreet) {
+        this.avsResultStreet = stringOrNull(avsResultStreet);
+    }
+
+    public String getAvsResultPostal() {
+        return avsResultPostal;
+    }
+
+    public void setAvsResultPostal(final Object avsResultPostal) {
+        this.avsResultPostal = stringOrNull(avsResultPostal);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -145,6 +256,24 @@ public class AbstractTransaction extends RecurlyObject {
         if (voidable != null ? !voidable.equals(that.voidable) : that.voidable != null) {
             return false;
         }
+        if (source != null ? !source.equals(that.source) : that.source != null) {
+            return false;
+        }
+        if (ipAddress != null ? !ipAddress.equals(that.ipAddress) : that.ipAddress != null) {
+            return false;
+        }
+        if (avsResult != null ? !avsResult.equals(that.avsResult) : that.avsResult != null) {
+            return false;
+        }
+        if (cvvResult != null ? !cvvResult.equals(that.cvvResult) : that.cvvResult != null) {
+            return false;
+        }
+        if (avsResultStreet != null ? !avsResultStreet.equals(that.avsResultStreet) : that.avsResultStreet != null) {
+            return false;
+        }
+        if (avsResultPostal != null ? !avsResultPostal.equals(that.avsResultPostal) : that.avsResultPostal != null) {
+            return false;
+        }
 
         return true;
     }
@@ -159,6 +288,12 @@ public class AbstractTransaction extends RecurlyObject {
         result = 31 * result + (voidable != null ? voidable.hashCode() : 0);
         result = 31 * result + (refundable != null ? refundable.hashCode() : 0);
         result = 31 * result + (transactionError != null ? transactionError.hashCode() : 0);
+        result = 31 * result + (source != null ? source.hashCode() : 0);
+        result = 31 * result + (ipAddress != null ? ipAddress.hashCode() : 0);
+        result = 31 * result + (cvvResult != null ? cvvResult.hashCode() : 0);
+        result = 31 * result + (avsResult != null ? avsResult.hashCode() : 0);
+        result = 31 * result + (avsResultStreet != null ? avsResultStreet.hashCode() : 0);
+        result = 31 * result + (avsResultPostal != null ? avsResultPostal.hashCode() : 0);
         return result;
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Transaction.java
+++ b/src/main/java/com/ning/billing/recurly/model/Transaction.java
@@ -45,9 +45,6 @@ public class Transaction extends AbstractTransaction {
     @XmlElement(name = "description")
     private String description;
 
-    @XmlElement(name = "source")
-    private String source;
-
     @XmlElement(name = "recurring")
     private Boolean recurring;
 
@@ -125,14 +122,6 @@ public class Transaction extends AbstractTransaction {
         this.description = stringOrNull(description);
     }
 
-    public String getSource() {
-        return source;
-    }
-
-    public void setSource(final Object source) {
-        this.source = stringOrNull(source);
-    }
-
     public Boolean getRecurring() {
         return recurring;
     }
@@ -184,7 +173,6 @@ public class Transaction extends AbstractTransaction {
         sb.append(", taxInCents=").append(taxInCents);
         sb.append(", currency='").append(currency).append('\'');
         sb.append(", description='").append(description).append('\'');
-        sb.append(", source='").append(source).append('\'');
         sb.append(", recurring=").append(recurring);
         sb.append(", createdAt=").append(createdAt);
         sb.append(", details=").append(details);
@@ -229,9 +217,6 @@ public class Transaction extends AbstractTransaction {
         if (recurring != null ? !recurring.equals(that.recurring) : that.recurring != null) {
             return false;
         }
-        if (source != null ? !source.equals(that.source) : that.source != null) {
-            return false;
-        }
         if (subscription != null ? !subscription.equals(that.subscription) : that.subscription != null) {
             return false;
         }
@@ -261,7 +246,6 @@ public class Transaction extends AbstractTransaction {
         result = 31 * result + (taxInCents != null ? taxInCents.hashCode() : 0);
         result = 31 * result + (currency != null ? currency.hashCode() : 0);
         result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (source != null ? source.hashCode() : 0);
         result = 31 * result + (recurring != null ? recurring.hashCode() : 0);
         result = 31 * result + (createdAt != null ? createdAt.hashCode() : 0);
         result = 31 * result + (details != null ? details.hashCode() : 0);

--- a/src/main/java/com/ning/billing/recurly/model/push/payment/PushTransaction.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/payment/PushTransaction.java
@@ -26,50 +26,6 @@ import com.ning.billing.recurly.model.AbstractTransaction;
 
 public class PushTransaction extends AbstractTransaction {
 
-    public static class VerificationResult {
-
-        private String code;
-
-        private String message;
-
-        public VerificationResult() {
-        }
-
-        public VerificationResult(final String code, final String message) {
-            this.code = code;
-            this.message = message;
-        }
-
-        public String getCode() {
-            return code;
-        }
-
-        public void setCode(final String code) {
-            this.code = code;
-        }
-
-        public String getMessage() {
-            return message;
-        }
-
-        public void setMessage(final String message) {
-            this.message = message;
-        }
-
-        public static VerificationResult as(final Object object) {
-            if (isNull(object)) {
-                return null;
-            }
-
-            if (object instanceof Map) {
-                final Map map = (Map) object;
-                return new VerificationResult(stringOrNull(map.get("code")), stringOrNull(map.get("")));
-            }
-
-            return new VerificationResult(null, object.toString());
-        }
-    }
-
     @XmlElement
     private String id;
 
@@ -87,12 +43,6 @@ public class PushTransaction extends AbstractTransaction {
 
     @XmlElement
     private String message;
-
-    @XmlElement(name = "cvv_result")
-    private VerificationResult cvvResult;
-
-    @XmlElement(name = "avs_result")
-    private VerificationResult avsResult;
 
     public String getId() {
         return id;
@@ -142,21 +92,7 @@ public class PushTransaction extends AbstractTransaction {
         this.message = stringOrNull(message);
     }
 
-    public VerificationResult getCvvResult() {
-        return cvvResult;
-    }
 
-    public void setCvvResult(final Object cvvResult) {
-        this.cvvResult = VerificationResult.as(cvvResult);
-    }
-
-    public VerificationResult getAvsResult() {
-        return avsResult;
-    }
-
-    public void setAvsResult(final Object avsResult) {
-        this.avsResult = VerificationResult.as(avsResult);
-    }
 
     @Override
     public boolean equals(final Object o) {
@@ -172,12 +108,6 @@ public class PushTransaction extends AbstractTransaction {
 
         final PushTransaction that = (PushTransaction) o;
 
-        if (avsResult != null ? !avsResult.equals(that.avsResult) : that.avsResult != null) {
-            return false;
-        }
-        if (cvvResult != null ? !cvvResult.equals(that.cvvResult) : that.cvvResult != null) {
-            return false;
-        }
         if (date != null ? !date.equals(that.date) : that.date != null) {
             return false;
         }
@@ -209,8 +139,6 @@ public class PushTransaction extends AbstractTransaction {
         result = 31 * result + (subscriptionId != null ? subscriptionId.hashCode() : 0);
         result = 31 * result + (date != null ? date.hashCode() : 0);
         result = 31 * result + (message != null ? message.hashCode() : 0);
-        result = 31 * result + (cvvResult != null ? cvvResult.hashCode() : 0);
-        result = 31 * result + (avsResult != null ? avsResult.hashCode() : 0);
         return result;
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestTransaction.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestTransaction.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import org.joda.time.DateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestTransaction extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        // See http://docs.recurly.com/api/invoices
+        final String transactionData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                       "<transaction href=\"https://your-subdomain.recurly.com/v2/transactions/a13acd8fe4294916b79aec87b7ea441f\">\n" +
+                                       "  <account href=\"https://your-subdomain.recurly.com/v2/accounts/1\"/>\n" +
+                                       "  <invoice href=\"https://your-subdomain.recurly.com/v2/invoices/1108\"/>\n" +
+                                       "  <uuid>a13acd8fe4294916b79aec87b7ea441f</uuid>\n" +
+                                       "  <action>purchase</action>\n" +
+                                       "  <amount_in_cents type=\"integer\">1000</amount_in_cents>\n" +
+                                       "  <tax_in_cents type=\"integer\">0</tax_in_cents>\n" +
+                                       "  <currency>USD</currency>\n" +
+                                       "  <status>success</status>\n" +
+                                       "  <payment_method>check</payment_method>\n" +
+                                       "  <reference nil=\"nil\"/>\n" +
+                                       "  <source>transaction</source>\n" +
+                                       "  <recurring type=\"boolean\">false</recurring>\n" +
+                                       "  <test type=\"boolean\">true</test>\n" +
+                                       "  <voidable type=\"boolean\">true</voidable>\n" +
+                                       "  <refundable type=\"boolean\">true</refundable>\n" +
+                                       "  <ip_address nil=\"nil\"/>\n" +
+                                       "  <cvv_result code=\"\" nil=\"nil\"></cvv_result>" +
+                                       "  <avs_result code=\"\" nil=\"nil\"></avs_result>" +
+                                       "  <avs_result_street nil=\"nil\"></avs_result_street>" +
+                                       "  <avs_result_postal nil=\"nil\"></avs_result_postal>" +
+                                       "  <created_at type=\"datetime\">2015-06-19T03:01:33Z</created_at>\n" +
+                                       "  <details>\n" +
+                                       "    <account>\n" +
+                                       "      <account_code>1</account_code>\n" +
+                                       "      <first_name nil=\"nil\"/>\n" +
+                                       "      <last_name nil=\"nil\"/>\n" +
+                                       "      <company nil=\"nil\"/>\n" +
+                                       "      <email nil=\"nil\"/>\n" +
+                                       "      <billing_info>\n" +
+                                       "        <first_name>Verena</first_name>\n" +
+                                       "        <last_name>Example</last_name>\n" +
+                                       "        <address1>123 Main St.</address1>\n" +
+                                       "        <address2 nil=\"nil\"/>\n" +
+                                       "        <city>San Francisco</city>\n" +
+                                       "        <state>CA</state>\n" +
+                                       "        <zip>94105</zip>\n" +
+                                       "        <country>US</country>\n" +
+                                       "        <phone nil=\"nil\"/>\n" +
+                                       "        <vat_number nil=\"nil\"/>\n" +
+                                       "      </billing_info>\n" +
+                                       "    </account>\n" +
+                                       "  </details>\n" +
+                                       "  <a name=\"refund\" href=\"https://your-subdomain.recurly.com/v2/transactions/a13acd8fe4294916b79aec87b7ea441f\" method=\"delete\"/>\n" +
+                                       "</transaction>";
+
+        final Transaction transaction = xmlMapper.readValue(transactionData, Transaction.class);
+        Assert.assertEquals(transaction.getHref(), "https://your-subdomain.recurly.com/v2/transactions/a13acd8fe4294916b79aec87b7ea441f");
+        Assert.assertEquals(transaction.getAccount().getHref(), "https://your-subdomain.recurly.com/v2/accounts/1");
+        Assert.assertEquals(transaction.getInvoice().getHref(), "https://your-subdomain.recurly.com/v2/invoices/1108");
+        Assert.assertEquals(transaction.getUuid(), "a13acd8fe4294916b79aec87b7ea441f");
+        Assert.assertEquals(transaction.getSource(), "transaction");
+        Assert.assertEquals(transaction.getRecurring(), new Boolean(false));
+        Assert.assertEquals(transaction.getTest(), new Boolean(true));
+        Assert.assertEquals(transaction.getVoidable(), new Boolean(true));
+        Assert.assertEquals(transaction.getRefundable(), new Boolean(true));
+        Assert.assertNull(transaction.getIpAddress());
+        Assert.assertNull(transaction.getAvsResult());
+        Assert.assertNull(transaction.getAvsResultPostal());
+        Assert.assertNull(transaction.getAvsResultStreet());
+        Assert.assertNull(transaction.getCvvResult());
+        Assert.assertEquals(transaction.getCreatedAt(), new DateTime("2015-06-19T03:01:33Z"));
+
+        final Account account = transaction.getDetails().getAccount();
+        Assert.assertEquals(account.getAccountCode(), "1");
+        Assert.assertNull(account.getFirstName());
+        Assert.assertNull(account.getLastName());
+        Assert.assertNull(account.getCompanyName());
+        Assert.assertNull(account.getEmail());
+
+        final BillingInfo billingInfo = account.getBillingInfo();
+        Assert.assertEquals(billingInfo.getFirstName(), "Verena");
+        Assert.assertEquals(billingInfo.getLastName(), "Example");
+        Assert.assertEquals(billingInfo.getAddress1(), "123 Main St.");
+        Assert.assertNull(billingInfo.getAddress2());
+        Assert.assertEquals(billingInfo.getCity(), "San Francisco");
+        Assert.assertEquals(billingInfo.getZip(), "94105");
+        Assert.assertEquals(billingInfo.getCountry(), "US");
+        Assert.assertNull(billingInfo.getPhone());
+        Assert.assertNull(billingInfo.getVatNumber());
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
@@ -92,8 +92,9 @@ public class TestNotification extends TestModelBase {
                                                   "  <reference></reference>\n" +
                                                   "  <cvv_result code=\"\"></cvv_result>\n" +
                                                   "  <avs_result code=\"D\">Street address and postal code match.</avs_result>\n" +
-                                                  "  <avs_result_street nil=\"true\"></avs_result_street>\n" +
-                                                  "  <avs_result_postal nil=\"true\"></avs_result_postal>\n" +
+                                                  "  <avs_result_street>123 Main St.</avs_result_street>\n" +
+                                                  "  <avs_result_postal>20121</avs_result_postal>\n" +
+                                                  "  <source>subscription</source>\n" +
                                                   "  <test type=\"boolean\">true</test>\n" +
                                                   "  <voidable type=\"boolean\">true</voidable>\n" +
                                                   "  <refundable type=\"boolean\">true</refundable>\n" +
@@ -194,6 +195,9 @@ public class TestNotification extends TestModelBase {
         Assert.assertTrue(transaction.getTest());
         Assert.assertTrue(transaction.getRefundable());
         Assert.assertTrue(transaction.getVoidable());
+        Assert.assertEquals(transaction.getAvsResultStreet(), "123 Main St.");
+        Assert.assertEquals(transaction.getAvsResultPostal(), "20121");
+        Assert.assertEquals(transaction.getSource(), "subscription");
 
         final PushTransaction.VerificationResult cvv = transaction.getCvvResult();
         Assert.assertNotNull(cvv);


### PR DESCRIPTION
This is for Issue https://github.com/killbilling/recurly-java-library/issues/79

A few of the Transaction fields are mapped incorrectly or are missing.

1.  cvv_result, avs_result were both being mapped to the PushTransaction, but needs to also appear in the regular Transaction object.  Both share the AbstractTransaction object, so I put the mapping in there.

2.  avs_result_street and avs_result_postal are missing from the mappings.  Since these are shared by both the PushTransaction and regular Transaction object, I put it inside the AbstractTransaction object.

3.  'source' field was being mapped to the Transaction object, but appears in a few webhooks.  B/c it is shared by PushTransaction also, I put this field inside AbstractTransaction.