### PR TITLE
Add HTTP status to exception

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -1010,12 +1010,13 @@ public class RecurlyClient {
                     }
                     throw new TransactionErrorException(errors);
                 } else {
-                    RecurlyAPIError recurlyError = null;
+                    RecurlyAPIError recurlyError = new RecurlyAPIError();
                     try {
                         recurlyError = xmlMapper.readValue(payload, RecurlyAPIError.class);
                     } catch (Exception e) {
                         log.debug("Unable to extract error", e);
                     }
+                    recurlyError.setHttpStatusCode(response.getStatusCode());
                     throw new RecurlyAPIException(recurlyError);
                 }
             }

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyAPIError.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyAPIError.java
@@ -33,6 +33,8 @@ public class RecurlyAPIError extends RecurlyObject {
     @XmlElement(name = "details")
     private String details;
 
+    private int httpStatusCode;
+
     public String getDescription() {
         return description;
     }
@@ -57,12 +59,19 @@ public class RecurlyAPIError extends RecurlyObject {
         this.details = details;
     }
 
+    public void setHttpStatusCode(final int httpStatusCode) {
+      this.httpStatusCode = httpStatusCode;
+    }
+
+    public int getHttpStatusCode() { return this.httpStatusCode; }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("RecurlyAPIError{");
         sb.append("description='").append(description).append('\'');
         sb.append(", symbol='").append(symbol).append('\'');
         sb.append(", details='").append(details).append('\'');
+        sb.append(", httpStatusCode='").append(httpStatusCode).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -92,7 +101,8 @@ public class RecurlyAPIError extends RecurlyObject {
         return Objects.hashCode(
                 description,
                 symbol,
-                details
+                details,
+                httpStatusCode
         );
     }
 }


### PR DESCRIPTION
Meant to address https://github.com/killbilling/recurly-java-library/issues/116

\cc @steelThread

You should be able to get the response code:

```java
apiException.getRecurlyError().getHttpStatusCode();
```