### PR TITLE
Jackson 2.6 serialization fix

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
@@ -76,7 +76,7 @@ public abstract class RecurlyObject {
         xmlMapper.setAnnotationIntrospector(pair);
         xmlMapper.registerModule(new JodaModule());
         xmlMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        xmlMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        xmlMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         final SimpleModule m = new SimpleModule("module", new Version(1, 0, 0, null, null, null));
         m.addSerializer(Accounts.class, new RecurlyObjectsSerializer<Accounts, Account>(Accounts.class, "account"));

--- a/src/main/java/com/ning/billing/recurly/model/jackson/RecurlyObjectsSerializer.java
+++ b/src/main/java/com/ning/billing/recurly/model/jackson/RecurlyObjectsSerializer.java
@@ -25,7 +25,6 @@ import com.ning.billing.recurly.model.RecurlyObject;
 import com.ning.billing.recurly.model.RecurlyObjects;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.json.JsonWriteContext;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
@@ -49,12 +48,12 @@ public class RecurlyObjectsSerializer<T extends RecurlyObjects<U>, U extends Rec
 
         final ToXmlGenerator xmlgen = (ToXmlGenerator) jgen;
         // Nested RecurlyObjects
-        final boolean shouldSkipWritingFieldName = xmlgen.getOutputContext().writeFieldName(elementName) == JsonWriteContext.STATUS_EXPECT_VALUE;
+        xmlgen.getOutputContext().writeFieldName(elementName);
         boolean firstValue = true;
         for (final U value : values) {
-            if (!shouldSkipWritingFieldName && firstValue) {
+            if (firstValue) {
                 xmlgen.setNextName(new QName(null, elementName));
-            } else if (!shouldSkipWritingFieldName) {
+            } else {
                 xmlgen.writeFieldName(elementName);
             }
             firstValue = false;


### PR DESCRIPTION
Using Jackson 2.6.X or 2.7.X, I ran into serialization issue when sending a SubscriptionUpdate with multiple SubcriptionAddOn elements. I narrowed this down to an issue between Jackson 2.5 and 2.6+. If you update jackson version to 2.6+ in recurly-java-library, the following unit test fails:
`testDeserializationWithAddons(com.ning.billing.recurly.model.TestSubscription): Can not start an object, expecting field name`

The use of JsonInclude.NON_EMPTY also causes problems in Jackson 2.6, namely that Integer fields with value 0 are treated as null. This caused TestAdjustment unit test to fail with error:
```
java.lang.NullPointerException
	at com.ning.billing.recurly.model.TestAdjustment.testSerialization(TestAdjustment.java:75)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
...
```
JsonInclude.NON_NULL is typically what I usually use and seemed to play better with Jackson 2.6+.

With this patch, all tests pass using Jackson 2.5.X, 2.6.0-2.6.4, and 2.7.4+. There seemed to be another issue using Jackson 2.6.5-2.7.3 with or without my fix.