### PR TITLE
Added originial invoice to the invoice object.

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -30,6 +30,9 @@ public class Invoice extends RecurlyObject {
     @XmlElement(name = "account")
     private Account account;
 
+    @XmlElement(name = "original_invoice")
+    private Invoice originalInvoice;
+
     @XmlElement(name = "uuid")
     private String uuid;
 
@@ -79,6 +82,27 @@ public class Invoice extends RecurlyObject {
             account = fetch(account, Account.class);
         }
         return account;
+    }
+
+  /**
+   * Set this original invoice to the passed in original invoice.
+   *
+   * @param originalInvoice original invoice
+   */
+  public void setOriginalInvoice(Invoice originalInvoice) {
+        this.originalInvoice = originalInvoice;
+    }
+
+  /**
+   * Fetches the original invoice if the href is populated, otherwise return the current original invoice.
+   *
+   * @return fully loaded original invoice
+   */
+  public Invoice getOriginalInvoice() {
+        if (originalInvoice != null && originalInvoice.getHref() != null && !originalInvoice.getHref().isEmpty()) {
+            originalInvoice = fetch(originalInvoice, Invoice.class);
+        }
+        return originalInvoice;
     }
 
     public void setAccount(final Account account) {
@@ -201,6 +225,7 @@ public class Invoice extends RecurlyObject {
     public String toString() {
         final StringBuilder sb = new StringBuilder("Invoice{");
         sb.append("account=").append(account);
+        sb.append(", originalInvoice='").append(originalInvoice).append('\'');
         sb.append(", uuid='").append(uuid).append('\'');
         sb.append(", state='").append(state).append('\'');
         sb.append(", invoiceNumber=").append(invoiceNumber);
@@ -227,6 +252,9 @@ public class Invoice extends RecurlyObject {
         final Invoice invoice = (Invoice) o;
 
         if (account != null ? !account.equals(invoice.account) : invoice.account != null) {
+            return false;
+        }
+        if (originalInvoice != null ? !originalInvoice.equals(invoice.originalInvoice) : invoice.originalInvoice != null) {
             return false;
         }
         if (collectionMethod != null ? !collectionMethod.equals(invoice.collectionMethod) : invoice.collectionMethod != null) {
@@ -279,6 +307,7 @@ public class Invoice extends RecurlyObject {
     public int hashCode() {
         return Objects.hashCode(
                 account,
+                originalInvoice,
                 uuid,
                 state,
                 invoiceNumber,

--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -91,7 +91,7 @@ public class Invoice extends RecurlyObject {
    */
   public void setOriginalInvoice(Invoice originalInvoice) {
         this.originalInvoice = originalInvoice;
-    }
+  }
 
   /**
    * Fetches the original invoice if the href is populated, otherwise return the current original invoice.
@@ -103,7 +103,7 @@ public class Invoice extends RecurlyObject {
             originalInvoice = fetch(originalInvoice, Invoice.class);
         }
         return originalInvoice;
-    }
+  }
 
     public void setAccount(final Account account) {
         this.account = account;

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
@@ -33,6 +33,7 @@ public class TestInvoice extends TestModelBase {
         final String invoiceData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                                    + "<invoice href=\"https://api.recurly.com/v2/invoices/e3f0a9e084a2468480d00ee61b090d4d\">\n"
                                    + "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n"
+                                   + "  <original_invoice href=\"https://api.recurly.com/v2/invoices/1192\"/>"
                                    + "  <uuid>421f7b7d414e4c6792938e7c49d552e9</uuid>\n"
                                    + "  <state>open</state>\n"
                                    + "  <invoice_number type=\"integer\">1402</invoice_number>\n"
@@ -69,6 +70,7 @@ public class TestInvoice extends TestModelBase {
         final Invoice invoice = xmlMapper.readValue(invoiceData, Invoice.class);
 
         Assert.assertEquals(invoice.getAccount().getHref(), "https://api.recurly.com/v2/accounts/1");
+        Assert.assertEquals(invoice.getOriginalInvoice().getHref(), "https://api.recurly.com/v2/invoices/1192");
         Assert.assertEquals(invoice.getUuid(), "421f7b7d414e4c6792938e7c49d552e9");
         Assert.assertEquals(invoice.getState(), "open");
         Assert.assertEquals((int) invoice.getInvoiceNumber(), 1402);


### PR DESCRIPTION
The invoice object was missing the original invoice link, this object is populated when you have a refund invoice and the original invoice indicates the invoice for which the refund was applied. This is to fix issue #106 