### PR TITLE
using Jackson 2.5 and up causes issues when interacting with reculry

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlTransient;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.joda.time.DateTime;
 
 import com.ning.billing.recurly.RecurlyClient;
@@ -75,6 +76,7 @@ public abstract class RecurlyObject {
         xmlMapper.setAnnotationIntrospector(pair);
         xmlMapper.registerModule(new JodaModule());
         xmlMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        xmlMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 
         final SimpleModule m = new SimpleModule("module", new Version(1, 0, 0, null, null, null));
         m.addSerializer(Accounts.class, new RecurlyObjectsSerializer<Accounts, Account>(Accounts.class, "account"));


### PR DESCRIPTION
Upgrading to Jackson 2.5 or higher causes recurly api calls to stop working. An example of a failed create subscription call:
```
<?xml version="1.0" encoding="UTF-8"?>
<error>
  <symbol>invalid_xml</symbol>
  <description>The provided XML was invalid.</description>
  <details>Unacceptable tag &lt;state&gt;</details>
</error>
```
This is the actual xml generated by recurly java library:
```
<subscription><unit_amount_in_cents/><quantity/><plan_code>full</plan_code><account><address/><account_code>xxxxxxxxxx</account_code><state/><username/><email/><first_name/><last_name/><company_name/><accept_language/><hosted_login_token/><created_at/><billing_info><account/><first_name/><last_name/><company/><address1/><address2/><city/><state/><zip/><country/><phone/><vat_number/><ip_address/><ip_address_country/><card_type/><year/><month/><first_six/><last_four/><number/><verification_value/><token_id>xyyxyxxyxyxy</token_id></billing_info></account><invoice/><plan/><uuid/><state/><currency>USD</currency><activated_at/><canceled_at/><expires_at/><current_period_started_at/><current_period_ends_at/><trial_started_at/><trial_ends_at/><pending_subscription/><starts_at/><collection_method/><net_terms/><coupon_code/><po_number/><terms_and_conditions/><customer_notes/><first_renewal_date/><bulk/></subscription>
```

Prior to the upgrade the actual xml doesn't include empty or null values like the example below:
```
<subscription><plan_code>plan</plan_code><account><account_code>xxxxxxxxxx</account_code><billing_info><token_id>xyyxyxxyxyxy</token_id></billing_info></account><currency>USD</currency></subscription>
```
Adding the below line to the RecurlyObject.java in newXmlMapper() method, fixes the problem.
```
xmlMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY); 
```
Look at issue: https://github.com/killbilling/recurly-java-library/issues/90