### PR TITLE
Make base class RecurlyObject.java implement java.io.Serializable.

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
@@ -17,6 +17,7 @@
 
 package com.ning.billing.recurly.model;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -25,12 +26,12 @@ import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlTransient;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import org.joda.time.DateTime;
 
 import com.ning.billing.recurly.RecurlyClient;
 import com.ning.billing.recurly.model.jackson.RecurlyObjectsSerializer;
 import com.ning.billing.recurly.model.jackson.RecurlyXmlSerializerProvider;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.Version;
@@ -45,9 +46,11 @@ import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract class RecurlyObject {
+public abstract class RecurlyObject implements Serializable{
 
-    @XmlTransient
+  	private static final long serialVersionUID = 1L;
+
+	@XmlTransient
     private RecurlyClient recurlyClient;
 
     @XmlTransient


### PR DESCRIPTION
Jboss needs recurly data models to implement java.io.Serializable to be passed as paremeters to EJB session bean methods, please review thanks!