### PR TITLE
Add Travis build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-recurly-java-library
+recurly-java-library [![Build Status](https://travis-ci.org/killbilling/recurly-java-library.svg)](https://travis-ci.org/killbilling/recurly-java-library)
 ====================
+
 
 Java library for Recurly, originally developed for [Kill Bill](http://killbill.io), an open-source subscription management and billing system.
 


### PR DESCRIPTION
This adds a badge the the README displaying the current build status. Just to add some confidence for the new user.