### PR TITLE
Update to API version 2.2

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -86,7 +86,7 @@ public class RecurlyClient {
 
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
     public static final String RECURLY_PAGE_SIZE_KEY = "recurly.page.size";
-    public static final String RECURLY_API_VERSION = "2.1";
+    public static final String RECURLY_API_VERSION = "2.2";
 
     private static final Integer DEFAULT_PAGE_SIZE = 20;
     private static final String PER_PAGE = "per_page=";

--- a/src/main/java/com/ning/billing/recurly/model/Account.java
+++ b/src/main/java/com/ning/billing/recurly/model/Account.java
@@ -86,6 +86,9 @@ public class Account extends RecurlyObject {
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
     @XmlElement(name = "billing_info")
     private BillingInfo billingInfo;
 
@@ -223,6 +226,14 @@ public class Account extends RecurlyObject {
         this.createdAt = dateTimeOrNull(createdAt);
     }
 
+    public DateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+        this.updatedAt = dateTimeOrNull(updatedAt);
+    }
+
     public BillingInfo getBillingInfo() {
         return billingInfo;
     }
@@ -250,6 +261,7 @@ public class Account extends RecurlyObject {
         sb.append(", acceptLanguage='").append(acceptLanguage).append('\'');
         sb.append(", hostedLoginToken='").append(hostedLoginToken).append('\'');
         sb.append(", createdAt=").append(createdAt);
+        sb.append(", updatedAt=").append(updatedAt);
         sb.append(", billingInfo=").append(billingInfo);
         sb.append('}');
         return sb.toString();
@@ -310,6 +322,9 @@ public class Account extends RecurlyObject {
         if (transactions != null ? !transactions.equals(account.transactions) : account.transactions != null) {
             return false;
         }
+        if (updatedAt != null ? updatedAt.compareTo(account.updatedAt) != 0 : account.updatedAt != null) {
+            return false;
+        }
         if (username != null ? !username.equals(account.username) : account.username != null) {
             return false;
         }
@@ -336,7 +351,8 @@ public class Account extends RecurlyObject {
                 acceptLanguage,
                 hostedLoginToken,
                 createdAt,
-                billingInfo
+                billingInfo,
+                updatedAt
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/AddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/AddOn.java
@@ -45,6 +45,9 @@ public class AddOn extends AbstractAddOn {
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
     public String getName() {
         return name;
     }
@@ -85,6 +88,14 @@ public class AddOn extends AbstractAddOn {
         this.createdAt = dateTimeOrNull(createdAt);
     }
 
+    public DateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+        this.updatedAt = dateTimeOrNull(updatedAt);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("AddOn{");
@@ -93,6 +104,7 @@ public class AddOn extends AbstractAddOn {
         sb.append(", defaultQuantity=").append(defaultQuantity);
         sb.append(", unitAmountInCents=").append(unitAmountInCents);
         sb.append(", createdAt=").append(createdAt);
+        sb.append(", updatedAt=").append(updatedAt);
         sb.append('}');
         return sb.toString();
     }
@@ -105,6 +117,9 @@ public class AddOn extends AbstractAddOn {
         final AddOn addOn = (AddOn) o;
 
         if (createdAt != null ? createdAt.compareTo(addOn.createdAt) != 0 : addOn.createdAt != null) {
+            return false;
+        }
+        if (updatedAt != null ? updatedAt.compareTo(addOn.updatedAt) != 0 : addOn.updatedAt != null) {
             return false;
         }
         if (defaultQuantity != null ? !defaultQuantity.equals(addOn.defaultQuantity) : addOn.defaultQuantity != null) {
@@ -130,7 +145,8 @@ public class AddOn extends AbstractAddOn {
                 displayQuantityOnHostedPage,
                 defaultQuantity,
                 unitAmountInCents,
-                createdAt
+                createdAt,
+                updatedAt
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Adjustment.java
+++ b/src/main/java/com/ning/billing/recurly/model/Adjustment.java
@@ -74,6 +74,9 @@ public class Adjustment extends RecurlyObject {
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
     public Account getAccount() {
         if (account != null && account.getCreatedAt() == null) {
             account = fetch(account, Account.class);
@@ -205,6 +208,14 @@ public class Adjustment extends RecurlyObject {
         this.createdAt = dateTimeOrNull(createdAt);
     }
 
+    public DateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+        this.updatedAt = dateTimeOrNull(updatedAt);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -225,6 +236,7 @@ public class Adjustment extends RecurlyObject {
         sb.append(", startDate=").append(startDate);
         sb.append(", endDate=").append(endDate);
         sb.append(", createdAt=").append(createdAt);
+        sb.append(", updatedAt=").append(updatedAt);
         sb.append('}');
         return sb.toString();
     }
@@ -284,6 +296,9 @@ public class Adjustment extends RecurlyObject {
         if (uuid != null ? !uuid.equals(that.uuid) : that.uuid != null) {
             return false;
         }
+        if (updatedAt != null ? updatedAt.compareTo(that.updatedAt) != 0 : that.updatedAt != null) {
+            return false;
+        }
 
         return true;
     }
@@ -306,7 +321,8 @@ public class Adjustment extends RecurlyObject {
                 taxExempt,
                 startDate,
                 endDate,
-                createdAt
+                createdAt,
+                updatedAt
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Coupon.java
+++ b/src/main/java/com/ning/billing/recurly/model/Coupon.java
@@ -99,6 +99,12 @@ public class Coupon extends RecurlyObject {
     @XmlElement(name = "state")
     private String state;
 
+    @XmlElement(name = "created_at")
+    private DateTime createdAt;
+
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
     public List<String> getPlanCodes() {
         return planCodes;
     }
@@ -110,8 +116,6 @@ public class Coupon extends RecurlyObject {
     @XmlElement( name="plan_code" )
     @XmlElementWrapper( name="plan_codes" )
     private List<String> planCodes;
-
-
 
     public String getState() {
         return state;
@@ -252,6 +256,21 @@ public class Coupon extends RecurlyObject {
         this.freeTrialAmount = integerOrNull(freeTrialAmount);
     }
 
+    public DateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(final Object createdAt) {
+        this.createdAt = dateTimeOrNull(createdAt);
+    }
+
+    public DateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+        this.updatedAt = dateTimeOrNull(updatedAt);
+    }
 
     @Override
     public String toString() {
@@ -261,6 +280,8 @@ public class Coupon extends RecurlyObject {
         sb.append(", couponCode='").append(couponCode).append('\'');
         sb.append(", discountType='").append(discountType).append('\'');
         sb.append(", discountPercent='").append(discountPercent).append('\'');
+        sb.append(", createdAt=").append(createdAt);
+        sb.append(", updatedAt=").append(updatedAt);
         sb.append('}');
         return sb.toString();
     }
@@ -280,6 +301,9 @@ public class Coupon extends RecurlyObject {
             return false;
         }
         if (couponCode != null ? !couponCode.equals(coupon.couponCode) : coupon.couponCode != null) {
+            return false;
+        }
+        if (createdAt != null ? createdAt.compareTo(coupon.createdAt) != 0 : coupon.createdAt != null) {
             return false;
         }
         if (discountInCents != null ? !discountInCents.equals(coupon.discountInCents) : coupon.discountInCents != null) {
@@ -309,6 +333,9 @@ public class Coupon extends RecurlyObject {
         if (freeTrialAmount != null ? !freeTrialAmount.equals(coupon.freeTrialAmount) : coupon.freeTrialAmount != null) {
             return false;
         }
+        if (updatedAt != null ? updatedAt.compareTo(coupon.updatedAt) != 0 : coupon.updatedAt != null) {
+            return false;
+        }
 
         return true;
     }
@@ -327,7 +354,9 @@ public class Coupon extends RecurlyObject {
                 appliesToAllPlans,
                 maxRedemptions,
                 freeTrialUnit,
-                freeTrialAmount
+                freeTrialAmount,
+                createdAt,
+                updatedAt
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -63,6 +63,9 @@ public class Invoice extends RecurlyObject {
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
     @XmlElement(name = "collection_method")
     private String collectionMethod;
 
@@ -189,6 +192,14 @@ public class Invoice extends RecurlyObject {
         this.createdAt = dateTimeOrNull(createdAt);
     }
 
+    public DateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+        this.updatedAt = dateTimeOrNull(updatedAt);
+    }
+
     public String getCollectionMethod() {
         return collectionMethod;
     }
@@ -236,6 +247,7 @@ public class Invoice extends RecurlyObject {
         sb.append(", totalInCents=").append(totalInCents);
         sb.append(", currency='").append(currency).append('\'');
         sb.append(", createdAt=").append(createdAt);
+        sb.append(", updatedAt=").append(updatedAt);
         sb.append(", collectionMethod='").append(collectionMethod).append('\'');
         sb.append(", netTerms=").append(netTerms);
         sb.append(", lineItems=").append(lineItems);
@@ -293,6 +305,9 @@ public class Invoice extends RecurlyObject {
         if (transactions != null ? !transactions.equals(invoice.transactions) : invoice.transactions != null) {
             return false;
         }
+        if (updatedAt != null ? updatedAt.compareTo(invoice.updatedAt) != 0 : invoice.updatedAt != null) {
+            return false;
+        }
         if (uuid != null ? !uuid.equals(invoice.uuid) : invoice.uuid != null) {
             return false;
         }
@@ -318,6 +333,7 @@ public class Invoice extends RecurlyObject {
                 taxInCents,
                 currency,
                 createdAt,
+                updatedAt,
                 collectionMethod,
                 netTerms,
                 lineItems,

--- a/src/main/java/com/ning/billing/recurly/model/Plan.java
+++ b/src/main/java/com/ning/billing/recurly/model/Plan.java
@@ -83,6 +83,9 @@ public class Plan extends RecurlyObject {
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
     @XmlElement(name = "unit_amount_in_cents")
     private RecurlyUnitCurrency unitAmountInCents;
 
@@ -217,6 +220,14 @@ public class Plan extends RecurlyObject {
         this.createdAt = dateTimeOrNull(createdAt);
     }
 
+    public DateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+        this.updatedAt = dateTimeOrNull(updatedAt);
+    }
+
     public RecurlyUnitCurrency getUnitAmountInCents() {
         return unitAmountInCents;
     }
@@ -262,6 +273,7 @@ public class Plan extends RecurlyObject {
         sb.append(", trialIntervalUnit='").append(trialIntervalUnit).append('\'');
         sb.append(", accountingCode='").append(accountingCode).append('\'');
         sb.append(", createdAt=").append(createdAt);
+        sb.append(", updatedAt=").append(updatedAt);
         sb.append(", unitAmountInCents=").append(unitAmountInCents);
         sb.append(", setupFeeInCents=").append(setupFeeInCents);
         sb.append('}');
@@ -332,6 +344,9 @@ public class Plan extends RecurlyObject {
         if (unitName != null ? !unitName.equals(plan.unitName) : plan.unitName != null) {
             return false;
         }
+        if (updatedAt != null ? updatedAt.compareTo(plan.updatedAt) != 0: plan.updatedAt != null) {
+            return false;
+        }
 
         return true;
     }
@@ -356,6 +371,7 @@ public class Plan extends RecurlyObject {
                 trialIntervalLength,
                 accountingCode,
                 createdAt,
+                updatedAt,
                 unitAmountInCents,
                 setupFeeInCents
         );

--- a/src/main/java/com/ning/billing/recurly/model/Redemption.java
+++ b/src/main/java/com/ning/billing/recurly/model/Redemption.java
@@ -64,6 +64,9 @@ public class Redemption extends RecurlyObject {
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
     public String getAccountCode() {
         return accountCode;
     }
@@ -142,6 +145,14 @@ public class Redemption extends RecurlyObject {
         this.createdAt = dateTimeOrNull(createdAt);
     }
 
+    public DateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+        this.updatedAt = dateTimeOrNull(updatedAt);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -155,6 +166,7 @@ public class Redemption extends RecurlyObject {
         sb.append(", currency='").append(currency).append('\'');
         sb.append(", state='").append(state).append('\'');
         sb.append(", createdAt=").append(createdAt);
+        sb.append(", updatedAt=").append(updatedAt);
         sb.append('}');
         return sb.toString();
     }
@@ -191,6 +203,9 @@ public class Redemption extends RecurlyObject {
         if (createdAt != null ? createdAt.compareTo(that.createdAt) != 0 : that.createdAt != null) {
             return false;
         }
+        if (updatedAt != null ? updatedAt.compareTo(that.updatedAt) != 0 : that.updatedAt != null) {
+            return false;
+        }
         if (uuid != null ? !uuid.equals(that.uuid) : that.uuid != null) {
             return false;
         }
@@ -209,7 +224,8 @@ public class Redemption extends RecurlyObject {
                 currency,
                 state,
                 uuid,
-                createdAt
+                createdAt,
+                updatedAt
         );
     }
 

--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -72,6 +72,9 @@ public class Subscription extends AbstractSubscription {
     @XmlElement(name = "starts_at")
     private DateTime startsAt;
 
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
     @XmlElement(name = "collection_method")
     private String collectionMethod;
 
@@ -275,6 +278,13 @@ public class Subscription extends AbstractSubscription {
         this.bulk = booleanOrNull(bulk);
     }
 
+    public DateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+        this.updatedAt = dateTimeOrNull(updatedAt);
+    }
 
     @Override
     public String toString() {
@@ -288,6 +298,7 @@ public class Subscription extends AbstractSubscription {
         sb.append(", currency='").append(currency).append('\'');
         sb.append(", quantity=").append(quantity);
         sb.append(", activatedAt=").append(activatedAt);
+        sb.append(", updatedAt=").append(updatedAt);
         sb.append(", canceledAt=").append(canceledAt);
         sb.append(", expiresAt=").append(expiresAt);
         sb.append(", currentPeriodStartedAt=").append(currentPeriodStartedAt);
@@ -323,6 +334,9 @@ public class Subscription extends AbstractSubscription {
             return false;
         }
         if (currency != null ? !currency.equals(that.currency) : that.currency != null) {
+            return false;
+        }
+        if (updatedAt != null ? updatedAt.compareTo(that.updatedAt) != 0 : that.updatedAt != null) {
             return false;
         }
         if (currentPeriodEndsAt != null ? currentPeriodEndsAt.compareTo(that.currentPeriodEndsAt) != 0 : that.currentPeriodEndsAt != null) {
@@ -373,7 +387,6 @@ public class Subscription extends AbstractSubscription {
         if (firstRenewalDate != null ? firstRenewalDate.compareTo(that.firstRenewalDate) != 0 : that.firstRenewalDate != null) {
             return false;
         }
-
         if (bulk != null ? !bulk.equals(that.bulk) : that.bulk != null) {
             return false;
         }
@@ -392,6 +405,7 @@ public class Subscription extends AbstractSubscription {
                 currency,
                 quantity,
                 activatedAt,
+                updatedAt,
                 canceledAt,
                 expiresAt,
                 currentPeriodStartedAt,
@@ -404,7 +418,6 @@ public class Subscription extends AbstractSubscription {
                 collectionMethod,
                 netTerms,
                 poNumber
-
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Transaction.java
+++ b/src/main/java/com/ning/billing/recurly/model/Transaction.java
@@ -54,6 +54,9 @@ public class Transaction extends AbstractTransaction {
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
     @XmlElement(name = "details")
     private TransactionDetails details;
 
@@ -141,6 +144,14 @@ public class Transaction extends AbstractTransaction {
         this.createdAt = dateTimeOrNull(createdAt);
     }
 
+    public DateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+        this.updatedAt = dateTimeOrNull(updatedAt);
+    }
+
     public TransactionDetails getDetails() {
         return details;
     }
@@ -181,6 +192,7 @@ public class Transaction extends AbstractTransaction {
         sb.append(", details=").append(details);
         sb.append(", paymentMethod=").append(paymentMethod);
         sb.append(", collectedAt=").append(collectedAt);
+        sb.append(", updatedAt=").append(updatedAt);
         sb.append('}');
         return sb.toString();
     }
@@ -222,6 +234,9 @@ public class Transaction extends AbstractTransaction {
         if (uuid != null ? !uuid.equals(that.uuid) : that.uuid != null) {
             return false;
         }
+        if (updatedAt != null ? updatedAt.compareTo(that.updatedAt) != 0 : that.updatedAt != null) {
+            return false;
+        }
         if (paymentMethod != null ? !paymentMethod.equals(that.paymentMethod) : that.paymentMethod != null) {
             return false;
         }
@@ -244,6 +259,7 @@ public class Transaction extends AbstractTransaction {
                 description,
                 recurring,
                 createdAt,
+                updatedAt,
                 details
         );
     }

--- a/src/test/java/com/ning/billing/recurly/model/TestAccount.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccount.java
@@ -46,6 +46,7 @@ public class TestAccount extends TestModelBase {
                                    "  <accept_language nil=\"nil\"></accept_language>\n" +
                                    "  <hosted_login_token>a92468579e9c4231a6c0031c4716c01d</hosted_login_token>\n" +
                                    "  <created_at type=\"datetime\">2011-10-25T12:00:00</created_at>\n" +
+                                   "  <updated_at type=\"datetime\">2011-10-25T12:00:00</updated_at>\n" +
                                    "  <address>\n" +
                                    "      <address1>123 Main St.</address1>\n" +
                                    "      <address2 nil=\"nil\"></address2>\n" +
@@ -88,6 +89,7 @@ public class TestAccount extends TestModelBase {
         Assert.assertNull(account.getAcceptLanguage());
         Assert.assertEquals(account.getHostedLoginToken(), "a92468579e9c4231a6c0031c4716c01d");
         Assert.assertEquals(account.getCreatedAt(), new DateTime("2011-10-25T12:00:00"));
+        Assert.assertEquals(account.getUpdatedAt(), new DateTime("2011-10-25T12:00:00"));
         Assert.assertEquals(account.getAddress().getAddress1(), "123 Main St.");
         Assert.assertNull(account.getAddress().getAddress2());
         Assert.assertEquals(account.getAddress().getCity(), "San Francisco");

--- a/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
@@ -42,6 +42,7 @@ public class TestAddOns extends TestModelBase {
                                   "      <USD>200</USD>\n" +
                                   "    </unit_amount_in_cents>\n" +
                                   "    <created_at type=\"datetime\">2011-06-28T12:34:56Z</created_at>\n" +
+                                  "    <updated_at type=\"datetime\">2011-06-28T12:34:56Z</updated_at>\n" +
                                   "  </add_on>\n" +
                                   "  <!-- Continued... -->\n" +
                                   "</add_ons>";
@@ -76,5 +77,6 @@ public class TestAddOns extends TestModelBase {
         Assert.assertEquals((int) addOn.getDefaultQuantity(), 1);
         Assert.assertEquals((int) addOn.getUnitAmountInCents().getUnitAmountUSD(), 200);
         Assert.assertEquals(addOn.getCreatedAt(), new DateTime("2011-06-28T12:34:56Z"));
+        Assert.assertEquals(addOn.getUpdatedAt(), new DateTime("2011-06-28T12:34:56Z"));
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestAdjustements.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAdjustements.java
@@ -45,6 +45,7 @@ public class TestAdjustements extends TestModelBase {
                                        "    <start_date type=\"datetime\">2011-08-31T03:30:00Z</start_date>\n" +
                                        "    <end_date nil=\"nil\"></end_date>\n" +
                                        "    <created_at type=\"datetime\">2011-08-31T03:30:00Z</created_at>\n" +
+                                       "    <updated_at type=\"datetime\">2011-08-31T03:30:00Z</updated_at>\n" +
                                        "  </adjustment>\n" +
                                        "  <!-- Continued... -->\n" +
                                        "</adjustments>";
@@ -69,5 +70,6 @@ public class TestAdjustements extends TestModelBase {
         Assert.assertEquals(adjustment.getStartDate(), new DateTime("2011-08-31T03:30:00Z"));
         Assert.assertNull(adjustment.getEndDate());
         Assert.assertEquals(adjustment.getCreatedAt(), new DateTime("2011-08-31T03:30:00Z"));
+        Assert.assertEquals(adjustment.getUpdatedAt(), new DateTime("2011-08-31T03:30:00Z"));
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
@@ -46,6 +46,7 @@ public class TestCoupon extends TestModelBase {
                 "  <max_redemptions nil=\"nil\"></max_redemptions>\n" +
                 "  <applies_to_all_plans type=\"boolean\">true</applies_to_all_plans>\n" +
                 "  <created_at type=\"datetime\">2013-05-08T10:21:52Z</created_at>\n" +
+                "  <updated_at type=\"datetime\">2013-05-08T10:21:52Z</updated_at>\n" +
                 "  <plan_codes type=\"array\">\n" +
                 "  </plan_codes>\n" +
                 "  <a name=\"redeem\" href=\"https://api.recurly.com/v2/coupons/f8028/redeem\" method=\"post\"/>\n" +
@@ -64,6 +65,8 @@ public class TestCoupon extends TestModelBase {
         assertEquals(coupon.getAppliesForMonths(), new Integer(1));
         assertEquals(coupon.getAppliesToAllPlans(), Boolean.TRUE);
         assertEquals(coupon.getMaxRedemptions(), null);
+        assertEquals(coupon.getCreatedAt(), new DateTime("2013-05-08T10:21:52Z"));
+        assertEquals(coupon.getUpdatedAt(), new DateTime("2013-05-08T10:21:52Z"));
     }
 
     @Test(groups = "fast", description = "https://github.com/killbilling/recurly-java-library/issues/57")
@@ -86,6 +89,7 @@ public class TestCoupon extends TestModelBase {
                 "  <max_redemptions nil=\"nil\"></max_redemptions>\n" +
                 "  <applies_to_all_plans type=\"boolean\">true</applies_to_all_plans>\n" +
                 "  <created_at type=\"datetime\">2013-05-08T10:21:52Z</created_at>\n" +
+                "  <updated_at type=\"datetime\">2013-05-08T10:21:52Z</updated_at>\n" +
                 "  <plan_codes type=\"array\">\n" +
                 "  </plan_codes>\n" +
                 "  <a name=\"redeem\" href=\"https://api.recurly.com/v2/coupons/f8028/redeem\" method=\"post\"/>\n" +
@@ -104,6 +108,8 @@ public class TestCoupon extends TestModelBase {
         assertEquals(coupon.getAppliesForMonths(), new Integer(1));
         assertEquals(coupon.getAppliesToAllPlans(), Boolean.TRUE);
         assertEquals(coupon.getMaxRedemptions(), null);
+        assertEquals(coupon.getCreatedAt(), new DateTime("2013-05-08T10:21:52Z"));
+        assertEquals(coupon.getUpdatedAt(), new DateTime("2013-05-08T10:21:52Z"));
     }
 
 
@@ -125,6 +131,7 @@ public class TestCoupon extends TestModelBase {
                         "  <max_redemptions nil=\"nil\"></max_redemptions>\n" +
                         "  <applies_to_all_plans type=\"boolean\">false</applies_to_all_plans>\n" +
                         "  <created_at type=\"datetime\">2013-05-08T10:21:52Z</created_at>\n" +
+                        "  <updated_at type=\"datetime\">2013-05-08T10:21:52Z</updated_at>\n" +
                         "  <plan_codes type=\"array\">\n" +
                         "  <plan_code>silver</plan_code>\n" +
                         "  <plan_code>gold</plan_code>\n" +
@@ -144,6 +151,8 @@ public class TestCoupon extends TestModelBase {
         assertTrue(coupon.getPlanCodes().contains("silver"));
         assertTrue(coupon.getPlanCodes().contains("gold"));
         assertEquals(coupon.getMaxRedemptions(), null);
+        assertEquals(coupon.getCreatedAt(), new DateTime("2013-05-08T10:21:52Z"));
+        assertEquals(coupon.getUpdatedAt(), new DateTime("2013-05-08T10:21:52Z"));
     }
 
     @Test(groups = "fast")

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
@@ -44,6 +44,7 @@ public class TestInvoice extends TestModelBase {
                                    + "  <total_in_cents type=\"integer\">9900</total_in_cents>\n"
                                    + "  <currency>USD</currency>\n"
                                    + "  <created_at type=\"datetime\">2011-08-25T12:00:00Z</created_at>\n"
+                                   + "  <updated_at type=\"datetime\">2011-08-25T12:00:00Z</updated_at>\n"
                                    + "  <line_items type=\"array\">\n"
                                    + "    <adjustment type=\"credit\" href=\"https://api.recurly.com/v2/adjustments/626db120a84102b1809909071c701c60\">\n"
                                    + "      <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n"
@@ -81,6 +82,7 @@ public class TestInvoice extends TestModelBase {
         Assert.assertEquals((int) invoice.getTotalInCents(), 9900);
         Assert.assertEquals(invoice.getCurrency(), "USD");
         Assert.assertEquals(invoice.getCreatedAt(), new DateTime("2011-08-25T12:00:00Z"));
+        Assert.assertEquals(invoice.getUpdatedAt(), new DateTime("2011-08-25T12:00:00Z"));
         Assert.assertNotNull(invoice.getLineItems());
         Assert.assertEquals(invoice.getLineItems().size(), 1);
 

--- a/src/test/java/com/ning/billing/recurly/model/TestPlan.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPlan.java
@@ -50,6 +50,7 @@ public class TestPlan extends TestModelBase {
                                 "  <trial_interval_unit>days</trial_interval_unit>\n" +
                                 "  <accounting_code nil=\"nil\"></accounting_code>\n" +
                                 "  <created_at type=\"datetime\">2011-04-19T07:00:00Z</created_at>\n" +
+                                "  <updated_at type=\"datetime\">2011-04-19T07:00:00Z</updated_at>\n" +
                                 "  <unit_amount_in_cents>\n" +
                                 "    <USD type=\"integer\">1000</USD>\n" +
                                 "    <EUR type=\"integer\">800</EUR>\n" +
@@ -70,6 +71,7 @@ public class TestPlan extends TestModelBase {
         Assert.assertFalse(plan.getDisplayDonationAmounts());
         Assert.assertFalse(plan.getDisplayQuantity());
         Assert.assertEquals(plan.getCreatedAt(), new DateTime("2011-04-19T07:00:00Z"));
+        Assert.assertEquals(plan.getUpdatedAt(), new DateTime("2011-04-19T07:00:00Z"));
         Assert.assertEquals(plan.getUnitAmountInCents().getUnitAmountUSD(), new Integer(1000));
         Assert.assertEquals(plan.getUnitAmountInCents().getUnitAmountEUR(), new Integer(800));
         Assert.assertEquals(plan.getSetupFeeInCents().getUnitAmountUSD(), new Integer(6000));
@@ -103,6 +105,7 @@ public class TestPlan extends TestModelBase {
                                 "  <trial_interval_unit>days</trial_interval_unit>\n" +
                                 "  <accounting_code nil=\"nil\"></accounting_code>\n" +
                                 "  <created_at type=\"datetime\">2011-04-19T07:00:00Z</created_at>\n" +
+                                "  <updated_at type=\"datetime\">2011-04-19T07:00:00Z</updated_at>\n" +
                                 "  <unit_amount_in_cents>\n" +
                                 "  </unit_amount_in_cents>\n" +
                                 "  <setup_fee_in_cents>\n" +
@@ -119,6 +122,7 @@ public class TestPlan extends TestModelBase {
         Assert.assertFalse(plan.getDisplayDonationAmounts());
         Assert.assertFalse(plan.getDisplayQuantity());
         Assert.assertEquals(plan.getCreatedAt(), new DateTime("2011-04-19T07:00:00Z"));
+        Assert.assertEquals(plan.getUpdatedAt(), new DateTime("2011-04-19T07:00:00Z"));
         Assert.assertNull(plan.getUnitAmountInCents().getUnitAmountUSD());
         Assert.assertNull(plan.getSetupFeeInCents().getUnitAmountUSD());
         Assert.assertNull(plan.getDescription());

--- a/src/test/java/com/ning/billing/recurly/model/TestRedemptions.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestRedemptions.java
@@ -38,6 +38,7 @@ public class TestRedemptions extends TestModelBase {
                 "    <currency>USD</currency>\n" +
                 "    <state>active</state>\n" +
                 "    <created_at type=\"datetime\">2015-09-23T17:13:30Z</created_at>\n" +
+                "    <updated_at type=\"datetime\">2015-09-23T17:13:30Z</updated_at>\n" +
                 "  </redemption>\n" +
                 "  <redemption href=\"https://your-subdomain.recurly.com/v2/accounts/1/redemptions/3169fd6127ff82ccbfa08a442188d575\">\n" +
                 "    <coupon href=\"https://your-subdomain.recurly.com/v2/coupons/special\"/>\n" +
@@ -48,6 +49,7 @@ public class TestRedemptions extends TestModelBase {
                 "    <currency>USD</currency>\n" +
                 "    <state>active</state>\n" +
                 "    <created_at type=\"datetime\">2011-06-27T12:34:56Z</created_at>\n" +
+                "    <updated_at type=\"datetime\">2011-06-27T12:34:56Z</updated_at>\n" +
                 "  </redemption>\n" +
                 "</redemptions>";
 
@@ -61,5 +63,6 @@ public class TestRedemptions extends TestModelBase {
         Assert.assertEquals(redemption.getState(), "active");
         Assert.assertEquals(redemption.getCurrency(), "USD");
         Assert.assertEquals(redemption.getCreatedAt(), new DateTime("2015-09-23T17:13:30Z"));
+        Assert.assertEquals(redemption.getUpdatedAt(), new DateTime("2015-09-23T17:13:30Z"));
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -45,6 +45,7 @@ public class TestSubscription extends TestModelBase {
                                         "  <currency>EUR</currency>\n" +
                                         "  <quantity type=\"integer\">1</quantity>\n" +
                                         "  <activated_at type=\"datetime\">2011-05-27T07:00:00Z</activated_at>\n" +
+                                        "  <updated_at type=\"datetime\">2011-05-27T07:00:00Z</updated_at>\n" +
                                         "  <canceled_at nil=\"nil\"></canceled_at>\n" +
                                         "  <expires_at nil=\"nil\"></expires_at>\n" +
                                         "  <current_period_started_at type=\"datetime\">2011-06-27T07:00:00Z</current_period_started_at>\n" +
@@ -95,6 +96,7 @@ public class TestSubscription extends TestModelBase {
                                         "  <currency>EUR</currency>\n" +
                                         "  <quantity type=\"integer\">1</quantity>\n" +
                                         "  <activated_at type=\"datetime\">2011-05-27T07:00:00Z</activated_at>\n" +
+                                        "  <updated_at type=\"datetime\">2011-05-27T07:00:00Z</updated_at>\n" +
                                         "  <canceled_at nil=\"nil\"></canceled_at>\n" +
                                         "  <expires_at nil=\"nil\"></expires_at>\n" +
                                         "  <current_period_started_at type=\"datetime\">2011-06-27T07:00:00Z</current_period_started_at>\n" +
@@ -162,6 +164,7 @@ public class TestSubscription extends TestModelBase {
         Assert.assertEquals(subscription.getCurrency(), "EUR");
         Assert.assertEquals(subscription.getQuantity(), (Integer) 1);
         Assert.assertEquals(subscription.getActivatedAt(), new DateTime("2011-05-27T07:00:00Z"));
+        Assert.assertEquals(subscription.getUpdatedAt(), new DateTime("2011-05-27T07:00:00Z"));
         Assert.assertNull(subscription.getCanceledAt(), "");
         Assert.assertNull(subscription.getExpiresAt(), "");
         Assert.assertEquals(subscription.getCurrentPeriodStartedAt(), new DateTime("2011-06-27T07:00:00Z"));

--- a/src/test/java/com/ning/billing/recurly/model/TestTransaction.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestTransaction.java
@@ -52,6 +52,7 @@ public class TestTransaction extends TestModelBase {
                                        "  <avs_result_street nil=\"nil\"></avs_result_street>" +
                                        "  <avs_result_postal nil=\"nil\"></avs_result_postal>" +
                                        "  <created_at type=\"datetime\">2015-06-19T03:01:33Z</created_at>\n" +
+                                       "  <updated_at type=\"datetime\">2015-06-19T03:01:33Z</updated_at>\n" +
                                        "  <details>\n" +
                                        "    <account>\n" +
                                        "      <account_code>1</account_code>\n" +
@@ -92,6 +93,7 @@ public class TestTransaction extends TestModelBase {
         Assert.assertNull(transaction.getAvsResultStreet());
         Assert.assertNull(transaction.getCvvResult());
         Assert.assertEquals(transaction.getCreatedAt(), new DateTime("2015-06-19T03:01:33Z"));
+        Assert.assertEquals(transaction.getUpdatedAt(), new DateTime("2015-06-19T03:01:33Z"));
 
         final Account account = transaction.getDetails().getAccount();
         Assert.assertEquals(account.getAccountCode(), "1");


### PR DESCRIPTION
This updates the HTTP API to version 2.2.

This brings the `updated_at` field and some other features which I can add in a piecemeal fashion later. This should be the minimum required to get some new features into this library.