### PR TITLE
Fix po number

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -140,7 +140,7 @@ public class Invoice extends RecurlyObject {
         return poNumber;
     }
 
-    public void setPoNumber(final String poNumber) {
+    public void setPoNumber(final Object poNumber) {
         this.poNumber = stringOrNull(poNumber);
     }
 

--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -43,7 +43,7 @@ public class Invoice extends RecurlyObject {
     private Integer invoiceNumber;
 
     @XmlElement(name = "po_number")
-    private Integer poNumber;
+    private String poNumber;
 
     @XmlElement(name = "vat_number")
     private String vatNumber;
@@ -136,12 +136,12 @@ public class Invoice extends RecurlyObject {
         this.invoiceNumber = integerOrNull(invoiceNumber);
     }
 
-    public Integer getPoNumber() {
+    public String getPoNumber() {
         return poNumber;
     }
 
-    public void setPoNumber(final Object poNumber) {
-        this.poNumber = integerOrNull(poNumber);
+    public void setPoNumber(final String poNumber) {
+        this.poNumber = stringOrNull(poNumber);
     }
 
     public String getVatNumber() {

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
@@ -37,7 +37,7 @@ public class TestInvoice extends TestModelBase {
                                    + "  <uuid>421f7b7d414e4c6792938e7c49d552e9</uuid>\n"
                                    + "  <state>open</state>\n"
                                    + "  <invoice_number type=\"integer\">1402</invoice_number>\n"
-                                   + "  <po_number nil=\"nil\"></po_number>\n"
+                                   + "  <po_number>abc-123</po_number>\n"
                                    + "  <vat_number></vat_number>\n"
                                    + "  <subtotal_in_cents type=\"integer\">9900</subtotal_in_cents>\n"
                                    + "  <tax_in_cents type=\"integer\">0</tax_in_cents>\n"
@@ -75,7 +75,7 @@ public class TestInvoice extends TestModelBase {
         Assert.assertEquals(invoice.getUuid(), "421f7b7d414e4c6792938e7c49d552e9");
         Assert.assertEquals(invoice.getState(), "open");
         Assert.assertEquals((int) invoice.getInvoiceNumber(), 1402);
-        Assert.assertNull(invoice.getPoNumber());
+        Assert.assertEquals(invoice.getPoNumber(), "abc-123");
         Assert.assertNull(invoice.getVatNumber());
         Assert.assertEquals((int) invoice.getSubtotalInCents(), 9900);
         Assert.assertEquals((int) invoice.getTaxInCents(), 0);

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoices.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoices.java
@@ -33,7 +33,7 @@ public class TestInvoices extends TestModelBase {
                                     + "    <uuid>421f7b7d414e4c6792938e7c49d552e9</uuid>\n"
                                     + "    <state>open</state>\n"
                                     + "    <invoice_number type=\"integer\">1005</invoice_number>\n"
-                                    + "    <po_number nil=\"nil\"></po_number>\n"
+                                    + "    <po_number>abc-123</po_number>\n"
                                     + "    <vat_number></vat_number>\n"
                                     + "    <subtotal_in_cents type=\"integer\">1200</subtotal_in_cents>\n"
                                     + "    <tax_in_cents type=\"integer\">0</tax_in_cents>\n"
@@ -73,7 +73,7 @@ public class TestInvoices extends TestModelBase {
         Assert.assertEquals(invoice.getUuid(), "421f7b7d414e4c6792938e7c49d552e9");
         Assert.assertEquals(invoice.getState(), "open");
         Assert.assertEquals((int) invoice.getInvoiceNumber(), 1005);
-        Assert.assertNull(invoice.getPoNumber());
+        Assert.assertEquals(invoice.getPoNumber(), "abc-123");
         Assert.assertNull(invoice.getVatNumber());
         Assert.assertEquals((int) invoice.getSubtotalInCents(), 1200);
         Assert.assertEquals((int) invoice.getTaxInCents(), 0);

--- a/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
@@ -108,7 +108,7 @@ public class TestNotification extends TestModelBase {
                                               "  <state>collected</state>\n" +
                                               "  <invoice_number_prefix></invoice_number_prefix>\n" +
                                               "  <invoice_number type=\"integer\">1000</invoice_number>\n" +
-                                              "  <po_number></po_number>\n" +
+                                              "  <po_number>PO-12345</po_number>\n" +
                                               "  <vat_number></vat_number>\n" +
                                               "  <total_in_cents type=\"integer\">1100</total_in_cents>\n" +
                                               "  <currency>USD</currency>\n" +
@@ -244,7 +244,7 @@ public class TestNotification extends TestModelBase {
         Assert.assertEquals(invoice.getState(), "collected");
         Assert.assertNull(invoice.getInvoiceNumberPrefix());
         Assert.assertEquals(invoice.getInvoiceNumber(), new Integer(1000));
-        Assert.assertNull(invoice.getPoNumber());
+        Assert.assertEquals(invoice.getPoNumber(), "PO-12345");
         Assert.assertNull(invoice.getVatNumber());
         Assert.assertEquals(invoice.getTotalInCents(), new Integer(1100));
         Assert.assertEquals(invoice.getCurrency(), "USD");

--- a/src/test/java/com/ning/billing/recurly/model/push/invoice/TestCloseInvoiceNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/invoice/TestCloseInvoiceNotification.java
@@ -42,7 +42,7 @@ public class TestCloseInvoiceNotification extends TestModelBase {
                                 "    <state>collected</state>\n" +
                                 "    <invoice_number_prefix></invoice_number_prefix>\n" +
                                 "    <invoice_number type=\"integer\">1000</invoice_number>\n" +
-                                "    <po_number></po_number>\n" +
+                                "    <po_number>PO-123</po_number>\n" +
                                 "    <vat_number></vat_number>\n" +
                                 "    <total_in_cents type=\"integer\">1100</total_in_cents>\n" +
                                 "    <currency>USD</currency>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/push/invoice/TestNewInvoiceNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/invoice/TestNewInvoiceNotification.java
@@ -42,7 +42,7 @@ public class TestNewInvoiceNotification extends TestModelBase {
                                 "    <state>open</state>\n" +
                                 "    <invoice_number_prefix></invoice_number_prefix>\n" +
                                 "    <invoice_number type=\"integer\">1000</invoice_number>\n" +
-                                "    <po_number></po_number>\n" +
+                                "    <po_number>abcd</po_number>\n" +
                                 "    <vat_number></vat_number>\n" +
                                 "    <total_in_cents type=\"integer\">1000</total_in_cents>\n" +
                                 "    <currency>USD</currency>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/push/invoice/TestPastDueInvoiceNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/invoice/TestPastDueInvoiceNotification.java
@@ -42,7 +42,7 @@ public class TestPastDueInvoiceNotification extends TestModelBase {
                                 "    <state>past_due</state>\n" +
                                 "    <invoice_number_prefix></invoice_number_prefix>\n" +
                                 "    <invoice_number type=\"integer\">1000</invoice_number>\n" +
-                                "    <po_number></po_number>\n" +
+                                "    <po_number>PO123</po_number>\n" +
                                 "    <vat_number></vat_number>\n" +
                                 "    <total_in_cents type=\"integer\">1100</total_in_cents>\n" +
                                 "    <currency>USD</currency>\n" +


### PR DESCRIPTION
-- Change "po_number" in Invoice class from Integer to String. "po_number" must be a String per https://dev.recurly.com/docs/post-an-invoice-invoice-pending-charges-on-an-acco
-- Update tests for deserialization