### PR TITLE
Run unit tests only for public PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,2 @@
 language: java
-script:
-  - mvn clean test -Pintegration -Dkillbill.payment.recurly.apiKey=$API_KEY -Dkillbill.payment.recurly.subDomain=$SUBDOMAIN
+script: ./travis-test.sh

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,7 @@
                                 <exclude>**/target/**</exclude>
                                 <exclude>**/.settings/**</exclude>
                                 <exclude>.travis.yml</exclude>
+                                <exclude>travis-test.sh</exclude>
                                 <exclude>bin/**</exclude>
                                 <exclude>CREDITS</exclude>
                             </excludes>

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -1212,7 +1212,6 @@ public class TestRecurlyClient {
             Assert.assertNotNull(subscription);
             Assert.assertEquals(subscription.getTrialEndsAt().getMonthOfYear(), now.getMonthOfYear() + 3);
         } finally {
-            recurlyClient.deleteCouponRedemption(accountData.getAccountCode());
             recurlyClient.closeAccount(accountData.getAccountCode());
             recurlyClient.deletePlan(planData.getPlanCode());
             recurlyClient.deleteCoupon(couponData.getCouponCode());

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -1,0 +1,5 @@
+if [ -z "$API_KEY" ]; then
+  mvn clean test
+else
+  mvn clean test -Pintegration -Dkillbill.payment.recurly.apiKey=$API_KEY -Dkillbill.payment.recurly.subDomain=$SUBDOMAIN
+fi


### PR DESCRIPTION
Have travis only run unit tests if the `API_KEY` is not set. `API_KEY` is not set when running tests on public PRs. I have to run the integration tests for every PR anyway.