### PR TITLE
Remove self-closing elements, eliminating jdk 1.8 javadoc complaints

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -162,7 +162,7 @@ public class RecurlyClient {
 
     /**
      * Create Account
-     * <p/>
+     * <p>
      * Creates a new account. You may optionally include billing information.
      *
      * @param account account object
@@ -174,7 +174,7 @@ public class RecurlyClient {
 
     /**
      * Get Accounts
-     * <p/>
+     * <p>
      * Returns information about all accounts.
      *
      * @return account object on success, null otherwise
@@ -189,7 +189,7 @@ public class RecurlyClient {
 
     /**
      * Get Account
-     * <p/>
+     * <p>
      * Returns information about a single account.
      *
      * @param accountCode recurly account id
@@ -201,7 +201,7 @@ public class RecurlyClient {
 
     /**
      * Update Account
-     * <p/>
+     * <p>
      * Updates an existing account.
      *
      * @param accountCode recurly account id
@@ -214,7 +214,7 @@ public class RecurlyClient {
 
     /**
      * Close Account
-     * <p/>
+     * <p>
      * Marks an account as closed and cancels any active subscriptions. Any saved billing information will also be
      * permanently removed from the account.
      *
@@ -265,7 +265,7 @@ public class RecurlyClient {
 
     /**
      * Create a subscription
-     * <p/>
+     * <p>
      * Creates a subscription for an account.
      *
      * @param subscription Subscription object
@@ -278,7 +278,7 @@ public class RecurlyClient {
 
     /**
      * Preview a subscription
-     * <p/>
+     * <p>
      * Previews a subscription for an account.
      *
      * @param subscription Subscription object
@@ -292,7 +292,7 @@ public class RecurlyClient {
 
     /**
      * Get a particular {@link Subscription} by it's UUID
-     * <p/>
+     * <p>
      * Returns information about a single subscription.
      *
      * @param uuid UUID of the subscription to lookup
@@ -306,7 +306,7 @@ public class RecurlyClient {
 
     /**
      * Cancel a subscription
-     * <p/>
+     * <p>
      * Cancel a subscription so it remains active and then expires at the end of the current bill cycle.
      *
      * @param subscription Subscription object
@@ -319,7 +319,7 @@ public class RecurlyClient {
 
     /**
      * Postpone a subscription
-     * <p/>
+     * <p>
      * postpone a subscription, setting a new renewal date.
      *
      * @param subscription Subscription object
@@ -342,7 +342,7 @@ public class RecurlyClient {
 
     /**
      * Reactivating a canceled subscription
-     * <p/>
+     * <p>
      * Reactivate a canceled subscription so it renews at the end of the current bill cycle.
      *
      * @param subscription Subscription object
@@ -355,7 +355,7 @@ public class RecurlyClient {
 
     /**
      * Update a particular {@link Subscription} by it's UUID
-     * <p/>
+     * <p>
      * Returns information about a single subscription.
      *
      * @param uuid               UUID of the subscription to update
@@ -371,7 +371,7 @@ public class RecurlyClient {
 
     /**
      * Preview an update to a particular {@link Subscription} by it's UUID
-     * <p/>
+     * <p>
      * Returns information about a single subscription.
      *
      * @param uuid UUID of the subscription to preview an update for
@@ -387,7 +387,7 @@ public class RecurlyClient {
 
     /**
      * Update to a particular {@link Subscription}'s notes by it's UUID
-     * <p/>
+     * <p>
      * Returns information about a single subscription.
      *
      * @param uuid UUID of the subscription to preview an update for
@@ -401,7 +401,7 @@ public class RecurlyClient {
 
     /**
      * Get the subscriptions for an {@link Account}.
-     * <p/>
+     * <p>
      * Returns information about a single {@link Account}.
      *
      * @param accountCode recurly account id
@@ -416,7 +416,7 @@ public class RecurlyClient {
 
     /**
      * Get the subscriptions for an account.
-     * <p/>
+     * <p>
      * Returns information about a single account.
      *
      * @param accountCode recurly account id
@@ -436,14 +436,14 @@ public class RecurlyClient {
 
     /**
      * Update an account's billing info
-     * <p/>
+     * <p>
      * When new or updated credit card information is updated, the billing information is only saved if the credit card
      * is valid. If the account has a past due invoice, the outstanding balance will be collected to validate the
      * billing information.
-     * <p/>
+     * <p>
      * If the account does not exist before the API request, the account will be created if the billing information
      * is valid.
-     * <p/>
+     * <p>
      * Please note: this API end-point may be used to import billing information without security codes (CVV).
      * Recurly recommends requiring CVV from your customers when collecting new or updated billing information.
      *
@@ -460,7 +460,7 @@ public class RecurlyClient {
 
     /**
      * Lookup an account's billing info
-     * <p/>
+     * <p>
      * Returns only the account's current billing information.
      *
      * @param accountCode recurly account id
@@ -473,7 +473,7 @@ public class RecurlyClient {
 
     /**
      * Clear an account's billing info
-     * <p/>
+     * <p>
      * You may remove any stored billing information for an account. If the account has a subscription, the renewal will
      * go into past due unless you update the billing info before the renewal occurs
      *
@@ -488,7 +488,7 @@ public class RecurlyClient {
 
     /**
      * Lookup an account's transactions history
-     * <p/>
+     * <p>
      * Returns the account's transaction history
      *
      * @param accountCode recurly account id
@@ -539,7 +539,7 @@ public class RecurlyClient {
 
     /**
      * Lookup an invoice
-     * <p/>
+     * <p>
      * Returns the invoice
      *
      * @param invoiceId Recurly Invoice ID
@@ -551,7 +551,7 @@ public class RecurlyClient {
 
     /**
      * Lookup an account's invoices
-     * <p/>
+     * <p>
      * Returns the account's invoices
      *
      * @param accountCode recurly account id
@@ -564,7 +564,7 @@ public class RecurlyClient {
 
     /**
      * Post an invoice: invoice pending charges on an account
-     * <p/>
+     * <p>
      * Returns an invoice
      *
      * @param accountCode
@@ -606,7 +606,7 @@ public class RecurlyClient {
 
     /**
      * Create a Plan's info
-     * <p/>
+     * <p>
      *
      * @param plan The plan to create on recurly
      * @return the plan object as identified by the passed in ID
@@ -617,7 +617,7 @@ public class RecurlyClient {
 
     /**
      * Get a Plan's details
-     * <p/>
+     * <p>
      *
      * @param planCode recurly id of plan
      * @return the plan object as identified by the passed in ID
@@ -628,7 +628,7 @@ public class RecurlyClient {
 
     /**
      * Return all the plans
-     * <p/>
+     * <p>
      *
      * @return the plan object as identified by the passed in ID
      */
@@ -638,7 +638,7 @@ public class RecurlyClient {
 
     /**
      * Deletes a {@link Plan}
-     * <p/>
+     * <p>
      *
      * @param planCode The {@link Plan} object to delete.
      */
@@ -652,7 +652,7 @@ public class RecurlyClient {
 
     /**
      * Create an AddOn to a Plan
-     * <p/>
+     * <p>
      *
      * @param planCode The planCode of the {@link Plan } to create within recurly
      * @param addOn    The {@link AddOn} to create within recurly
@@ -668,7 +668,7 @@ public class RecurlyClient {
 
     /**
      * Get an AddOn's details
-     * <p/>
+     * <p>
      *
      * @param addOnCode recurly id of {@link AddOn}
      * @param planCode  recurly id of {@link Plan}
@@ -685,7 +685,7 @@ public class RecurlyClient {
 
     /**
      * Return all the {@link AddOn} for a {@link Plan}
-     * <p/>
+     * <p>
      *
      * @return the {@link AddOn} objects as identified by the passed plan ID
      */
@@ -698,7 +698,7 @@ public class RecurlyClient {
 
     /**
      * Deletes a {@link AddOn} for a Plan
-     * <p/>
+     * <p>
      *
      * @param planCode  The {@link Plan} object.
      * @param addOnCode The {@link AddOn} object to delete.
@@ -716,7 +716,7 @@ public class RecurlyClient {
 
     /**
      * Create a {@link Coupon}
-     * <p/>
+     * <p>
      *
      * @param coupon The coupon to create on recurly
      * @return the {@link Coupon} object
@@ -727,7 +727,7 @@ public class RecurlyClient {
 
     /**
      * Get a Coupon
-     * <p/>
+     * <p>
      *
      * @param couponCode The code for the {@link Coupon}
      * @return The {@link Coupon} object as identified by the passed in code
@@ -738,7 +738,7 @@ public class RecurlyClient {
 
     /**
      * Delete a {@link Coupon}
-     * <p/>
+     * <p>
      *
      * @param couponCode The code for the {@link Coupon}
      */
@@ -798,7 +798,7 @@ public class RecurlyClient {
 
     /**
      * Fetch Subscription
-     * <p/>
+     * <p>
      * Returns subscription from a recurly.js token.
      *
      * @param recurlyToken token given by recurly.js
@@ -810,7 +810,7 @@ public class RecurlyClient {
 
     /**
      * Fetch BillingInfo
-     * <p/>
+     * <p>
      * Returns billing info from a recurly.js token.
      *
      * @param recurlyToken token given by recurly.js
@@ -822,7 +822,7 @@ public class RecurlyClient {
 
     /**
      * Fetch Invoice
-     * <p/>
+     * <p>
      * Returns invoice from a recurly.js token.
      *
      * @param recurlyToken token given by recurly.js

--- a/src/main/java/com/ning/billing/recurly/RecurlyJs.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyJs.java
@@ -42,7 +42,7 @@ public class RecurlyJs {
     /**
      * Get Recurly.js Signature
      * See spec here: https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures
-     * <p/>
+     * <p>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *
      * @param privateJsKey recurly.js private key
@@ -55,7 +55,7 @@ public class RecurlyJs {
     /**
      * Get Recurly.js Signature
      * See spec here: https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures
-     * <p/>
+     * <p>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *
      * @param privateJsKey recurly.js private key
@@ -71,7 +71,7 @@ public class RecurlyJs {
     /**
      * Get Recurly.js Signature with extra parameter strings in the format "[param]=[value]"
      * See spec here: https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures
-     * <p/>
+     * <p>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *
      * @param privateJsKey recurly.js private key
@@ -92,7 +92,7 @@ public class RecurlyJs {
 
     /**
      * HMAC-SHA1 Hash Generator - Helper method
-     * <p/>
+     * <p>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *
      * @param privateJsKey recurly.js private key

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -96,7 +96,7 @@ public class BillingInfo extends RecurlyObject {
 
     /**
      * Account object associated to this BillingInfo
-     * <p/>
+     * <p>
      * Note: when fetching a BillingInfo object from Recurly, the account object is not guaranteed to be populated.
      *
      * @return account object

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
@@ -21,7 +21,7 @@ import javax.xml.bind.annotation.XmlElement;
 
 /**
  * Subscription object for update calls.
- * <p/>
+ * <p>
  * The timeframe parameter is specific to the update.
  */
 public class SubscriptionUpdate extends AbstractSubscription {


### PR DESCRIPTION
Seemingly attempting to `mvn install` under jdk8 fails to build the documentation with lots of errors like this:

recurly-java-library/src/main/java/com/ning/billing/recurly/RecurlyJs.java:74: error: self-closing element not allowed
[ERROR] * <p/>

This patch fixes these errors.