### PR TITLE
Update to API version 2.3

### DIFF
--- a/src/main/java/com/ning/billing/recurly/PaginationUtils.java
+++ b/src/main/java/com/ning/billing/recurly/PaginationUtils.java
@@ -24,7 +24,6 @@ public abstract class PaginationUtils {
 
     public static String[] getLinks(final String linkHeader) {
         String start = null;
-        String prev = null;
         String next = null;
 
         final Pattern pattern = Pattern.compile("\\<([^>]+)\\>; rel=\\\"([^\"]+)\\\"");
@@ -32,13 +31,11 @@ public abstract class PaginationUtils {
         while (matcher.find()) {
             if ("start".equals(matcher.group(2))) {
                 start = matcher.group(1);
-            } else if ("prev".equals(matcher.group(2))) {
-                prev = matcher.group(1);
             } else if ("next".equals(matcher.group(2))) {
                 next = matcher.group(1);
             }
         }
 
-        return new String[]{start, prev, next};
+        return new String[]{start, next};
     }
 }

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -37,6 +37,7 @@ import javax.annotation.Nullable;
 import javax.xml.bind.DatatypeConverter;
 
 import com.ning.billing.recurly.model.Account;
+import com.ning.billing.recurly.model.AccountBalance;
 import com.ning.billing.recurly.model.Accounts;
 import com.ning.billing.recurly.model.AddOn;
 import com.ning.billing.recurly.model.AddOns;
@@ -86,7 +87,7 @@ public class RecurlyClient {
 
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
     public static final String RECURLY_PAGE_SIZE_KEY = "recurly.page.size";
-    public static final String RECURLY_API_VERSION = "2.2";
+    public static final String RECURLY_API_VERSION = "2.3";
 
     private static final Integer DEFAULT_PAGE_SIZE = 20;
     private static final String PER_PAGE = "per_page=";
@@ -217,6 +218,18 @@ public class RecurlyClient {
      */
     public Account updateAccount(final String accountCode, final Account account) {
         return doPUT(Account.ACCOUNT_RESOURCE + "/" + accountCode, account, Account.class);
+    }
+
+    /**
+     * Get Account Balance
+     * <p>
+     * Retrieves the remaining balance on the account
+     *
+     * @param accountCode recurly account id
+     * @return the updated AccountBalance if success, null otherwise
+     */
+    public AccountBalance getAccountBalance(final String accountCode) {
+        return doGET(Account.ACCOUNT_RESOURCE + "/" + accountCode + "/" + AccountBalance.ACCOUNT_BALANCE_RESOURCE, AccountBalance.class);
     }
 
     /**
@@ -1048,8 +1061,7 @@ public class RecurlyClient {
                 if (linkHeader != null) {
                     final String[] links = PaginationUtils.getLinks(linkHeader);
                     recurlyObjects.setStartUrl(links[0]);
-                    recurlyObjects.setPrevUrl(links[1]);
-                    recurlyObjects.setNextUrl(links[2]);
+                    recurlyObjects.setNextUrl(links[1]);
                 }
             }
             return obj;

--- a/src/main/java/com/ning/billing/recurly/model/AccountBalance.java
+++ b/src/main/java/com/ning/billing/recurly/model/AccountBalance.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.google.common.base.Objects;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+import com.google.common.primitives.Booleans;
+import org.joda.time.DateTime;
+
+@XmlRootElement(name = "account_balance")
+public class AccountBalance extends RecurlyObject {
+
+    @XmlTransient
+    public static final String ACCOUNT_BALANCE_RESOURCE = "/balance";
+
+    @XmlElement(name = "past_due")
+    private Boolean pastDue;
+
+    @XmlElement(name = "balance_in_cents")
+    private RecurlyUnitCurrency balanceInCents;
+
+    public Boolean getPastDue() {
+        return pastDue;
+    }
+
+    public void setPastDue(final Object pastDue) { this.pastDue = booleanOrNull(pastDue); }
+
+    public RecurlyUnitCurrency getBalanceInCents() {
+        return balanceInCents;
+    }
+
+    public void setBalanceInCents(final RecurlyUnitCurrency balanceInCents) { this.balanceInCents = balanceInCents; }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("AccountBalance{");
+        sb.append(", pastDue=").append(pastDue);
+        sb.append(", balanceInCents=").append(balanceInCents);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final AccountBalance accountBalance = (AccountBalance) o;
+
+        if (pastDue != null ? !pastDue.equals(accountBalance.pastDue) : accountBalance.pastDue != null) {
+            return false;
+        }
+        if (balanceInCents != null ? !balanceInCents.equals(accountBalance.balanceInCents) : accountBalance.balanceInCents != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(
+                pastDue,
+                balanceInCents
+        );
+    }
+
+
+}

--- a/src/main/java/com/ning/billing/recurly/model/Accounts.java
+++ b/src/main/java/com/ning/billing/recurly/model/Accounts.java
@@ -44,11 +44,6 @@ public class Accounts extends RecurlyObjects<Account> {
     }
 
     @JsonIgnore
-    public Accounts getPrev() {
-        return getPrev(Accounts.class);
-    }
-
-    @JsonIgnore
     public Accounts getNext() {
         return getNext(Accounts.class);
     }

--- a/src/main/java/com/ning/billing/recurly/model/AddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/AddOn.java
@@ -42,6 +42,9 @@ public class AddOn extends AbstractAddOn {
     @XmlElement(name = "unit_amount_in_cents")
     private RecurlyUnitCurrency unitAmountInCents;
 
+    @XmlElement(name = "revenue_schedule_type")
+    private RevenueScheduleType revenueScheduleType;
+
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
@@ -70,6 +73,14 @@ public class AddOn extends AbstractAddOn {
 
     public void setDefaultQuantity(final Object defaultQuantity) {
         this.defaultQuantity = integerOrNull(defaultQuantity);
+    }
+
+    public RevenueScheduleType getRevenueScheduleType() {
+        return revenueScheduleType;
+    }
+
+    public void setRevenueScheduleType(final String revenueScheduleType) {
+        this.revenueScheduleType = RevenueScheduleType.valueOf(revenueScheduleType.toUpperCase());
     }
 
     public RecurlyUnitCurrency getUnitAmountInCents() {
@@ -103,6 +114,7 @@ public class AddOn extends AbstractAddOn {
         sb.append(", displayQuantityOnHostedPage=").append(displayQuantityOnHostedPage);
         sb.append(", defaultQuantity=").append(defaultQuantity);
         sb.append(", unitAmountInCents=").append(unitAmountInCents);
+        sb.append(", revenueScheduleType=").append(revenueScheduleType);
         sb.append(", createdAt=").append(createdAt);
         sb.append(", updatedAt=").append(updatedAt);
         sb.append('}');
@@ -128,6 +140,9 @@ public class AddOn extends AbstractAddOn {
         if (displayQuantityOnHostedPage != null ? !displayQuantityOnHostedPage.equals(addOn.displayQuantityOnHostedPage) : addOn.displayQuantityOnHostedPage != null) {
             return false;
         }
+        if (revenueScheduleType != null ? !revenueScheduleType.equals(addOn.revenueScheduleType) : addOn.revenueScheduleType != null) {
+            return false;
+        }
         if (name != null ? !name.equals(addOn.name) : addOn.name != null) {
             return false;
         }
@@ -145,6 +160,7 @@ public class AddOn extends AbstractAddOn {
                 displayQuantityOnHostedPage,
                 defaultQuantity,
                 unitAmountInCents,
+                revenueScheduleType,
                 createdAt,
                 updatedAt
         );

--- a/src/main/java/com/ning/billing/recurly/model/AddOns.java
+++ b/src/main/java/com/ning/billing/recurly/model/AddOns.java
@@ -44,11 +44,6 @@ public class AddOns extends RecurlyObjects<AddOn> {
     }
 
     @JsonIgnore
-    public AddOns getPrev() {
-        return getPrev(AddOns.class);
-    }
-
-    @JsonIgnore
     public AddOns getNext() {
         return getNext(AddOns.class);
     }

--- a/src/main/java/com/ning/billing/recurly/model/Adjustments.java
+++ b/src/main/java/com/ning/billing/recurly/model/Adjustments.java
@@ -74,11 +74,6 @@ public class Adjustments extends RecurlyObjects<Adjustment> {
     }
 
     @JsonIgnore
-    public Adjustments getPrev() {
-        return getPrev(Adjustments.class);
-    }
-
-    @JsonIgnore
     public Adjustments getNext() {
         return getNext(Adjustments.class);
     }

--- a/src/main/java/com/ning/billing/recurly/model/Coupons.java
+++ b/src/main/java/com/ning/billing/recurly/model/Coupons.java
@@ -44,11 +44,6 @@ public class Coupons extends RecurlyObjects<Coupon> {
     }
 
     @JsonIgnore
-    public Coupons getPrev() {
-        return getPrev(Coupons.class);
-    }
-
-    @JsonIgnore
     public Coupons getNext() {
         return getNext(Coupons.class);
     }

--- a/src/main/java/com/ning/billing/recurly/model/Invoices.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoices.java
@@ -44,11 +44,6 @@ public class Invoices extends RecurlyObjects<Invoice> {
     }
 
     @JsonIgnore
-    public Invoices getPrev() {
-        return getPrev(Invoices.class);
-    }
-
-    @JsonIgnore
     public Invoices getNext() {
         return getNext(Invoices.class);
     }

--- a/src/main/java/com/ning/billing/recurly/model/Plan.java
+++ b/src/main/java/com/ning/billing/recurly/model/Plan.java
@@ -80,6 +80,12 @@ public class Plan extends RecurlyObject {
     @XmlElement(name = "accounting_code")
     private String accountingCode;
 
+    @XmlElement(name = "revenue_schedule_type")
+    private RevenueScheduleType revenueScheduleType;
+
+    @XmlElement(name = "setup_fee_revenue_schedule_type")
+    private RevenueScheduleType setupFeeRevenueScheduleType;
+
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
@@ -252,6 +258,22 @@ public class Plan extends RecurlyObject {
         this.addOns = addOns;
     }
 
+    public RevenueScheduleType getSetupFeeRevenueScheduleType() {
+        return setupFeeRevenueScheduleType;
+    }
+
+    public void setSetupFeeRevenueScheduleType(final String setupFeeRevenueScheduleType) {
+        this.setupFeeRevenueScheduleType = RevenueScheduleType.valueOf(setupFeeRevenueScheduleType.toUpperCase());
+    }
+
+    public RevenueScheduleType getRevenueScheduleType() {
+        return revenueScheduleType;
+    }
+
+    public void setRevenueScheduleType(final String revenueScheduleType) {
+        this.revenueScheduleType = RevenueScheduleType.valueOf(revenueScheduleType.toUpperCase());
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -276,6 +298,8 @@ public class Plan extends RecurlyObject {
         sb.append(", updatedAt=").append(updatedAt);
         sb.append(", unitAmountInCents=").append(unitAmountInCents);
         sb.append(", setupFeeInCents=").append(setupFeeInCents);
+        sb.append(", revenueScheduleType=").append(revenueScheduleType);
+        sb.append(", setupFeeRevenueScheduleType=").append(setupFeeRevenueScheduleType);
         sb.append('}');
         return sb.toString();
     }
@@ -326,7 +350,13 @@ public class Plan extends RecurlyObject {
         if (planIntervalUnit != null ? !planIntervalUnit.equals(plan.planIntervalUnit) : plan.planIntervalUnit != null) {
             return false;
         }
+        if (revenueScheduleType != null ? !revenueScheduleType.equals(plan.revenueScheduleType) : plan.revenueScheduleType != null) {
+            return false;
+        }
         if (setupFeeInCents != null ? !setupFeeInCents.equals(plan.setupFeeInCents) : plan.setupFeeInCents != null) {
+            return false;
+        }
+        if (setupFeeRevenueScheduleType != null ? !setupFeeRevenueScheduleType.equals(plan.setupFeeRevenueScheduleType) : plan.setupFeeRevenueScheduleType != null) {
             return false;
         }
         if (successLink != null ? !successLink.equals(plan.successLink) : plan.successLink != null) {
@@ -373,7 +403,9 @@ public class Plan extends RecurlyObject {
                 createdAt,
                 updatedAt,
                 unitAmountInCents,
-                setupFeeInCents
+                setupFeeInCents,
+                revenueScheduleType,
+                setupFeeRevenueScheduleType
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Plans.java
+++ b/src/main/java/com/ning/billing/recurly/model/Plans.java
@@ -44,11 +44,6 @@ public class Plans extends RecurlyObjects<Plan> {
     }
 
     @JsonIgnore
-    public Plans getPrev() {
-        return getPrev(Plans.class);
-    }
-
-    @JsonIgnore
     public Plans getNext() {
         return getNext(Plans.class);
     }

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyErrors.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyErrors.java
@@ -41,11 +41,6 @@ public class RecurlyErrors extends RecurlyObjects<RecurlyError> {
     }
 
     @JsonIgnore
-    public RecurlyErrors getPrev() {
-        return getPrev(RecurlyErrors.class);
-    }
-
-    @JsonIgnore
     public RecurlyErrors getNext() {
         return getNext(RecurlyErrors.class);
     }

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObjects.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObjects.java
@@ -48,9 +48,6 @@ public abstract class RecurlyObjects<T extends RecurlyObject> extends ArrayList<
     private String startUrl;
 
     @XmlTransient
-    private String prevUrl;
-
-    @XmlTransient
     private String nextUrl;
 
     @XmlTransient
@@ -62,14 +59,6 @@ public abstract class RecurlyObjects<T extends RecurlyObject> extends ArrayList<
             return null;
         }
         return recurlyClient.doGETWithFullURL(clazz, startUrl);
-    }
-
-    @JsonIgnore
-    <U extends RecurlyObjects> U getPrev(final Class<U> clazz) {
-        if (recurlyClient == null || prevUrl == null) {
-            return null;
-        }
-        return recurlyClient.doGETWithFullURL(clazz, prevUrl);
     }
 
     @JsonIgnore
@@ -93,16 +82,6 @@ public abstract class RecurlyObjects<T extends RecurlyObject> extends ArrayList<
     @JsonIgnore
     public void setStartUrl(final String startUrl) {
         this.startUrl = startUrl;
-    }
-
-    @JsonIgnore
-    public String getPrevUrl() {
-        return prevUrl;
-    }
-
-    @JsonIgnore
-    public void setPrevUrl(final String prevUrl) {
-        this.prevUrl = prevUrl;
     }
 
     @JsonIgnore

--- a/src/main/java/com/ning/billing/recurly/model/Redemptions.java
+++ b/src/main/java/com/ning/billing/recurly/model/Redemptions.java
@@ -44,11 +44,6 @@ public class Redemptions extends RecurlyObjects<Redemption> {
     }
 
     @JsonIgnore
-    public Redemptions getPrev() {
-        return getPrev(Redemptions.class);
-    }
-
-    @JsonIgnore
     public Redemptions getNext() {
         return getNext(Redemptions.class);
     }

--- a/src/main/java/com/ning/billing/recurly/model/RevenueScheduleType.java
+++ b/src/main/java/com/ning/billing/recurly/model/RevenueScheduleType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package com.ning.billing.recurly.model;
+
+public enum RevenueScheduleType {
+    NEVER("never"),
+    EVENLY("evenly"),
+    AT_INVOICE("at_invoice"),
+    AT_RANGE_END("at_range_end"),
+    AT_RANGE_START("at_range_start");
+
+    private final String type;
+
+    private RevenueScheduleType(final String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -100,6 +100,9 @@ public class Subscription extends AbstractSubscription {
     @XmlElement(name = "bulk")
     private Boolean bulk;
 
+    @XmlElement(name = "revenue_schedule_type")
+    private RevenueScheduleType revenueScheduleType;
+
     public Account getAccount() {
         if (account != null && account.getHref() != null && !account.getHref().isEmpty()) {
             account = fetch(account, Account.class);
@@ -278,6 +281,14 @@ public class Subscription extends AbstractSubscription {
         this.bulk = booleanOrNull(bulk);
     }
 
+    public RevenueScheduleType getRevenueScheduleType() {
+        return revenueScheduleType;
+    }
+
+    public void setRevenueScheduleType(final String revenueScheduleType) {
+        this.revenueScheduleType = RevenueScheduleType.valueOf(revenueScheduleType.toUpperCase());
+    }
+
     public DateTime getUpdatedAt() {
         return updatedAt;
     }
@@ -310,6 +321,7 @@ public class Subscription extends AbstractSubscription {
         sb.append(", pendingSubscription=").append(pendingSubscription);
         sb.append(", firstRenewalDate=").append(firstRenewalDate);
         sb.append(", bulk=").append(bulk);
+        sb.append(", revenueScheduleType=").append(revenueScheduleType);
         sb.append('}');
         return sb.toString();
     }
@@ -390,6 +402,9 @@ public class Subscription extends AbstractSubscription {
         if (bulk != null ? !bulk.equals(that.bulk) : that.bulk != null) {
             return false;
         }
+        if (revenueScheduleType != null ? !revenueScheduleType.equals(that.revenueScheduleType) : that.revenueScheduleType != null) {
+            return false;
+        }
 
         return true;
     }
@@ -417,7 +432,8 @@ public class Subscription extends AbstractSubscription {
                 startsAt,
                 collectionMethod,
                 netTerms,
-                poNumber
+                poNumber,
+                revenueScheduleType
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionAddOns.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionAddOns.java
@@ -44,11 +44,6 @@ public class SubscriptionAddOns extends RecurlyObjects<SubscriptionAddOn> {
     }
 
     @JsonIgnore
-    public SubscriptionAddOns getPrev() {
-        return getPrev(SubscriptionAddOns.class);
-    }
-
-    @JsonIgnore
     public SubscriptionAddOns getNext() {
         return getNext(SubscriptionAddOns.class);
     }

--- a/src/main/java/com/ning/billing/recurly/model/Subscriptions.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscriptions.java
@@ -44,11 +44,6 @@ public class Subscriptions extends RecurlyObjects<Subscription> {
     }
 
     @JsonIgnore
-    public Subscriptions getPrev() {
-        return getPrev(Subscriptions.class);
-    }
-
-    @JsonIgnore
     public Subscriptions getNext() {
         return getNext(Subscriptions.class);
     }

--- a/src/main/java/com/ning/billing/recurly/model/Transactions.java
+++ b/src/main/java/com/ning/billing/recurly/model/Transactions.java
@@ -44,11 +44,6 @@ public class Transactions extends RecurlyObjects<Transaction> {
     }
 
     @JsonIgnore
-    public Transactions getPrev() {
-        return getPrev(Transactions.class);
-    }
-
-    @JsonIgnore
     public Transactions getNext() {
         return getNext(Transactions.class);
     }

--- a/src/test/java/com/ning/billing/recurly/TestPaginationUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestPaginationUtils.java
@@ -27,18 +27,15 @@ public class TestPaginationUtils {
         final String linkHeader = "<https://your-subdomain.recurly.com/v2/accounts?cursor=1304958672>; rel=\"next\"";
         final String[] links = PaginationUtils.getLinks(linkHeader);
         Assert.assertNull(links[0]);
-        Assert.assertNull(links[1]);
-        Assert.assertEquals(links[2], "https://your-subdomain.recurly.com/v2/accounts?cursor=1304958672");
+        Assert.assertEquals(links[1], "https://your-subdomain.recurly.com/v2/accounts?cursor=1304958672");
     }
 
     @Test(groups = "fast")
     public void testParserAll() throws Exception {
         final String linkHeader = "<https://your-subdomain.recurly.com/v2/transactions>; rel=\"start\",\n" +
-                                  "  <https://your-subdomain.recurly.com/v2/transactions?cursor=-1318344434>; rel=\"prev\"\n" +
                                   "  <https://your-subdomain.recurly.com/v2/transactions?cursor=1318388868>; rel=\"next\"";
         final String[] links = PaginationUtils.getLinks(linkHeader);
         Assert.assertEquals(links[0], "https://your-subdomain.recurly.com/v2/transactions");
-        Assert.assertEquals(links[1], "https://your-subdomain.recurly.com/v2/transactions?cursor=-1318344434");
-        Assert.assertEquals(links[2], "https://your-subdomain.recurly.com/v2/transactions?cursor=1318388868");
+        Assert.assertEquals(links[1], "https://your-subdomain.recurly.com/v2/transactions?cursor=1318388868");
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestAccountBalance.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccountBalance.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestAccountBalance extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testSerialization() throws Exception {
+        final String accountBalanceData = "<account_balance href=\"https://api.recurly.com/v2/accounts/1/balance\">\n" +
+                "<account href=\"https://api.recurly.com/v2/accounts/1\"/>\n" +
+                "<past_due type=\"boolean\">true</past_due>\n" +
+                "<balance_in_cents>\n" +
+                    "<USD type=\"integer\">400</USD>\n" +
+                "</balance_in_cents>\n" +
+                "</account_balance>\n";
+
+        final AccountBalance balance = xmlMapper.readValue(accountBalanceData, AccountBalance.class);
+
+        Assert.assertEquals(balance.getHref(), "https://api.recurly.com/v2/accounts/1/balance");
+        Assert.assertEquals(balance.getPastDue(), Boolean.TRUE);
+        Assert.assertEquals(balance.getBalanceInCents().getUnitAmountUSD(), new Integer(400));
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
@@ -41,6 +41,7 @@ public class TestAddOns extends TestModelBase {
                                   "    <unit_amount_in_cents>\n" +
                                   "      <USD>200</USD>\n" +
                                   "    </unit_amount_in_cents>\n" +
+                                  "    <revenue_schedule_type>evenly</revenue_schedule_type>\n" +
                                   "    <created_at type=\"datetime\">2011-06-28T12:34:56Z</created_at>\n" +
                                   "    <updated_at type=\"datetime\">2011-06-28T12:34:56Z</updated_at>\n" +
                                   "  </add_on>\n" +
@@ -76,6 +77,7 @@ public class TestAddOns extends TestModelBase {
         Assert.assertEquals((boolean) addOn.getDisplayQuantityOnHostedPage(), false);
         Assert.assertEquals((int) addOn.getDefaultQuantity(), 1);
         Assert.assertEquals((int) addOn.getUnitAmountInCents().getUnitAmountUSD(), 200);
+        Assert.assertEquals(addOn.getRevenueScheduleType(), RevenueScheduleType.EVENLY);
         Assert.assertEquals(addOn.getCreatedAt(), new DateTime("2011-06-28T12:34:56Z"));
         Assert.assertEquals(addOn.getUpdatedAt(), new DateTime("2011-06-28T12:34:56Z"));
     }

--- a/src/test/java/com/ning/billing/recurly/model/TestPlan.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPlan.java
@@ -104,6 +104,8 @@ public class TestPlan extends TestModelBase {
                                 "  <trial_interval_length type=\"integer\">0</trial_interval_length>\n" +
                                 "  <trial_interval_unit>days</trial_interval_unit>\n" +
                                 "  <accounting_code nil=\"nil\"></accounting_code>\n" +
+                                "  <revenue_schedule_type>evenly</revenue_schedule_type>\n" +
+                                "  <setup_fee_revenue_schedule_type>evenly</setup_fee_revenue_schedule_type>>\n" +
                                 "  <created_at type=\"datetime\">2011-04-19T07:00:00Z</created_at>\n" +
                                 "  <updated_at type=\"datetime\">2011-04-19T07:00:00Z</updated_at>\n" +
                                 "  <unit_amount_in_cents>\n" +
@@ -129,6 +131,8 @@ public class TestPlan extends TestModelBase {
         Assert.assertNull(plan.getSuccessLink());
         Assert.assertNull(plan.getCancelLink());
         Assert.assertNull(plan.getAccountingCode());
+        Assert.assertEquals(plan.getRevenueScheduleType(), RevenueScheduleType.EVENLY);
+        Assert.assertEquals(plan.getSetupFeeRevenueScheduleType(), RevenueScheduleType.EVENLY);
     }
 
     @Test(groups = "fast")

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -59,6 +59,7 @@ public class TestSubscription extends TestModelBase {
                                         "  <collection_method>manual</collection_method>\n" +
                                         "  <net_terms type=\"integer\">10</net_terms>\n" +
                                         "  <po_number>PO19384</po_number>\n" +
+                                        "  <revenue_schedule_type>evenly</revenue_schedule_type>\n" +
                                         "  <first_renewal_date type=\"datetime\">2011-07-01T07:00:00Z</first_renewal_date>\n" +
                                         "  <subscription_add_ons type=\"array\">\n" +
                                         "  </subscription_add_ons>\n" +
@@ -111,6 +112,7 @@ public class TestSubscription extends TestModelBase {
                                         "  <net_terms type=\"integer\">10</net_terms>\n" +
                                         "  <po_number>PO19384</po_number>\n" +
                                         "  <first_renewal_date type=\"datetime\">2011-07-01T07:00:00Z</first_renewal_date>\n" +
+                                        "  <revenue_schedule_type>evenly</revenue_schedule_type>\n" +
                                         "  <subscription_add_ons type=\"array\">\n" +
                                         "    <subscription_add_on>\n" +
                                         "      <add_on_code>extra_users</add_on_code>\n" +
@@ -176,6 +178,7 @@ public class TestSubscription extends TestModelBase {
         Assert.assertEquals(subscription.getNetTerms(), (Integer) 10);
         Assert.assertEquals(subscription.getPoNumber(), "PO19384");
         Assert.assertEquals(subscription.getFirstRenewalDate(), new DateTime("2011-07-01T07:00:00Z"));
+        Assert.assertEquals(subscription.getRevenueScheduleType(), RevenueScheduleType.EVENLY);
 
         return subscription;
     }


### PR DESCRIPTION
This updates us to API version 2.3.

The biggest change here is the deprecation of going backwards in pagination. We have also added support for getting the account balance which was the last feature advantage that v1 had over v2.

* Add revenue recognition fields
* Remove support for `prev` in pagination
* Add `AccountBalance`