### PR TITLE
Refactor and test code around equals and hashCode

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/AbstractAddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/AbstractAddOn.java
@@ -18,6 +18,7 @@
 package com.ning.billing.recurly.model;
 
 import javax.xml.bind.annotation.XmlElement;
+import com.google.common.base.Objects;
 
 public class AbstractAddOn extends RecurlyObject {
 
@@ -42,12 +43,8 @@ public class AbstractAddOn extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final AbstractAddOn that = (AbstractAddOn) o;
 
@@ -60,6 +57,6 @@ public class AbstractAddOn extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        return addOnCode != null ? addOnCode.hashCode() : 0;
+        return Objects.hashCode(addOnCode);
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/AbstractSubscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/AbstractSubscription.java
@@ -21,6 +21,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.google.common.base.Objects;
+
 @XmlRootElement(name = "subscription")
 public class AbstractSubscription extends RecurlyObject {
 
@@ -73,12 +75,8 @@ public class AbstractSubscription extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof AbstractSubscription)) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final AbstractSubscription that = (AbstractSubscription) o;
 
@@ -100,10 +98,11 @@ public class AbstractSubscription extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        int result = unitAmountInCents != null ? unitAmountInCents.hashCode() : 0;
-        result = 31 * result + (quantity != null ? quantity.hashCode() : 0);
-        result = 31 * result + (addOns != null ? addOns.hashCode() : 0);
-        result = 31 * result + (planCode != null ? planCode.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                unitAmountInCents,
+                quantity,
+                addOns,
+                planCode
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/AbstractTransaction.java
+++ b/src/main/java/com/ning/billing/recurly/model/AbstractTransaction.java
@@ -20,6 +20,7 @@ package com.ning.billing.recurly.model;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Map;
+import com.google.common.base.Objects;
 
 @XmlRootElement(name = "transaction")
 public class AbstractTransaction extends RecurlyObject {
@@ -224,12 +225,8 @@ public class AbstractTransaction extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final AbstractTransaction that = (AbstractTransaction) o;
 
@@ -281,20 +278,21 @@ public class AbstractTransaction extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        int result = action != null ? action.hashCode() : 0;
-        result = 31 * result + (amountInCents != null ? amountInCents.hashCode() : 0);
-        result = 31 * result + (status != null ? status.hashCode() : 0);
-        result = 31 * result + (reference != null ? reference.hashCode() : 0);
-        result = 31 * result + (test != null ? test.hashCode() : 0);
-        result = 31 * result + (voidable != null ? voidable.hashCode() : 0);
-        result = 31 * result + (refundable != null ? refundable.hashCode() : 0);
-        result = 31 * result + (transactionError != null ? transactionError.hashCode() : 0);
-        result = 31 * result + (source != null ? source.hashCode() : 0);
-        result = 31 * result + (ipAddress != null ? ipAddress.hashCode() : 0);
-        result = 31 * result + (cvvResult != null ? cvvResult.hashCode() : 0);
-        result = 31 * result + (avsResult != null ? avsResult.hashCode() : 0);
-        result = 31 * result + (avsResultStreet != null ? avsResultStreet.hashCode() : 0);
-        result = 31 * result + (avsResultPostal != null ? avsResultPostal.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                action,
+                amountInCents,
+                status,
+                reference,
+                test,
+                voidable,
+                refundable,
+                transactionError,
+                source,
+                ipAddress,
+                cvvResult,
+                avsResult,
+                avsResultStreet,
+                avsResultPostal
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Account.java
+++ b/src/main/java/com/ning/billing/recurly/model/Account.java
@@ -17,6 +17,7 @@
 
 package com.ning.billing.recurly.model;
 
+import com.google.common.base.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -256,12 +257,8 @@ public class Account extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final Account account = (Account) o;
 
@@ -283,7 +280,7 @@ public class Account extends RecurlyObject {
         if (companyName != null ? !companyName.equals(account.companyName) : account.companyName != null) {
             return false;
         }
-        if (createdAt != null ? !createdAt.equals(account.createdAt) : account.createdAt != null) {
+        if (createdAt != null ? createdAt.compareTo(account.createdAt) != 0 : account.createdAt != null) {
             return false;
         }
         if (email != null ? !email.equals(account.email) : account.email != null) {
@@ -322,23 +319,24 @@ public class Account extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        int result = address != null ? address.hashCode() : 0;
-        result = 31 * result + (href != null ? href.hashCode() : 0);
-        result = 31 * result + (adjustments != null ? adjustments.hashCode() : 0);
-        result = 31 * result + (invoices != null ? invoices.hashCode() : 0);
-        result = 31 * result + (subscriptions != null ? subscriptions.hashCode() : 0);
-        result = 31 * result + (transactions != null ? transactions.hashCode() : 0);
-        result = 31 * result + (accountCode != null ? accountCode.hashCode() : 0);
-        result = 31 * result + (state != null ? state.hashCode() : 0);
-        result = 31 * result + (username != null ? username.hashCode() : 0);
-        result = 31 * result + (email != null ? email.hashCode() : 0);
-        result = 31 * result + (firstName != null ? firstName.hashCode() : 0);
-        result = 31 * result + (lastName != null ? lastName.hashCode() : 0);
-        result = 31 * result + (companyName != null ? companyName.hashCode() : 0);
-        result = 31 * result + (acceptLanguage != null ? acceptLanguage.hashCode() : 0);
-        result = 31 * result + (hostedLoginToken != null ? hostedLoginToken.hashCode() : 0);
-        result = 31 * result + (createdAt != null ? createdAt.hashCode() : 0);
-        result = 31 * result + (billingInfo != null ? billingInfo.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                address,
+                href,
+                adjustments,
+                invoices,
+                subscriptions,
+                transactions,
+                accountCode,
+                state,
+                username,
+                email,
+                firstName,
+                lastName,
+                companyName,
+                acceptLanguage,
+                hostedLoginToken,
+                createdAt,
+                billingInfo
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/AddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/AddOn.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
 import org.joda.time.DateTime;
+import com.google.common.base.Objects;
 
 @XmlRootElement(name = "add_on")
 public class AddOn extends AbstractAddOn {
@@ -98,15 +99,8 @@ public class AddOn extends AbstractAddOn {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final AddOn addOn = (AddOn) o;
 
@@ -131,12 +125,12 @@ public class AddOn extends AbstractAddOn {
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (displayQuantityOnHostedPage != null ? displayQuantityOnHostedPage.hashCode() : 0);
-        result = 31 * result + (defaultQuantity != null ? defaultQuantity.hashCode() : 0);
-        result = 31 * result + (unitAmountInCents != null ? unitAmountInCents.hashCode() : 0);
-        result = 31 * result + (createdAt != null ? createdAt.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                name,
+                displayQuantityOnHostedPage,
+                defaultQuantity,
+                unitAmountInCents,
+                createdAt
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Address.java
+++ b/src/main/java/com/ning/billing/recurly/model/Address.java
@@ -19,6 +19,7 @@ package com.ning.billing.recurly.model;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import com.google.common.base.Objects;
 
 @XmlRootElement(name = "account")
 public class Address extends RecurlyObject {
@@ -116,12 +117,8 @@ public class Address extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final Address address = (Address) o;
 
@@ -150,15 +147,17 @@ public class Address extends RecurlyObject {
         return true;
     }
 
+
     @Override
     public int hashCode() {
-        int result = address1 != null ? address1.hashCode() : 0;
-        result = 31 * result + (address2 != null ? address2.hashCode() : 0);
-        result = 31 * result + (city != null ? city.hashCode() : 0);
-        result = 31 * result + (state != null ? state.hashCode() : 0);
-        result = 31 * result + (zip != null ? zip.hashCode() : 0);
-        result = 31 * result + (country != null ? country.hashCode() : 0);
-        result = 31 * result + (phone != null ? phone.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                address1,
+                address2,
+                city,
+                state,
+                zip,
+                country,
+                phone
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Adjustment.java
+++ b/src/main/java/com/ning/billing/recurly/model/Adjustment.java
@@ -21,6 +21,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.joda.time.DateTime;
+import com.google.common.base.Objects;
 
 @XmlRootElement(name = "adjustment")
 public class Adjustment extends RecurlyObject {
@@ -218,12 +219,8 @@ public class Adjustment extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final Adjustment that = (Adjustment) o;
 
@@ -233,7 +230,7 @@ public class Adjustment extends RecurlyObject {
         if (accountingCode != null ? !accountingCode.equals(that.accountingCode) : that.accountingCode != null) {
             return false;
         }
-        if (createdAt != null ? !createdAt.equals(that.createdAt) : that.createdAt != null) {
+        if (createdAt != null ? createdAt.compareTo(that.createdAt) != 0 : that.createdAt != null) {
             return false;
         }
         if (currency != null ? !currency.equals(that.currency) : that.currency != null) {
@@ -278,21 +275,22 @@ public class Adjustment extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        int result = account != null ? account.hashCode() : 0;
-        result = 31 * result + (uuid != null ? uuid.hashCode() : 0);
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (accountingCode != null ? accountingCode.hashCode() : 0);
-        result = 31 * result + (origin != null ? origin.hashCode() : 0);
-        result = 31 * result + (unitAmountInCents != null ? unitAmountInCents.hashCode() : 0);
-        result = 31 * result + (quantity != null ? quantity.hashCode() : 0);
-        result = 31 * result + (discountInCents != null ? discountInCents.hashCode() : 0);
-        result = 31 * result + (taxInCents != null ? taxInCents.hashCode() : 0);
-        result = 31 * result + (totalInCents != null ? totalInCents.hashCode() : 0);
-        result = 31 * result + (currency != null ? currency.hashCode() : 0);
-        result = 31 * result + (taxable != null ? taxable.hashCode() : 0);
-        result = 31 * result + (startDate != null ? startDate.hashCode() : 0);
-        result = 31 * result + (endDate != null ? endDate.hashCode() : 0);
-        result = 31 * result + (createdAt != null ? createdAt.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                account,
+                uuid,
+                description,
+                accountingCode,
+                origin,
+                unitAmountInCents,
+                quantity,
+                discountInCents,
+                taxInCents,
+                totalInCents,
+                currency,
+                taxable,
+                startDate,
+                endDate,
+                createdAt
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -21,6 +21,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
+import com.google.common.base.Objects;
+
 @XmlRootElement(name = "billing_info")
 public class BillingInfo extends RecurlyObject {
 
@@ -309,12 +311,8 @@ public class BillingInfo extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final BillingInfo that = (BillingInfo) o;
 
@@ -381,25 +379,26 @@ public class BillingInfo extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        int result = account != null ? account.hashCode() : 0;
-        result = 31 * result + (firstName != null ? firstName.hashCode() : 0);
-        result = 31 * result + (lastName != null ? lastName.hashCode() : 0);
-        result = 31 * result + (company != null ? company.hashCode() : 0);
-        result = 31 * result + (address1 != null ? address1.hashCode() : 0);
-        result = 31 * result + (address2 != null ? address2.hashCode() : 0);
-        result = 31 * result + (city != null ? city.hashCode() : 0);
-        result = 31 * result + (state != null ? state.hashCode() : 0);
-        result = 31 * result + (zip != null ? zip.hashCode() : 0);
-        result = 31 * result + (country != null ? country.hashCode() : 0);
-        result = 31 * result + (phone != null ? phone.hashCode() : 0);
-        result = 31 * result + (vatNumber != null ? vatNumber.hashCode() : 0);
-        result = 31 * result + (ipAddress != null ? ipAddress.hashCode() : 0);
-        result = 31 * result + (ipAddressCountry != null ? ipAddressCountry.hashCode() : 0);
-        result = 31 * result + (cardType != null ? cardType.hashCode() : 0);
-        result = 31 * result + (year != null ? year.hashCode() : 0);
-        result = 31 * result + (month != null ? month.hashCode() : 0);
-        result = 31 * result + (firstSix != null ? firstSix.hashCode() : 0);
-        result = 31 * result + (lastFour != null ? lastFour.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                account,
+                firstName,
+                lastName,
+                company,
+                address1,
+                address2,
+                city,
+                state,
+                zip,
+                country,
+                phone,
+                vatNumber,
+                ipAddress,
+                ipAddressCountry,
+                cardType,
+                year,
+                month,
+                firstSix,
+                lastFour
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Coupon.java
+++ b/src/main/java/com/ning/billing/recurly/model/Coupon.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
 import org.joda.time.DateTime;
+import com.google.common.base.Objects;
 
 /**
  * Class that represents the Concept of a Coupon within the Recurly API.
@@ -221,18 +222,24 @@ public class Coupon extends RecurlyObject {
         return sb.toString();
     }
 
+
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final Coupon coupon = (Coupon) o;
 
+        if (appliesForMonths != null ? !appliesForMonths.equals(coupon.appliesForMonths) : coupon.appliesForMonths != null) {
+            return false;
+        }
+        if (appliesToAllPlans != null ? !appliesToAllPlans.equals(coupon.appliesToAllPlans) : coupon.appliesToAllPlans != null) {
+            return false;
+        }
         if (couponCode != null ? !couponCode.equals(coupon.couponCode) : coupon.couponCode != null) {
+            return false;
+        }
+        if (discountInCents != null ? !discountInCents.equals(coupon.discountInCents) : coupon.discountInCents != null) {
             return false;
         }
         if (discountPercent != null ? !discountPercent.equals(coupon.discountPercent) : coupon.discountPercent != null) {
@@ -241,7 +248,16 @@ public class Coupon extends RecurlyObject {
         if (discountType != null ? !discountType.equals(coupon.discountType) : coupon.discountType != null) {
             return false;
         }
+        if (maxRedemptions != null ? !maxRedemptions.equals(coupon.maxRedemptions) : coupon.maxRedemptions != null) {
+            return false;
+        }
         if (name != null ? !name.equals(coupon.name) : coupon.name != null) {
+            return false;
+        }
+        if (redeemByDate != null ? redeemByDate.compareTo(coupon.redeemByDate) != 0 : coupon.redeemByDate != null) {
+            return false;
+        }
+        if (singleUse != null ? singleUse.compareTo(coupon.singleUse) != 0 : coupon.singleUse != null) {
             return false;
         }
 
@@ -250,10 +266,17 @@ public class Coupon extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (couponCode != null ? couponCode.hashCode() : 0);
-        result = 31 * result + (discountType != null ? discountType.hashCode() : 0);
-        result = 31 * result + (discountPercent != null ? discountPercent.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                name,
+                couponCode,
+                discountType,
+                discountPercent,
+                discountInCents,
+                redeemByDate,
+                singleUse,
+                appliesForMonths,
+                appliesToAllPlans,
+                maxRedemptions
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Errors.java
+++ b/src/main/java/com/ning/billing/recurly/model/Errors.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.google.common.base.Objects;
+
 @XmlRootElement(name = "errors")
 public class Errors extends RecurlyObject {
 
@@ -106,9 +108,10 @@ public class Errors extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        int result = transactionError != null ? transactionError.hashCode() : 0;
-        result = 31 * result + (transaction != null ? transaction.hashCode() : 0);
-        result = 31 * result + (recurlyErrors != null ? recurlyErrors.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                transactionError,
+                transaction,
+                recurlyErrors
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.joda.time.DateTime;
+import com.google.common.base.Objects;
 
 @XmlRootElement(name = "invoice")
 public class Invoice extends RecurlyObject {
@@ -220,12 +221,8 @@ public class Invoice extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final Invoice invoice = (Invoice) o;
 
@@ -280,21 +277,22 @@ public class Invoice extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        int result = account != null ? account.hashCode() : 0;
-        result = 31 * result + (uuid != null ? uuid.hashCode() : 0);
-        result = 31 * result + (state != null ? state.hashCode() : 0);
-        result = 31 * result + (invoiceNumber != null ? invoiceNumber.hashCode() : 0);
-        result = 31 * result + (poNumber != null ? poNumber.hashCode() : 0);
-        result = 31 * result + (vatNumber != null ? vatNumber.hashCode() : 0);
-        result = 31 * result + (subtotalInCents != null ? subtotalInCents.hashCode() : 0);
-        result = 31 * result + (taxInCents != null ? taxInCents.hashCode() : 0);
-        result = 31 * result + (totalInCents != null ? totalInCents.hashCode() : 0);
-        result = 31 * result + (currency != null ? currency.hashCode() : 0);
-        result = 31 * result + (createdAt != null ? createdAt.hashCode() : 0);
-        result = 31 * result + (collectionMethod != null ? collectionMethod.hashCode() : 0);
-        result = 31 * result + (netTerms != null ? netTerms.hashCode() : 0);
-        result = 31 * result + (lineItems != null ? lineItems.hashCode() : 0);
-        result = 31 * result + (transactions != null ? transactions.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                account,
+                uuid,
+                state,
+                invoiceNumber,
+                poNumber,
+                vatNumber,
+                subtotalInCents,
+                totalInCents,
+                taxInCents,
+                currency,
+                createdAt,
+                collectionMethod,
+                netTerms,
+                lineItems,
+                transactions
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/LineItem.java
+++ b/src/main/java/com/ning/billing/recurly/model/LineItem.java
@@ -19,6 +19,7 @@ package com.ning.billing.recurly.model;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import com.google.common.base.Objects;
 
 @XmlRootElement(name = "invoice")
 public class LineItem extends RecurlyObject {
@@ -45,12 +46,8 @@ public class LineItem extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final LineItem lineItem = (LineItem) o;
 
@@ -63,6 +60,6 @@ public class LineItem extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        return adjustment != null ? adjustment.hashCode() : 0;
+        return Objects.hashCode(adjustment);
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Plan.java
+++ b/src/main/java/com/ning/billing/recurly/model/Plan.java
@@ -23,6 +23,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
 import org.joda.time.DateTime;
+import com.google.common.base.Objects;
 
 @XmlRootElement(name = "plan")
 public class Plan extends RecurlyObject {
@@ -269,12 +270,8 @@ public class Plan extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final Plan plan = (Plan) o;
 
@@ -293,7 +290,7 @@ public class Plan extends RecurlyObject {
         if (cancelLink != null ? !cancelLink.equals(plan.cancelLink) : plan.cancelLink != null) {
             return false;
         }
-        if (createdAt != null ? !createdAt.equals(plan.createdAt) : plan.createdAt != null) {
+        if (createdAt != null ? createdAt.compareTo(plan.createdAt) != 0: plan.createdAt != null) {
             return false;
         }
         if (description != null ? !description.equals(plan.description) : plan.description != null) {
@@ -341,25 +338,26 @@ public class Plan extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        int result = addOns != null ? addOns.hashCode() : 0;
-        result = 31 * result + (planCode != null ? planCode.hashCode() : 0);
-        result = 31 * result + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (successLink != null ? successLink.hashCode() : 0);
-        result = 31 * result + (cancelLink != null ? cancelLink.hashCode() : 0);
-        result = 31 * result + (displayDonationAmounts != null ? displayDonationAmounts.hashCode() : 0);
-        result = 31 * result + (displayQuantity != null ? displayQuantity.hashCode() : 0);
-        result = 31 * result + (displayPhoneNumber ? 1 : 0);
-        result = 31 * result + (bypassHostedConfirmation ? 1 : 0);
-        result = 31 * result + (unitName != null ? unitName.hashCode() : 0);
-        result = 31 * result + (planIntervalUnit != null ? planIntervalUnit.hashCode() : 0);
-        result = 31 * result + (planIntervalLength != null ? planIntervalLength.hashCode() : 0);
-        result = 31 * result + (trialIntervalLength != null ? trialIntervalLength.hashCode() : 0);
-        result = 31 * result + (trialIntervalUnit != null ? trialIntervalUnit.hashCode() : 0);
-        result = 31 * result + (accountingCode != null ? accountingCode.hashCode() : 0);
-        result = 31 * result + (createdAt != null ? createdAt.hashCode() : 0);
-        result = 31 * result + (unitAmountInCents != null ? unitAmountInCents.hashCode() : 0);
-        result = 31 * result + (setupFeeInCents != null ? setupFeeInCents.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                addOns,
+                planCode,
+                name,
+                description,
+                successLink,
+                cancelLink,
+                displayDonationAmounts,
+                displayQuantity,
+                displayPhoneNumber,
+                bypassHostedConfirmation,
+                unitName,
+                planIntervalUnit,
+                planIntervalLength,
+                trialIntervalUnit,
+                trialIntervalLength,
+                accountingCode,
+                createdAt,
+                unitAmountInCents,
+                setupFeeInCents
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyAPIError.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyAPIError.java
@@ -19,6 +19,7 @@ package com.ning.billing.recurly.model;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import com.google.common.base.Objects;
 
 @XmlRootElement(name = "error")
 public class RecurlyAPIError extends RecurlyObject {
@@ -68,12 +69,8 @@ public class RecurlyAPIError extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final RecurlyAPIError that = (RecurlyAPIError) o;
 
@@ -92,9 +89,10 @@ public class RecurlyAPIError extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        int result = description != null ? description.hashCode() : 0;
-        result = 31 * result + (symbol != null ? symbol.hashCode() : 0);
-        result = 31 * result + (details != null ? details.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                description,
+                symbol,
+                details
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyError.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyError.java
@@ -19,6 +19,7 @@ package com.ning.billing.recurly.model;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import com.google.common.base.Objects;
 
 @XmlRootElement(name = "error")
 public class RecurlyError extends RecurlyObject {
@@ -68,12 +69,8 @@ public class RecurlyError extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final RecurlyError that = (RecurlyError) o;
 
@@ -92,9 +89,10 @@ public class RecurlyError extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        int result = field != null ? field.hashCode() : 0;
-        result = 31 * result + (symbol != null ? symbol.hashCode() : 0);
-        result = 31 * result + (message != null ? message.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                field,
+                symbol,
+                message
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
@@ -181,4 +181,12 @@ public abstract class RecurlyObject {
     public void setRecurlyClient(final RecurlyClient recurlyClient) {
         this.recurlyClient = recurlyClient;
     }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        return this.hashCode() == o.hashCode();
+    }
 }

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyUnitCurrency.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyUnitCurrency.java
@@ -18,6 +18,7 @@
 package com.ning.billing.recurly.model;
 
 import java.util.Map;
+import com.google.common.base.Objects;
 
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlElement;
@@ -266,12 +267,8 @@ public class RecurlyUnitCurrency {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final RecurlyUnitCurrency that = (RecurlyUnitCurrency) o;
 
@@ -326,21 +323,22 @@ public class RecurlyUnitCurrency {
 
     @Override
     public int hashCode() {
-        int result = unitAmountUSD != null ? unitAmountUSD.hashCode() : 0;
-        result = 31 * result + (unitAmountAUD != null ? unitAmountAUD.hashCode() : 0);
-        result = 31 * result + (unitAmountCAD != null ? unitAmountCAD.hashCode() : 0);
-        result = 31 * result + (unitAmountEUR != null ? unitAmountEUR.hashCode() : 0);
-        result = 31 * result + (unitAmountGBP != null ? unitAmountGBP.hashCode() : 0);
-        result = 31 * result + (unitAmountCZK != null ? unitAmountCZK.hashCode() : 0);
-        result = 31 * result + (unitAmountDKK != null ? unitAmountDKK.hashCode() : 0);
-        result = 31 * result + (unitAmountHUF != null ? unitAmountHUF.hashCode() : 0);
-        result = 31 * result + (unitAmountNOK != null ? unitAmountNOK.hashCode() : 0);
-        result = 31 * result + (unitAmountNZD != null ? unitAmountNZD.hashCode() : 0);
-        result = 31 * result + (unitAmountPLN != null ? unitAmountPLN.hashCode() : 0);
-        result = 31 * result + (unitAmountSGD != null ? unitAmountSGD.hashCode() : 0);
-        result = 31 * result + (unitAmountSEK != null ? unitAmountSEK.hashCode() : 0);
-        result = 31 * result + (unitAmountCHF != null ? unitAmountCHF.hashCode() : 0);
-        result = 31 * result + (unitAmountZAR != null ? unitAmountZAR.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                unitAmountUSD,
+                unitAmountCAD,
+                unitAmountAUD,
+                unitAmountEUR,
+                unitAmountGBP,
+                unitAmountCZK,
+                unitAmountDKK,
+                unitAmountHUF,
+                unitAmountNOK,
+                unitAmountNZD,
+                unitAmountPLN,
+                unitAmountSGD,
+                unitAmountSEK,
+                unitAmountCHF,
+                unitAmountZAR
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Redemption.java
+++ b/src/main/java/com/ning/billing/recurly/model/Redemption.java
@@ -23,6 +23,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
+import com.google.common.base.Objects;
+
 @XmlRootElement(name = "redemption")
 public class Redemption extends RecurlyObject {
 
@@ -144,12 +146,9 @@ public class Redemption extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
         final Redemption that = (Redemption) o;
 
         if (accountCode != null ? !accountCode.equals(that.accountCode) : that.accountCode != null) {
@@ -174,23 +173,25 @@ public class Redemption extends RecurlyObject {
         if (state != null ? !state.equals(that.state) : that.state != null) {
             return false;
         }
-        if (createdAt != null ? !createdAt.equals(that.createdAt) : that.createdAt != null) {
+        if (createdAt != null ? createdAt.compareTo(that.createdAt) != 0 : that.createdAt != null) {
             return false;
         }
+
         return true;
     }
 
     @Override
     public int hashCode() {
-        int result = accountCode != null ? accountCode.hashCode() : 0;
-        result = 31 * result + (coupon != null ? coupon.hashCode() : 0);
-        result = 31 * result + (account != null ? account.hashCode() : 0);
-        result = 31 * result + (singleUse != null ? singleUse.hashCode() : 0);
-        result = 31 * result + (totalDiscountedInCents != null ? totalDiscountedInCents.hashCode() : 0);
-        result = 31 * result + (currency != null ? currency.hashCode() : 0);
-        result = 31 * result + (state != null ? state.hashCode() : 0);
-        result = 31 * result + (createdAt != null ? createdAt.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                accountCode,
+                coupon,
+                account,
+                singleUse,
+                totalDiscountedInCents,
+                currency,
+                state,
+                createdAt
+        );
     }
 
 }

--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -22,6 +22,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import org.joda.time.DateTime;
 
+import com.google.common.base.Objects;
+
 @XmlRootElement(name = "subscription")
 public class Subscription extends AbstractSubscription {
 
@@ -303,37 +305,33 @@ public class Subscription extends AbstractSubscription {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final Subscription that = (Subscription) o;
 
         if (account != null ? !account.equals(that.account) : that.account != null) {
             return false;
         }
-        if (activatedAt != null ? !activatedAt.equals(that.activatedAt) : that.activatedAt != null) {
+        if (activatedAt != null ? activatedAt.compareTo(that.activatedAt) != 0 : that.activatedAt != null) {
             return false;
         }
         if (addOns != null ? !addOns.equals(that.addOns) : that.addOns != null) {
             return false;
         }
-        if (canceledAt != null ? !canceledAt.equals(that.canceledAt) : that.canceledAt != null) {
+        if (canceledAt != null ? canceledAt.compareTo(that.canceledAt) != 0 : that.canceledAt != null) {
             return false;
         }
         if (currency != null ? !currency.equals(that.currency) : that.currency != null) {
             return false;
         }
-        if (currentPeriodEndsAt != null ? !currentPeriodEndsAt.equals(that.currentPeriodEndsAt) : that.currentPeriodEndsAt != null) {
+        if (currentPeriodEndsAt != null ? currentPeriodEndsAt.compareTo(that.currentPeriodEndsAt) != 0 : that.currentPeriodEndsAt != null) {
             return false;
         }
-        if (currentPeriodStartedAt != null ? !currentPeriodStartedAt.equals(that.currentPeriodStartedAt) : that.currentPeriodStartedAt != null) {
+        if (currentPeriodStartedAt != null ? currentPeriodStartedAt.compareTo(that.currentPeriodStartedAt) != 0 : that.currentPeriodStartedAt != null) {
             return false;
         }
-        if (expiresAt != null ? !expiresAt.equals(that.expiresAt) : that.expiresAt != null) {
+        if (expiresAt != null ? expiresAt.compareTo(that.expiresAt) != 0 : that.expiresAt != null) {
             return false;
         }
         if (plan != null ? !plan.equals(that.plan) : that.plan != null) {
@@ -342,14 +340,13 @@ public class Subscription extends AbstractSubscription {
         if (quantity != null ? !quantity.equals(that.quantity) : that.quantity != null) {
             return false;
         }
-
         if (state != null ? !state.equals(that.state) : that.state != null) {
             return false;
         }
-        if (trialEndsAt != null ? !trialEndsAt.equals(that.trialEndsAt) : that.trialEndsAt != null) {
+        if (trialEndsAt != null ? trialEndsAt.compareTo(that.trialEndsAt) != 0 : that.trialEndsAt != null) {
             return false;
         }
-        if (trialStartedAt != null ? !trialStartedAt.equals(that.trialStartedAt) : that.trialStartedAt != null) {
+        if (trialStartedAt != null ? trialStartedAt.compareTo(that.trialStartedAt) != 0 : that.trialStartedAt != null) {
             return false;
         }
         if (unitAmountInCents != null ? !unitAmountInCents.equals(that.unitAmountInCents) : that.unitAmountInCents != null) {
@@ -358,7 +355,7 @@ public class Subscription extends AbstractSubscription {
         if (uuid != null ? !uuid.equals(that.uuid) : that.uuid != null) {
             return false;
         }
-        if (startsAt != null ? !startsAt.equals(that.startsAt) : that.startsAt != null) {
+        if (startsAt != null ? startsAt.compareTo(that.startsAt) != 0 : that.startsAt != null) {
             return false;
         }
         if (pendingSubscription != null ? !pendingSubscription.equals(that.pendingSubscription) : that.pendingSubscription != null) {
@@ -367,19 +364,16 @@ public class Subscription extends AbstractSubscription {
         if (collectionMethod != null ? !collectionMethod.equals(that.collectionMethod) : that.collectionMethod != null) {
             return false;
         }
-
         if (netTerms != null ? !netTerms.equals(that.netTerms) : that.netTerms != null) {
             return false;
         }
-
         if (poNumber != null ? !poNumber.equals(that.poNumber) : that.poNumber != null) {
             return false;
         }
-
-        if (firstRenewalDate != null ? !firstRenewalDate.equals(that.firstRenewalDate) : that.firstRenewalDate != null) {
+        if (firstRenewalDate != null ? firstRenewalDate.compareTo(that.firstRenewalDate) != 0 : that.firstRenewalDate != null) {
             return false;
         }
-        
+
         if (bulk != null ? !bulk.equals(that.bulk) : that.bulk != null) {
             return false;
         }
@@ -389,26 +383,28 @@ public class Subscription extends AbstractSubscription {
 
     @Override
     public int hashCode() {
-        int result = account != null ? account.hashCode() : 0;
-        result = 31 * result + (plan != null ? plan.hashCode() : 0);
-        result = 31 * result + (uuid != null ? uuid.hashCode() : 0);
-        //result = 31 * result + (state != null ? state.hashCode() : 0);
-        result = 31 * result + (unitAmountInCents != null ? unitAmountInCents.hashCode() : 0);
-        result = 31 * result + (currency != null ? currency.hashCode() : 0);
-        result = 31 * result + (quantity != null ? quantity.hashCode() : 0);
-        result = 31 * result + (activatedAt != null ? activatedAt.hashCode() : 0);
-        result = 31 * result + (canceledAt != null ? canceledAt.hashCode() : 0);
-        result = 31 * result + (expiresAt != null ? expiresAt.hashCode() : 0);
-        result = 31 * result + (currentPeriodStartedAt != null ? currentPeriodStartedAt.hashCode() : 0);
-        result = 31 * result + (currentPeriodEndsAt != null ? currentPeriodEndsAt.hashCode() : 0);
-        result = 31 * result + (trialStartedAt != null ? trialStartedAt.hashCode() : 0);
-        result = 31 * result + (trialEndsAt != null ? trialEndsAt.hashCode() : 0);
-        result = 31 * result + (addOns != null ? addOns.hashCode() : 0);
-        result = 31 * result + (pendingSubscription != null ? pendingSubscription.hashCode() : 0);
-        result = 31 * result + (startsAt != null ? startsAt.hashCode() : 0);
-        result = 31 * result + (collectionMethod != null ? collectionMethod.hashCode() : 0);
-        result = 31 * result + (netTerms != null ? netTerms.hashCode() : 0);
-        result = 31 * result + (poNumber != null ? poNumber.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                account,
+                plan,
+                uuid,
+                state,
+                unitAmountInCents,
+                currency,
+                quantity,
+                activatedAt,
+                canceledAt,
+                expiresAt,
+                currentPeriodStartedAt,
+                currentPeriodEndsAt,
+                trialStartedAt,
+                trialEndsAt,
+                addOns,
+                pendingSubscription,
+                startsAt,
+                collectionMethod,
+                netTerms,
+                poNumber
+
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionAddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionAddOn.java
@@ -20,6 +20,8 @@ package com.ning.billing.recurly.model;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.google.common.base.Objects;
+
 @XmlRootElement(name = "subscription_add_on")
 public class SubscriptionAddOn extends AbstractAddOn {
 
@@ -56,15 +58,8 @@ public class SubscriptionAddOn extends AbstractAddOn {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final SubscriptionAddOn addOn = (SubscriptionAddOn) o;
 
@@ -80,9 +75,9 @@ public class SubscriptionAddOn extends AbstractAddOn {
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (unitAmountInCents != null ? unitAmountInCents.hashCode() : 0);
-        result = 31 * result + (quantity != null ? quantity.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                unitAmountInCents,
+                quantity
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionNotes.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionNotes.java
@@ -18,7 +18,8 @@
 package com.ning.billing.recurly.model;
 
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
+
+import com.google.common.base.Objects;
 
 public class SubscriptionNotes extends AbstractSubscription {
 
@@ -67,26 +68,17 @@ public class SubscriptionNotes extends AbstractSubscription {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final SubscriptionNotes that = (SubscriptionNotes) o;
 
         if (termsAndConditions != null ? !termsAndConditions.equals(that.termsAndConditions) : that.termsAndConditions != null) {
             return false;
         }
-        
         if (customerNotes != null ? !customerNotes.equals(that.customerNotes) : that.customerNotes != null) {
             return false;
         }
-        
         if (vatReverseChargeNotes != null ? !vatReverseChargeNotes.equals(that.vatReverseChargeNotes) : that.vatReverseChargeNotes != null) {
             return false;
         }
@@ -96,10 +88,10 @@ public class SubscriptionNotes extends AbstractSubscription {
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (termsAndConditions != null ? termsAndConditions.hashCode() : 0);
-        result = 31 * result + (customerNotes != null ? customerNotes.hashCode() : 0);
-        result = 31 * result + (vatReverseChargeNotes != null ? vatReverseChargeNotes.hashCode() : 0);             
-        return result;
+        return Objects.hashCode(
+                termsAndConditions,
+                customerNotes,
+                vatReverseChargeNotes
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
@@ -18,6 +18,7 @@
 package com.ning.billing.recurly.model;
 
 import javax.xml.bind.annotation.XmlElement;
+import com.google.common.base.Objects;
 
 /**
  * Subscription object for update calls.
@@ -55,15 +56,8 @@ public class SubscriptionUpdate extends AbstractSubscription {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final SubscriptionUpdate that = (SubscriptionUpdate) o;
 
@@ -79,9 +73,9 @@ public class SubscriptionUpdate extends AbstractSubscription {
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (timeframe != null ? timeframe.hashCode() : 0);
-        result = 31 * result + (collectionMethod != null ? collectionMethod.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                timeframe,
+                collectionMethod
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Transaction.java
+++ b/src/main/java/com/ning/billing/recurly/model/Transaction.java
@@ -22,6 +22,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import org.joda.time.DateTime;
 
+import com.google.common.base.Objects;
+
 @XmlRootElement(name = "transaction")
 public class Transaction extends AbstractTransaction {
 
@@ -185,22 +187,15 @@ public class Transaction extends AbstractTransaction {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final Transaction that = (Transaction) o;
 
         if (account != null ? !account.equals(that.account) : that.account != null) {
             return false;
         }
-        if (createdAt != null ? !createdAt.equals(that.createdAt) : that.createdAt != null) {
+        if (createdAt != null ? createdAt.compareTo(that.createdAt) != 0 : that.createdAt != null) {
             return false;
         }
         if (currency != null ? !currency.equals(that.currency) : that.currency != null) {
@@ -230,7 +225,7 @@ public class Transaction extends AbstractTransaction {
         if (paymentMethod != null ? !paymentMethod.equals(that.paymentMethod) : that.paymentMethod != null) {
             return false;
         }
-        if (collectedAt != null ? !collectedAt.equals(that.collectedAt) : that.collectedAt != null) {
+        if (collectedAt != null ? collectedAt.compareTo(that.collectedAt) != 0 : that.collectedAt != null) {
             return false;
         }
 
@@ -239,17 +234,17 @@ public class Transaction extends AbstractTransaction {
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (account != null ? account.hashCode() : 0);
-        result = 31 * result + (invoice != null ? invoice.hashCode() : 0);
-        result = 31 * result + (subscription != null ? subscription.hashCode() : 0);
-        result = 31 * result + (uuid != null ? uuid.hashCode() : 0);
-        result = 31 * result + (taxInCents != null ? taxInCents.hashCode() : 0);
-        result = 31 * result + (currency != null ? currency.hashCode() : 0);
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (recurring != null ? recurring.hashCode() : 0);
-        result = 31 * result + (createdAt != null ? createdAt.hashCode() : 0);
-        result = 31 * result + (details != null ? details.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                account,
+                invoice,
+                subscription,
+                uuid,
+                taxInCents,
+                currency,
+                description,
+                recurring,
+                createdAt,
+                details
+        );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/TransactionDetails.java
+++ b/src/main/java/com/ning/billing/recurly/model/TransactionDetails.java
@@ -19,6 +19,7 @@ package com.ning.billing.recurly.model;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import com.google.common.base.Objects;
 
 @XmlRootElement(name = "details")
 public class TransactionDetails extends RecurlyObject {
@@ -44,12 +45,8 @@ public class TransactionDetails extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final TransactionDetails that = (TransactionDetails) o;
 
@@ -62,6 +59,6 @@ public class TransactionDetails extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        return account != null ? account.hashCode() : 0;
+        return Objects.hashCode(account);
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/TransactionError.java
+++ b/src/main/java/com/ning/billing/recurly/model/TransactionError.java
@@ -20,6 +20,8 @@ package com.ning.billing.recurly.model;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.google.common.base.Objects;
+
 @XmlRootElement(name = "transaction_error")
 public class TransactionError extends RecurlyObject {
 
@@ -80,12 +82,8 @@ public class TransactionError extends RecurlyObject {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         final TransactionError that = (TransactionError) o;
 
@@ -107,10 +105,11 @@ public class TransactionError extends RecurlyObject {
 
     @Override
     public int hashCode() {
-        int result = errorCode != null ? errorCode.hashCode() : 0;
-        result = 31 * result + (errorCategory != null ? errorCategory.hashCode() : 0);
-        result = 31 * result + (merchantMessage != null ? merchantMessage.hashCode() : 0);
-        result = 31 * result + (customerMessage != null ? customerMessage.hashCode() : 0);
-        return result;
+        return Objects.hashCode(
+                errorCode,
+                errorCategory,
+                merchantMessage,
+                customerMessage
+        );
     }
 }

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -69,6 +69,7 @@ public class TestRecurlyClient {
     public void setUp() throws Exception {
         final String apiKey = System.getProperty(KILLBILL_PAYMENT_RECURLY_API_KEY);
         String subDomainTemp = System.getProperty(KILLBILL_PAYMENT_RECURLY_SUBDOMAIN);
+
         if (apiKey == null) {
             Assert.fail("You need to set your Recurly api key to run integration tests:" +
                         " -Dkillbill.payment.recurly.apiKey=...");

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -17,8 +17,15 @@
 
 package com.ning.billing.recurly;
 
+import java.util.Date;
+import java.util.Random;
 import java.util.UUID;
 
+import com.ning.billing.recurly.model.Adjustment;
+import com.ning.billing.recurly.model.Adjustments;
+import com.ning.billing.recurly.model.Invoice;
+import com.ning.billing.recurly.model.Redemption;
+import com.ning.billing.recurly.model.Transactions;
 import org.joda.time.DateTime;
 
 import com.ning.billing.recurly.model.Account;
@@ -35,43 +42,157 @@ import com.ning.billing.recurly.model.Transaction;
 
 public class TestUtils {
 
+    private static enum StringMode {
+        ALPHA,
+        ALPHA_NUMERIC,
+        NUMERIC,
+    };
+
+    private static final char[] SYMBOLS;
+
+    // Build an array of symbols
+    static {
+        int idx = 0;
+        SYMBOLS = new char[62];
+
+        for (char ch = 'A'; ch <= 'Z'; ++ch) SYMBOLS[idx++] = ch;
+        for (char ch = 'a'; ch <= 'z'; ++ch) SYMBOLS[idx++] = ch;
+        for (char ch = '0'; ch <= '9'; ++ch) SYMBOLS[idx++] = ch;
+    }
+
+    private static final DateTime NOW = new DateTime();
+    private static final DateTime TOMORROW = new DateTime(NOW.toDate().getTime() + (1000 * 60 * 60 * 24));
+
     /**
      * Returns a random {@link String}.
+     *
+     * @param length The limit of the upperRange - the random returned value could be upto and including this value
+     * @param lowerIdx The low index to use on the SYMBOLS table
+     * @param upperIdx The upper index to use on the SYMBOLS table
+     * @param seed The RNG seed
+     * @return The random {@link String}
+     */
+    public static String randomString(final int length, final int lowerIdx, final int upperIdx, final int seed) {
+        Random random = new Random(seed);
+        StringBuilder sb = new StringBuilder();
+        int range = upperIdx - lowerIdx;
+
+        for (int i = 0; i < length; i++)
+            sb.append(SYMBOLS[lowerIdx + random.nextInt(range)]);
+
+        return sb.toString();
+    }
+
+    /**
+     * Returns a random {@link String} but deterministic
+     *
+     * @param length The limit of the upperRange - the random returned value could be upto and including this value
+     * @param mode
+     * @param seed The RNG seed
+     * @return The random {@link String}
+     */
+    public static String randomString(final int length, final StringMode mode, final int seed) {
+        switch (mode) {
+            case ALPHA:
+                return randomString(length, 0, 52, seed);
+            case ALPHA_NUMERIC:
+                return randomString(length, 0, 62, seed);
+            case NUMERIC:
+                return randomString(length, 52, 62, seed);
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Returns a random {@link String}.
+     *
+     * @param length The limit of the upperRange - the random returned value could be upto and including this value
+     * @return The random {@link String}
+     */
+    public static String randomString(final int length, final StringMode mode) {
+        return randomString(length, mode, randomSeed());
+    }
+
+    /**
+     * Returns a random alpha {@link String}.
+     *
+     * @param length The limit of the upperRange - the random returned value could be upto and including this value
+     * @return The random {@link String}
+     */
+    public static String randomAlphaString(final int length) {
+        return randomAlphaString(length, randomSeed());
+    }
+
+    /**
+     * Returns a random alpha {@link String} given a seed
+     *
+     * @param length The limit of the upperRange - the random returned value could be upto and including this value
+     * @param seed The RNG seed
+     * @return The random {@link String}
+     */
+    public static String randomAlphaString(final int length, final int seed) {
+        return randomString(length, StringMode.ALPHA, seed);
+    }
+
+    /**
+     * Returns a random alpha-numeric {@link String} given a seed.
+     *
+     * @param length The limit of the upperRange - the random returned value could be upto and including this value
+     * @param seed The RNG seed
+     * @return The random {@link String}
+     */
+    public static String randomAlphaNumericString(final int length, final int seed) {
+        return randomString(length, StringMode.ALPHA_NUMERIC, seed);
+    }
+
+    /**
+     * Returns a random alpha-numeric {@link String}.
+     *
+     * @param length The limit of the upperRange - the random returned value could be upto and including this value
+     * @return The random {@link String}
+     */
+    public static String randomAlphaNumericString(final int length) {
+        return randomAlphaNumericString(length, randomSeed());
+    }
+
+    /**
+     * Returns a random numeric {@link String}.
+     *
+     * @param length The limit of the upperRange - the random returned value could be upto and including this value
+     * @return The random {@link String}
+     */
+    public static String randomNumericString(final int length) {
+        return randomNumericString(length, randomSeed());
+    }
+
+    /**
+     * Returns a random numeric {@link String} given a seed
+     *
+     * @param length The limit of the upperRange - the random returned value could be upto and including this value
+     * @param seed The RNG seed
+     * @return The random {@link String}
+     */
+    public static String randomNumericString(final int length, final int seed) {
+        return randomString(length, StringMode.NUMERIC, seed);
+    }
+
+    /**
+     * Returns a random alpha-numeric {@link String} with a random length b/w 1 and 30.
      *
      * @return The random {@link String}
      */
     public static String randomString() {
-        return UUID.randomUUID().toString().replace("-", "").substring(0, 5);
+        return randomString(1 + randomInteger(30), StringMode.NUMERIC, randomSeed());
     }
 
     /**
-     * Generates a String comprised of random alpha-numeric
-     * chars upto the length as defined by the input param.
+     * Returns a a big random {@link Integer} to be used as a seed
      *
-     * @param n The length, in number of chars, of the returned
-     *          String
-     * @return A random alpah-numeric String
+     * @return The random {@link Integer}
      */
-    public static String getRandomAlphaNumString(final int n) {
-        int offset = n;
-        final String retValue = UUID.randomUUID().toString().replace("-", "");
-
-        if (retValue.length() <= n) {
-            offset = retValue.length() - 1;
-        }
-        return retValue.substring(0, offset);
-    }
-
-    /**
-     * Generates a String comprised of random numeric
-     * chars upto the length as defined by the input param.
-     *
-     * @param n The length, in number of chars, of the returned
-     *          String
-     * @return A random numeric String
-     */
-    public static String getRandomNumString(final int n) {
-        return "" + new Double(Math.random() * 100).intValue();
+    public static int randomSeed() {
+        return (int) (Math.random() * Integer.MAX_VALUE);
     }
 
     /**
@@ -81,7 +202,19 @@ public class TestUtils {
      * @return The random integer - from within the range 0 to upperRange
      */
     public static Integer randomInteger(final int upperRange) {
-        return (int) (Math.random() * upperRange);
+        return randomInteger(upperRange, randomSeed());
+    }
+
+    /**
+     * Returns a random {@link Integer} within the range 0 to upperRange given a seed
+     *
+     * @param upperRange The limit of the upperRange - the random returned value could be upto and including this value
+     * @param seed The RNG seed
+     * @return The random integer - from within the range 0 to upperRange
+     */
+    public static Integer randomInteger(final int upperRange, final int seed) {
+        Random random = new Random(seed);
+        return random.nextInt(upperRange);
     }
 
     public static String createTestCCNumber() {
@@ -106,26 +239,86 @@ public class TestUtils {
      * @return The random {@link com.ning.billing.recurly.model.Account} object
      */
     public static Account createRandomAccount() {
-        final Account account = new Account();
-        account.setAcceptLanguage("en_US");
-        account.setAccountCode(UUID.randomUUID().toString());
-        account.setCompanyName(getRandomAlphaNumString(10));
-        account.setEmail(getRandomAlphaNumString(4) + "@test.com");
-        account.setFirstName(getRandomAlphaNumString(5));
-        account.setLastName(getRandomAlphaNumString(6));
+        return createRandomAccount(randomSeed());
+    }
 
-        final Address address = new Address();
-        address.setAddress1(UUID.randomUUID().toString());
-        address.setAddress2(UUID.randomUUID().toString());
-        address.setCity(UUID.randomUUID().toString());
-        address.setState(UUID.randomUUID().toString());
-        address.setZip(49302);
-        address.setCountry(UUID.randomUUID().toString());
-        address.setPhone(UUID.randomUUID().toString());
-        account.setAddress(address);
+    /**
+     * Creates a random {@link com.ning.billing.recurly.model.Account} object for testing use given a seed
+     *
+     * @param seed The RNG seed
+     * @return The random {@link com.ning.billing.recurly.model.Account} object
+     */
+    public static Account createRandomAccount(final int seed) {
+        final Account account = new Account();
+
+        account.setAcceptLanguage("en_US");
+        account.setAccountCode(randomAlphaNumericString(10, seed));
+        account.setCompanyName(randomAlphaNumericString(10, seed));
+        account.setEmail(randomAlphaNumericString(4, seed) + "@test.com");
+        account.setFirstName(randomAlphaNumericString(5, seed));
+        account.setLastName(randomAlphaNumericString(6, seed));
+        account.setAddress(createRandomAddress(seed));
 
         return account;
     }
+
+    /**
+     * Creates a random {@link com.ning.billing.recurly.model.Address} object for testing use
+     *
+     * @return The random {@link com.ning.billing.recurly.model.Address} object
+     */
+    public static Address createRandomAddress() {
+        return createRandomAddress(randomSeed());
+    }
+
+    /**
+     * Creates a random {@link com.ning.billing.recurly.model.Address} object for testing use given a seed
+     *
+     * @param seed The RNG seed
+     * @return The random {@link com.ning.billing.recurly.model.Address} object
+     */
+    public static Address createRandomAddress(final int seed) {
+        final Address address = new Address();
+
+        address.setAddress1(randomAlphaNumericString(10, seed));
+        address.setAddress2(randomAlphaNumericString(10, seed));
+        address.setCity(randomAlphaNumericString(10, seed));
+        address.setState(randomAlphaString(2, seed));
+        address.setZip(49302);
+        address.setCountry(randomAlphaString(3, seed));
+        address.setPhone(randomNumericString(10, seed));
+
+        return address;
+    }
+
+    /**
+     * Creates a random {@link com.ning.billing.recurly.model.Adjustment} object for testing use given a seed
+     *
+     * @param seed The RNG seed
+     * @return The random {@link com.ning.billing.recurly.model.Adjustment} object
+     */
+    public static Adjustment createRandomAdjustment(final int seed) {
+        final Adjustment adjustment = new Adjustment();
+
+        adjustment.setAccount(createRandomAccount(seed));
+        adjustment.setUuid(randomAlphaNumericString(20, seed));
+        adjustment.setDescription(randomAlphaNumericString(50, seed));
+        adjustment.setAccountingCode(randomAlphaNumericString(10, seed));
+        adjustment.setOrigin(randomAlphaNumericString(10, seed));
+        adjustment.setUnitAmountInCents(randomInteger(1000, seed));
+        adjustment.setQuantity(1 + randomInteger(10, seed));
+        adjustment.setDiscountInCents(randomInteger(1000, seed));
+        adjustment.setTaxInCents(randomInteger(1000, seed));
+        adjustment.setTotalInCents(randomInteger(1000, seed));
+        adjustment.setCurrency(randomCurrency(seed));
+        adjustment.setTaxable(true);
+        adjustment.setStartDate(NOW);
+        adjustment.setStartDate(TOMORROW);
+        adjustment.setCreatedAt(NOW);
+
+        return adjustment;
+    }
+
 
     /**
      * Creates a random {@link com.ning.billing.recurly.model.BillingInfo} object for testing use.
@@ -133,20 +326,30 @@ public class TestUtils {
      * @return The random {@link com.ning.billing.recurly.model.BillingInfo} object
      */
     public static BillingInfo createRandomBillingInfo() {
+        return createRandomBillingInfo(randomSeed());
+    }
+
+    /**
+     * Creates a random {@link com.ning.billing.recurly.model.BillingInfo} object for testing use given a seed
+     *
+     * @param seed The RNG seed
+     * @return The random {@link com.ning.billing.recurly.model.BillingInfo} object
+     */
+    public static BillingInfo createRandomBillingInfo(final int seed) {
         final BillingInfo info = new BillingInfo();
-        info.setAccount(createRandomAccount());
-        info.setFirstName(getRandomAlphaNumString(5));
-        info.setLastName(getRandomAlphaNumString(6));
-        info.setCompany(getRandomAlphaNumString(10));
-        info.setAddress1(getRandomAlphaNumString(10));
-        info.setAddress2(getRandomAlphaNumString(10));
-        info.setCity(getRandomAlphaNumString(10));
-        info.setState(getRandomAlphaNumString(10));
-        info.setZip(getRandomAlphaNumString(5));
-        info.setCountry(getRandomAlphaNumString(5));
-        info.setPhone(randomInteger(8));
-        info.setVatNumber(getRandomNumString(8));
-        //info.setIpAddress(LifecycleTest.getRandomAlphaNumString(5));
+
+        info.setAccount(createRandomAccount(seed));
+        info.setFirstName(randomAlphaNumericString(5, seed));
+        info.setLastName(randomAlphaNumericString(6, seed));
+        info.setCompany(randomAlphaNumericString(10, seed));
+        info.setAddress1(randomAlphaNumericString(10, seed));
+        info.setAddress2(randomAlphaNumericString(10, seed));
+        info.setCity(randomAlphaNumericString(10, seed));
+        info.setState(randomAlphaNumericString(10, seed));
+        info.setZip(randomAlphaNumericString(5, seed));
+        info.setCountry(randomAlphaNumericString(5, seed));
+        info.setPhone(randomInteger(8, seed));
+        info.setVatNumber(randomNumericString(8, seed));
         info.setYear(createTestCCYear());
         info.setMonth(createTestCCMonth());
         info.setNumber(createTestCCNumber());
@@ -161,13 +364,28 @@ public class TestUtils {
      * @return The random {@link com.ning.billing.recurly.model.Plan} object
      */
     public static Plan createRandomPlan() {
+        return createRandomPlan(randomSeed());
+    }
+
+    /**
+     * Creates a random {@link com.ning.billing.recurly.model.Plan} object for testing use given a seed
+     *
+     * @param seed The RNG seed
+     * @return The random {@link com.ning.billing.recurly.model.Plan} object
+     */
+    public static Plan createRandomPlan(final int seed) {
         final Plan plan = new Plan();
-        plan.setPlanCode(getRandomAlphaNumString(10));
-        plan.setName(getRandomAlphaNumString(10));
-        plan.setPlanIntervalLength(randomInteger(50) + 1);
+
+        plan.setPlanCode(randomAlphaNumericString(10, seed));
+        plan.setName(randomAlphaNumericString(10, seed));
+        plan.setPlanIntervalLength(randomInteger(50, seed) + 1);
         plan.setPlanIntervalUnit("months");
         plan.setSetupFeeInCents(createRandomPrice());
         plan.setUnitAmountInCents(createRandomPrice());
+        plan.setDisplayDonationAmounts(true);
+        plan.setDisplayPhoneNumber(true);
+        plan.setDisplayQuantity(true);
+        plan.setBypassHostedConfirmation(true);
 
         return plan;
     }
@@ -177,6 +395,7 @@ public class TestUtils {
      */
     public static Plan createRandomPlan(final String currencyCode) {
         final Plan plan = createRandomPlan();
+
         plan.setSetupFeeInCents(createRandomSinglePrice(currencyCode));
         plan.setUnitAmountInCents(createRandomSinglePrice(currencyCode));
 
@@ -242,10 +461,55 @@ public class TestUtils {
      *
      * @return The {@link String} code for the randomly chosen currency
      */
-    public static String createRandomCurrency() {
-        final String[] currencies = {"EUR", "GBP", "USD", "SEK"};
-        return currencies[(int) (Math.random() * currencies.length)];
+    public static String randomCurrency() {
+        return randomCurrency(randomSeed());
     }
+
+    /**
+     * Creates a random currency {@link String} given a seed from the set:
+     * <ul>
+     * <li>EUR</li>
+     * <li>GBP</li>
+     * <li>USD</li>
+     * <li>SEK</li>
+     * </ul>
+     *
+     * @param seed The RNG seed
+     * @return The {@link String} code for the randomly chosen currency
+     */
+    public static String randomCurrency(final int seed) {
+        final String[] currencies = {"EUR", "GBP", "USD", "SEK"};
+        return currencies[randomInteger(currencies.length, seed)];
+    }
+
+    /**
+     * Creates a random {@link com.ning.billing.recurly.model.Subscription} object for use in tests given a seed
+     *
+     * @param seed The RNG seed
+     * @return The {@link com.ning.billing.recurly.model.Subscription} object
+     */
+    public static Subscription createRandomSubscription(final int seed) {
+        final Subscription sub = new Subscription();
+        final Plan plan = createRandomPlan(seed);
+
+        sub.setQuantity(randomInteger(10, seed) + 1);
+        sub.setCurrency(randomCurrency(seed));
+        sub.setPlanCode(plan.getPlanCode());
+        sub.setAccount(createRandomAccount(seed));
+        sub.setUnitAmountInCents(randomInteger(10, seed));
+        sub.setCurrency(randomCurrency(seed));
+
+        final SubscriptionAddOns addOns = new SubscriptionAddOns();
+
+        for (int i = 0; i < 5; i++) {
+            addOns.add(createRandomSubscriptionAddOn("code"+i));
+        }
+
+        sub.setAddOns(addOns);
+
+        return sub;
+    }
+
 
     /**
      * Creates a random {@link com.ning.billing.recurly.model.Subscription} object for use in tests
@@ -258,9 +522,10 @@ public class TestUtils {
      */
     public static Subscription createRandomSubscription(final String currencyCode, final Plan plan, final Account account, final Iterable<AddOn> planAddOns) {
         final Subscription sub = new Subscription();
+
         // Make sure the quantity is > 0
         sub.setQuantity(randomInteger(10) + 1);
-        sub.setCurrency(createRandomCurrency());
+        sub.setCurrency(randomCurrency());
         sub.setPlanCode(plan.getPlanCode());
         sub.setAccount(account);
         sub.setUnitAmountInCents(randomInteger(10));
@@ -280,14 +545,26 @@ public class TestUtils {
      * @return The random {@link Transaction} object
      */
     public static Transaction createRandomTransaction() {
+        return createRandomTransaction(randomSeed());
+    }
+
+    /**
+     * Creates a random {@link Transaction} object for use in Tests given a seed
+     *
+     * @param seed The RNG seed
+     * @return The random {@link Transaction} object
+     */
+    public static Transaction createRandomTransaction(final int seed) {
         final Transaction trans = new Transaction();
-        trans.setAccount(createRandomAccount());
-        trans.setAction(getRandomAlphaNumString(5));
-        trans.setAmountInCents(getRandomNumString(100));
-        trans.setTaxInCents(getRandomNumString(100));
-        trans.setCurrency(createRandomCurrency());
-        trans.setStatus(getRandomAlphaNumString(2));
-        trans.setCreatedAt(DateTime.now());
+
+        trans.setAccount(createRandomAccount(seed));
+        trans.setAction(randomAlphaNumericString(5, seed));
+        trans.setAmountInCents(randomInteger(1000, seed));
+        trans.setTaxInCents(randomInteger(10, seed));
+        trans.setDescription(randomAlphaNumericString(50, seed));
+        trans.setCurrency(randomCurrency(seed));
+        trans.setStatus(randomAlphaNumericString(2, seed));
+        trans.setCreatedAt(NOW);
 
         return trans;
     }
@@ -299,11 +576,31 @@ public class TestUtils {
      */
     public static AddOn createRandomAddOn() {
         final AddOn addOn = new AddOn();
-        addOn.setAddOnCode(getRandomAlphaNumString(10));
-        addOn.setName(getRandomAlphaNumString(10));
+
+        addOn.setAddOnCode(randomAlphaNumericString(10));
+        addOn.setName(randomAlphaNumericString(10));
         addOn.setUnitAmountInCents(createRandomPrice());
         addOn.setDefaultQuantity(5);
         addOn.setDisplayQuantityOnHostedPage(false);
+
+        return addOn;
+    }
+
+    /**
+     * Creates a random {@link AddOn} for use in Tests given a seed.
+     *
+     * @param seed The RNG seed
+     * @return The random {@link AddOn}
+     */
+    public static AddOn createRandomAddOn(final int seed) {
+        final AddOn addOn = new AddOn();
+
+        addOn.setAddOnCode(randomAlphaNumericString(10, seed));
+        addOn.setName(randomAlphaNumericString(10, seed));
+        addOn.setUnitAmountInCents(createRandomPrice());
+        addOn.setDefaultQuantity(5);
+        addOn.setDisplayQuantityOnHostedPage(false);
+
         return addOn;
     }
 
@@ -315,9 +612,11 @@ public class TestUtils {
      */
     public static SubscriptionAddOn createRandomSubscriptionAddOn(final String addOnCode) {
         final SubscriptionAddOn addOn = new SubscriptionAddOn();
+
         addOn.setAddOnCode(addOnCode);
         addOn.setUnitAmountInCents(42);
         addOn.setQuantity(5);
+
         return addOn;
     }
 
@@ -330,6 +629,7 @@ public class TestUtils {
      */
     public static AddOn createRandomAddOn(final String currencyCode) {
         final AddOn addOn = createRandomAddOn();
+
         addOn.setUnitAmountInCents(createRandomSinglePrice(currencyCode));
 
         return addOn;
@@ -341,11 +641,101 @@ public class TestUtils {
      * @return The random {@link Coupon} object
      */
     public static Coupon createRandomCoupon() {
+        return createRandomCoupon(randomSeed());
+    }
+
+    /**
+     * Creates a random {@link Coupon} object for use in Tests
+     *
+     * @param seed The RNG seed
+     * @return The random {@link Coupon} object
+     */
+    public static Coupon createRandomCoupon(int seed) {
         final Coupon coupon = new Coupon();
-        coupon.setName(TestUtils.randomString());
-        coupon.setCouponCode(TestUtils.randomString());
+
+        coupon.setName(randomAlphaNumericString(10, seed));
+        coupon.setCouponCode(randomAlphaNumericString(10, seed).toLowerCase());
         coupon.setDiscountType("percent");
-        coupon.setDiscountPercent("10");
+        coupon.setDiscountPercent(randomNumericString(2, seed));
+
         return coupon;
+    }
+
+    /**
+     * Creates a random {@link Invoice} object for use in Tests
+     *
+     * @return The random {@link Invoice} object
+     */
+    public static Invoice createRandomInvoice() {
+        return createRandomInvoice(randomSeed());
+    }
+
+    /**
+     * Creates a random {@link Invoice} object for use in Tests given a seed
+     *
+     * @param seed The RNG seed
+     * @return The random {@link Invoice} object
+     */
+    public static Invoice createRandomInvoice(final int seed) {
+        final Invoice invoice = new Invoice();
+
+        invoice.setAccount(createRandomAccount(seed));
+        invoice.setUuid(randomAlphaNumericString(20, seed));
+        invoice.setState("open");
+        invoice.setInvoiceNumber(randomInteger(10000, seed));
+        invoice.setPoNumber(randomNumericString(5, seed));
+        invoice.setVatNumber(randomAlphaNumericString(5, seed));
+        invoice.setSubtotalInCents(randomInteger(1000, seed));
+        invoice.setTaxInCents(randomInteger(1000, seed));
+        invoice.setTotalInCents(randomInteger(1000, seed));
+        invoice.setCurrency(randomCurrency(seed));
+        invoice.setCreatedAt(NOW);
+        invoice.setCollectionMethod("credit_card");
+        invoice.setNetTerms(randomInteger(100, seed));
+
+        Adjustments adjustments = new Adjustments();
+        for (int i = 0; i < 3; i++) {
+            adjustments.add(createRandomAdjustment(seed + i));
+        }
+        invoice.setLineItems(adjustments);
+
+        Transactions transactions = new Transactions();
+        for (int i = 0; i < 3; i++) {
+            transactions.add(createRandomTransaction(seed + i));
+        }
+        invoice.setTransactions(transactions);
+
+
+        return invoice;
+    }
+
+    /**
+     * Creates a random {@link Redemption} object for use in Tests
+     *
+     * @return The random {@link Redemption} object
+     */
+    public static Redemption createRandomRedemption() {
+        return createRandomRedemption(randomSeed());
+    }
+
+    /**
+     * Creates a random {@link Redemption} object for use in Tests given a seed
+     *
+     * @param seed The RNG seed
+     * @return The random {@link Redemption} object
+     */
+    public static Redemption createRandomRedemption(final int seed) {
+        final Redemption redemption = new Redemption();
+        final Account account = createRandomAccount(seed);
+
+        redemption.setAccount(account);
+        redemption.setAccountCode(account.getAccountCode());
+        redemption.setCoupon(createRandomCoupon(seed));
+        redemption.setSingleUse(true);
+        redemption.setState("redeemed");
+        redemption.setCurrency(randomCurrency(seed));
+        redemption.setTotalDiscountedInCents(randomInteger(1000, seed));
+
+        return redemption;
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestAccount.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccount.java
@@ -17,9 +17,13 @@
 
 package com.ning.billing.recurly.model;
 
+import com.ning.billing.recurly.TestUtils;
 import org.joda.time.DateTime;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 public class TestAccount extends TestModelBase {
 
@@ -63,6 +67,17 @@ public class TestAccount extends TestModelBase {
         verifyAccount(account2);
     }
 
+    @Test(groups = "fast")
+    public void testHashCodeAndEquality() throws Exception {
+        // create accounts of the same value but difference references
+        Account account = TestUtils.createRandomAccount(0);
+        Account otherAccount = TestUtils.createRandomAccount(0);
+
+        assertNotEquals(System.identityHashCode(account), System.identityHashCode(otherAccount));
+        assertEquals(account.hashCode(), otherAccount.hashCode());
+        assertEquals(account, otherAccount);
+    }
+
     private void verifyAccount(final Account account) {
         Assert.assertEquals(account.getAccountCode(), "1");
         Assert.assertEquals(account.getState(), "active");
@@ -81,4 +96,5 @@ public class TestAccount extends TestModelBase {
         Assert.assertEquals(account.getAddress().getCountry(), "US");
         Assert.assertNull(account.getAddress().getPhone());
     }
+
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
@@ -17,9 +17,13 @@
 
 package com.ning.billing.recurly.model;
 
+import com.ning.billing.recurly.TestUtils;
 import org.joda.time.DateTime;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 public class TestAddOns extends TestModelBase {
 
@@ -49,6 +53,17 @@ public class TestAddOns extends TestModelBase {
         final String addOnsSerialized = xmlMapper.writeValueAsString(addOns);
         final AddOns addOns2 = xmlMapper.readValue(addOnsSerialized, AddOns.class);
         verifyAddOns(addOns2);
+    }
+
+    @Test(groups = "fast")
+    public void testHashCodeAndEquality() throws Exception {
+        // create AddOns of the same value but difference references
+        AddOn addOn = TestUtils.createRandomAddOn(0);
+        AddOn otherAddOn = TestUtils.createRandomAddOn(0);
+
+        assertNotEquals(System.identityHashCode(addOn), System.identityHashCode(otherAddOn));
+        assertEquals(addOn.hashCode(), otherAddOn.hashCode());
+        assertEquals(addOn, otherAddOn);
     }
 
     private void verifyAddOns(final AddOns addOns) {

--- a/src/test/java/com/ning/billing/recurly/model/TestAddress.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAddress.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.ning.billing.recurly.TestUtils;
+import org.joda.time.DateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+public class TestAddress extends TestModelBase {
+    
+    @Test(groups = "fast")
+    public void testHashCodeAndEquality() throws Exception {
+        // create addresses of the same value but difference references
+        Address address = TestUtils.createRandomAddress(0);
+        Address otherAddress = TestUtils.createRandomAddress(0);
+
+        assertNotEquals(System.identityHashCode(address), System.identityHashCode(otherAddress));
+        assertEquals(address.hashCode(), otherAddress.hashCode());
+        assertEquals(address, otherAddress);
+    }
+
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestBillingInfo.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestBillingInfo.java
@@ -17,10 +17,13 @@
 
 package com.ning.billing.recurly.model;
 
+import com.ning.billing.recurly.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static com.ning.billing.recurly.TestUtils.randomString;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 public class TestBillingInfo extends TestModelBase {
 
@@ -50,5 +53,16 @@ public class TestBillingInfo extends TestModelBase {
 
         final String xml = xmlMapper.writeValueAsString(billingInfo);
         Assert.assertEquals(xmlMapper.readValue(xml, BillingInfo.class), billingInfo);
+    }
+
+    @Test(groups = "fast")
+    public void testHashCodeAndEquality() throws Exception {
+        // create billing infos of the same value but difference references
+        BillingInfo info = TestUtils.createRandomBillingInfo(0);
+        BillingInfo otherInfo = TestUtils.createRandomBillingInfo(0);
+
+        assertNotEquals(System.identityHashCode(info), System.identityHashCode(otherInfo));
+        assertEquals(info.hashCode(), otherInfo.hashCode());
+        assertEquals(info, otherInfo);
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
@@ -17,10 +17,13 @@
 
 package com.ning.billing.recurly.model;
 
+import com.ning.billing.recurly.TestUtils;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertEqualsNoOrder;
+import static org.testng.Assert.assertNotEquals;
 
 public class TestCoupon extends TestModelBase {
 
@@ -100,5 +103,16 @@ public class TestCoupon extends TestModelBase {
         assertEquals(coupon.getAppliesForMonths(), new Integer(1));
         assertEquals(coupon.getAppliesToAllPlans(), Boolean.TRUE);
         assertEquals(coupon.getMaxRedemptions(), null);
+    }
+
+    @Test(groups = "fast")
+    public void testHashCodeAndEquality() throws Exception {
+        // create coupons of the same value but difference references
+        Coupon coupon = TestUtils.createRandomCoupon(0);
+        Coupon otherCoupon = TestUtils.createRandomCoupon(0);
+
+        assertNotEquals(System.identityHashCode(coupon), System.identityHashCode(otherCoupon));
+        assertEquals(coupon.hashCode(), otherCoupon.hashCode());
+        assertEquals(coupon, otherCoupon);
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
@@ -17,9 +17,13 @@
 
 package com.ning.billing.recurly.model;
 
+import com.ning.billing.recurly.TestUtils;
 import org.joda.time.DateTime;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 public class TestInvoice extends TestModelBase {
 
@@ -84,5 +88,16 @@ public class TestInvoice extends TestModelBase {
         Assert.assertEquals(adjustment.getStartDate(), new DateTime("2011-08-31T03:30:00Z"));
 
         Assert.assertEquals(invoice.getTransactions().size(), 0);
+    }
+
+    @Test(groups = "fast")
+    public void testHashCodeAndEquality() throws Exception {
+        // create invoices of the same value but difference references
+        Invoice invoice = TestUtils.createRandomInvoice(0);
+        Invoice otherInvoice = TestUtils.createRandomInvoice(0);
+
+        assertNotEquals(System.identityHashCode(invoice), System.identityHashCode(otherInvoice));
+        assertEquals(invoice.hashCode(), otherInvoice.hashCode());
+        assertEquals(invoice, otherInvoice);
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestPlan.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPlan.java
@@ -17,9 +17,13 @@
 
 package com.ning.billing.recurly.model;
 
+import com.ning.billing.recurly.TestUtils;
 import org.joda.time.DateTime;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 public class TestPlan extends TestModelBase {
 
@@ -121,5 +125,16 @@ public class TestPlan extends TestModelBase {
         Assert.assertNull(plan.getSuccessLink());
         Assert.assertNull(plan.getCancelLink());
         Assert.assertNull(plan.getAccountingCode());
+    }
+
+    @Test(groups = "fast")
+    public void testHashCodeAndEquality() throws Exception {
+        // create plans of the same value but difference references
+        Plan plan = TestUtils.createRandomPlan(0);
+        Plan otherPlan = TestUtils.createRandomPlan(0);
+
+        assertNotEquals(System.identityHashCode(plan), System.identityHashCode(otherPlan));
+        assertEquals(plan.hashCode(), otherPlan.hashCode());
+        assertEquals(plan, otherPlan);
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestRedemption.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestRedemption.java
@@ -17,9 +17,13 @@
 
 package com.ning.billing.recurly.model;
 
+import com.ning.billing.recurly.TestUtils;
 import org.joda.time.DateTime;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 public class TestRedemption extends TestModelBase {
 
@@ -56,5 +60,16 @@ public class TestRedemption extends TestModelBase {
                 "<account_code>1</account_code>" +
                 "<currency>USD</currency>" +
                 "</redemption>");
+    }
+
+    @Test(groups = "fast")
+    public void testHashCodeAndEquality() throws Exception {
+        // create redemptions of the same value but difference references
+        Redemption redemption = TestUtils.createRandomRedemption(0);
+        Redemption otherRedemption = TestUtils.createRandomRedemption(0);
+
+        assertNotEquals(System.identityHashCode(redemption), System.identityHashCode(otherRedemption));
+        assertEquals(redemption.hashCode(), otherRedemption.hashCode());
+        assertEquals(redemption, otherRedemption);
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -19,9 +19,13 @@ package com.ning.billing.recurly.model;
 
 import java.io.IOException;
 
+import com.ning.billing.recurly.TestUtils;
 import org.joda.time.DateTime;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 public class TestSubscription extends TestModelBase {
 
@@ -127,6 +131,17 @@ public class TestSubscription extends TestModelBase {
         final String subscriptionDataSerialized = xmlMapper.writeValueAsString(subscription);
         final Subscription subscription2 = verifySubscription(subscriptionDataSerialized);
         verifySubscriptionAddons(subscription2);
+    }
+
+    @Test(groups = "fast")
+    public void testHashCodeAndEquality() throws Exception {
+        // create subscriptions of the same value but difference references
+        Subscription subscription = TestUtils.createRandomSubscription(0);
+        Subscription otherSubscription = TestUtils.createRandomSubscription(0);
+
+        assertNotEquals(System.identityHashCode(subscription), System.identityHashCode(otherSubscription));
+        assertEquals(subscription.hashCode(), otherSubscription.hashCode());
+        assertEquals(subscription, otherSubscription);
     }
 
     private void verifySubscriptionAddons(final Subscription subscription) {

--- a/src/test/java/com/ning/billing/recurly/model/TestTransaction.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestTransaction.java
@@ -16,9 +16,13 @@
 
 package com.ning.billing.recurly.model;
 
+import com.ning.billing.recurly.TestUtils;
 import org.joda.time.DateTime;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 public class TestTransaction extends TestModelBase {
 
@@ -106,5 +110,16 @@ public class TestTransaction extends TestModelBase {
         Assert.assertEquals(billingInfo.getCountry(), "US");
         Assert.assertNull(billingInfo.getPhone());
         Assert.assertNull(billingInfo.getVatNumber());
+    }
+
+    @Test(groups = "fast")
+    public void testHashCodeAndEquality() throws Exception {
+        // create transactions of the same value but difference references
+        Transaction transaction = TestUtils.createRandomTransaction(0);
+        Transaction otherTransaction = TestUtils.createRandomTransaction(0);
+
+        assertNotEquals(System.identityHashCode(transaction), System.identityHashCode(otherTransaction));
+        assertEquals(transaction.hashCode(), otherTransaction.hashCode());
+        assertEquals(transaction, otherTransaction);
     }
 }


### PR DESCRIPTION
As discussed here: https://github.com/killbilling/recurly-java-library/pull/101

This is still a work in progress

This code ensures that each model overrides `hashCode()`. It also makes sure not to use super's hashCode implementation because that was including references. We want to do a logical compare and not a reference compare. This code also removes the individual overrides of `equals` in favor of sharing one equals method on the `RecurlyObject` class.

It also adds a test case for each model and some helper methods to deterministically build random model data.

@pierre Let me know if you have any thoughts.