### PR TITLE
Add TLS property documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 recurly-java-library [![Build Status](https://travis-ci.org/killbilling/recurly-java-library.svg)](https://travis-ci.org/killbilling/recurly-java-library)
 ====================
 
-
 Java library for Recurly, originally developed for [Kill Bill](http://killbill.io), an open-source subscription management and billing system.
 
 Getting started
@@ -35,6 +34,7 @@ Java properties
 * Set `-Drecurly.debug=true` to output debug information in the info log file
 * Set `-Drecurly.page.size=20` to configure the page size for Recurly API calls
 * To run the tests, one can use `-Dkillbill.payment.recurly.currency=EUR` to override the default USD currency used
+* You may optionally pass the TLS protocol used with the setting `-Dkillbill.payment.recurly.tlsProtocol`. Keep in mind that Recurly only supports `TLSv1.1` and above. This setting defaults to `TLSv1.2`.
 
 Push notifications
 ------------------

--- a/src/main/java/com/ning/billing/recurly/util/http/SslUtils.java
+++ b/src/main/java/com/ning/billing/recurly/util/http/SslUtils.java
@@ -24,8 +24,8 @@ import javax.net.ssl.SSLContext;
 
 public class SslUtils {
 
-    private static final String TLS_PROTCOL_KEY = "killbill.payment.recurly.tlsProtocol";
-    private static final String TLS_PROTCOL_DEFAULT = "TLSv1.2";
+    private static final String TLS_PROTOCOL_KEY = "killbill.payment.recurly.tlsProtocol";
+    private static final String TLS_PROTOCOL_DEFAULT = "TLSv1.2";
     private SSLContext context;
 
     private static class SingletonHolder {
@@ -39,7 +39,7 @@ public class SslUtils {
     public SSLContext getSSLContext() throws NoSuchAlgorithmException, KeyManagementException {
         if (context != null) return this.context;
 
-        final String protocol = System.getProperty(TLS_PROTCOL_KEY, TLS_PROTCOL_DEFAULT);
+        final String protocol = System.getProperty(TLS_PROTOCOL_KEY, TLS_PROTOCOL_DEFAULT);
         context = SSLContext.getInstance(protocol);
         context.init(null, null, null);
 


### PR DESCRIPTION
This updates the README to explain how to use the `tlsProtocol` property.

I also needed to fix the spelling on those *_PROTOCOL_* constants.

@pierre What do you think of adding another section in the readme that states we only support Java 7 and above?