### PR TITLE
Updating docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you wish to specify extra parameters (such as account id and subscription cod
     extraParams.add(String.format("%s=%s", "account%5Baccount_code%5D", "123abc"));
 	String signature = RecurlyJs.getRecurlySignature(String jsPrivateKey, extraParams);
 
-Refer to the [Recurly.js Signature Generation documentation](http://docs.recurly.com/api/recurlyjs/signatures) for more information on the format for building parameters.
+Refer to the [Recurly.js Signature Generation documentation](https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures) for more information on the format for building parameters.
 
 
 Build

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -128,7 +128,7 @@ public class RecurlyClient {
     private final String key;
     private final String baseUrl;
     private AsyncHttpClient client;
-    
+
     public RecurlyClient(final String apiKey) {
         this(apiKey, "api");
     }
@@ -383,8 +383,8 @@ public class RecurlyClient {
                       subscriptionUpdate,
                       Subscription.class);
     }
-    
-    
+
+
     /**
      * Update to a particular {@link Subscription}'s notes by it's UUID
      * <p/>
@@ -392,7 +392,7 @@ public class RecurlyClient {
      *
      * @param uuid UUID of the subscription to preview an update for
      * @param subscriptionNotes SubscriptionNotes object
-     * @return Subscription the updated subscription 
+     * @return Subscription the updated subscription
      */
     public Subscription updateSubscriptionNotes(final String uuid, final SubscriptionNotes subscriptionNotes) {
       return doPUT(SubscriptionNotes.SUBSCRIPTION_RESOURCE + "/" + uuid + "/notes",
@@ -536,7 +536,7 @@ public class RecurlyClient {
 
     ///////////////////////////////////////////////////////////////////////////
     // User invoices
-    
+
     /**
      * Lookup an invoice
      * <p/>
@@ -547,7 +547,7 @@ public class RecurlyClient {
      */
     public Invoice getInvoice(final Integer invoiceId) {
         return doGET(Invoices.INVOICES_RESOURCE + "/" + invoiceId, Invoice.class);
-    }    
+    }
 
     /**
      * Lookup an account's invoices
@@ -951,7 +951,7 @@ public class RecurlyClient {
                     try {
                         errors = xmlMapper.readValue(payload, Errors.class);
                     } catch (Exception e) {
-                        // 422 is returned for transaction errors (see http://docs.recurly.com/api/transactions/error-codes)
+                        // 422 is returned for transaction errors (see https://recurly.readme.io/v2.0/page/transaction-errors)
                         // as well as bad input payloads
                         log.debug("Unable to extract error", e);
                         return null;

--- a/src/main/java/com/ning/billing/recurly/RecurlyJs.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyJs.java
@@ -41,7 +41,7 @@ public class RecurlyJs {
 
     /**
      * Get Recurly.js Signature
-     * See spec here: http://docs.recurly.com/api/recurlyjs/signatures
+     * See spec here: https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures
      * <p/>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *
@@ -54,7 +54,7 @@ public class RecurlyJs {
 
     /**
      * Get Recurly.js Signature
-     * See spec here: http://docs.recurly.com/api/recurlyjs/signatures
+     * See spec here: https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures
      * <p/>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *
@@ -70,7 +70,7 @@ public class RecurlyJs {
 
     /**
      * Get Recurly.js Signature with extra parameter strings in the format "[param]=[value]"
-     * See spec here: http://docs.recurly.com/api/recurlyjs/signatures
+     * See spec here: https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures
      * <p/>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *

--- a/src/test/java/com/ning/billing/recurly/model/TestAccount.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccount.java
@@ -25,7 +25,7 @@ public class TestAccount extends TestModelBase {
 
     @Test(groups = "fast")
     public void testSerialization() throws Exception {
-        // See http://docs.recurly.com/api/accounts
+        // See https://dev.recurly.com/docs/list-accounts
         final String accountData = "<account href=\"https://api.recurly.com/v2/accounts/1\">\n" +
                                    "  <adjustments href=\"https://api.recurly.com/v2/accounts/1/adjustments\"/>\n" +
                                    "  <billing_info href=\"https://api.recurly.com/v2/accounts/1/billing_info\"/>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestAccounts.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccounts.java
@@ -25,7 +25,7 @@ public class TestAccounts extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/accounts
+        // See https://dev.recurly.com/docs/list-accounts
         final String accountsData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                     "<accounts type=\"array\">\n" +
                                     "  <account href=\"https://api.recurly.com/v2/accounts/1\">\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
@@ -25,7 +25,7 @@ public class TestAddOns extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/plans/add-ons
+        // See https://dev.recurly.com/docs/list-add-ons-for-a-plan
         final String addOnsData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                   "<add_ons type=\"array\">\n" +
                                   "  <add_on href=\"https://your-subdomain.recurly.com/v2/plans/gold/add_ons/ipaddresses\">\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestAdjustements.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAdjustements.java
@@ -25,7 +25,7 @@ public class TestAdjustements extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/adjustments
+        // See https://dev.recurly.com/docs/list-an-accounts-adjustments
         final String adjustmentsData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                        "<adjustments type=\"array\">\n" +
                                        "  <adjustment type=\"credit\" href=\"https://api.recurly.com/v2/adjustments/626db120a84102b1809909071c701c60\">\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestAdjustment.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAdjustment.java
@@ -25,7 +25,7 @@ public class TestAdjustment extends TestModelBase {
 
     @Test(groups = "fast")
     public void testSerialization() throws Exception {
-        // See http://docs.recurly.com/api/adjustments
+        // See https://dev.recurly.com/docs/list-an-accounts-adjustments
         final String adjustmentData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                       "<adjustment type=\"credit\" href=\"https://api.recurly.com/v2/adjustments/626db120a84102b1809909071c701c60\">\n" +
                                       "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
@@ -26,7 +26,7 @@ public class TestCoupon extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserializationPercent() throws Exception {
-        // See http://docs.recurly.com/api/coupons
+        // See https://dev.recurly.com/docs/list-active-coupons
         final String couponData =
                 "<coupon href=\"https://api.recurly.com/v2/coupons/f8028\">\n" +
                 "  <redemptions href=\"https://api.recurly.com/v2/coupons/f8028/redemptions\"/>\n" +
@@ -64,7 +64,7 @@ public class TestCoupon extends TestModelBase {
 
     @Test(groups = "fast", description = "https://github.com/killbilling/recurly-java-library/issues/57")
     public void testDeserializationDollars() throws Exception {
-        // See http://docs.recurly.com/api/coupons
+        // See https://dev.recurly.com/docs/list-active-coupons
         final String couponData =
                 "<coupon href=\"https://api.recurly.com/v2/coupons/f8028\">\n" +
                 "  <redemptions href=\"https://api.recurly.com/v2/coupons/f8028/redemptions\"/>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestCoupons.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCoupons.java
@@ -24,7 +24,7 @@ public class TestCoupons extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/accounts
+        // See https://dev.recurly.com/docs/list-accounts
         final String accountsData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                     "<coupons type=\"array\">\n" +
                                     "  <coupon href=\"https://api.recurly.com/v2/coupons/cdeb2\">\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
@@ -25,7 +25,7 @@ public class TestInvoice extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/invoices
+        // See https://dev.recurly.com/docs/list-invoices
         final String invoiceData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                                    + "<invoice href=\"https://api.recurly.com/v2/invoices/e3f0a9e084a2468480d00ee61b090d4d\">\n"
                                    + "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n"

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoices.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoices.java
@@ -25,7 +25,7 @@ public class TestInvoices extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/invoices
+        // See https://dev.recurly.com/docs/list-invoices
         final String invoicesData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                                     + "<invoices type=\"array\">\n"
                                     + "  <invoice href=\"https://api.recurly.com/v2/invoices/e3f0a9e084a2468480d00ee61b090d4d\">\n"

--- a/src/test/java/com/ning/billing/recurly/model/TestPlan.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPlan.java
@@ -25,7 +25,7 @@ public class TestPlan extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserializationWithAmounts() throws Exception {
-        // See http://docs.recurly.com/api/plans
+        // See https://dev.recurly.com/docs/list-plans
         final String planData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                 "<plan href=\"https://api.recurly.com/v2/plans/gold\">\n" +
                                 "  <add_ons href=\"https://api.recurly.com/v2/plans/gold/add_ons\"/>\n" +
@@ -78,7 +78,7 @@ public class TestPlan extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserializationWithoutAmounts() throws Exception {
-        // See http://docs.recurly.com/api/plans
+        // See https://dev.recurly.com/docs/list-plans
         final String planData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                 "<plan href=\"https://api.recurly.com/v2/plans/gold\">\n" +
                                 "  <add_ons href=\"https://api.recurly.com/v2/plans/gold/add_ons\"/>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestPlans.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPlans.java
@@ -25,7 +25,7 @@ public class TestPlans extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/plans
+        // See https://dev.recurly.com/docs/list-plans
         final String plansData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                  "<plans type=\"array\">\n" +
                                  "  <plan href=\"https://api.recurly.com/v2/plans/gold\">\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestRedemption.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestRedemption.java
@@ -25,7 +25,7 @@ public class TestRedemption extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See https://docs.recurly.com/api/coupons/coupon-redemption
+        // See https://dev.recurly.com/docs/lookup-a-coupon-redemption-on-an-account
         final String redemptionData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<redemption href=\"https://your-subdomain.recurly.com/v2/accounts/1/redemption\">\n" +
                 "  <coupon href=\"https://your-subdomain.recurly.com/v2/coupons/special\"/>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -27,7 +27,7 @@ public class TestSubscription extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/subscriptions
+        // See https://dev.recurly.com/docs/list-subscriptions
         final String subscriptionData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                         "<subscription href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96\">\n" +
                                         "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n" +
@@ -77,7 +77,7 @@ public class TestSubscription extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserializationWithAddons() throws Exception {
-        // See http://docs.recurly.com/api/subscriptions/subscription-add-ons
+        // See https://dev.recurly.com/docs/subscription-add-ons
         final String subscriptionData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                         "<subscription href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96\">\n" +
                                         "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
@@ -24,7 +24,7 @@ public class TestSubscriptionUpdate extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/subscriptions
+        // See https://dev.recurly.com/docs/list-subscriptions
         final String subscriptionData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                         "<subscription>\n" +
                                         "  <timeframe>now</timeframe>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscriptions.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscriptions.java
@@ -24,7 +24,7 @@ public class TestSubscriptions extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/subscriptions
+        // See https://dev.recurly.com/docs/list-subscriptions
         final String subscriptionsData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                          "<subscriptions type=\"array\">\n" +
                                          "  <subscription href=\"https://your-subdomain.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96\">\n" +

--- a/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
@@ -47,7 +47,7 @@ import com.ning.billing.recurly.model.push.subscription.UpdatedSubscriptionNotif
 
 import com.google.common.base.CaseFormat;
 
-// See http://docs.recurly.com/api/push-notifications
+// See https://recurly.readme.io/v2.0/page/webhooks
 public class TestNotification extends TestModelBase {
 
     private static final Logger log = LoggerFactory.getLogger(TestNotification.class);

--- a/src/test/java/com/ning/billing/recurly/model/push/TestVoidNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestVoidNotification.java
@@ -22,7 +22,7 @@ import com.ning.billing.recurly.model.push.payment.VoidPaymentNotification;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-// See http://docs.recurly.com/api/push-notifications
+// See https://recurly.readme.io/v2.0/page/webhooks
 public class TestVoidNotification extends TestModelBase {
 
     @Test(groups = "fast")


### PR DESCRIPTION
Recurly recently switched from `docs.recurly.com/api` to `dev.recurly.com` a. Navigating to an old docs link will redirect to the new docs site. These changes just make that new URL explicit.