### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+script:
+  - mvn clean test


### PR DESCRIPTION
Starting to address https://github.com/killbilling/recurly-java-library/issues/71

This currently only runs unit tests. We'll need to discuss a way to run integration tests in Travis. Ideally we could privately set the credentials to a sandbox account.

@pierre Killbilling org needs to be enabled in Travis by an org admin. I believe this would be the url for you: https://travis-ci.org/profile/killbilling