### PR TITLE
Support invoices with prefix

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -567,12 +567,27 @@ public class RecurlyClient {
     /**
      * Lookup an invoice
      * <p>
-     * Returns the invoice
+     * Returns the invoice given an integer id
      *
      * @param invoiceId Recurly Invoice ID
      * @return the invoice
      */
     public Invoice getInvoice(final Integer invoiceId) {
+        return getInvoice(invoiceId.toString());
+    }
+
+    /**
+     * Lookup an invoice (with or without prefix)
+     * <p>
+     * Returns the invoice given a string id.
+     * The invoice may or may not have acountry code prefix (ex: IE1023).
+     * Use this if you ever expect to use invoice prefixes:
+     * https://docs.recurly.com/docs/site-settings#section-invoice-prefixing
+     *
+     * @param invoiceId String Recurly Invoice ID
+     * @return the invoice
+     */
+    public Invoice getInvoice(final String invoiceId) {
         return doGET(Invoices.INVOICES_RESOURCE + "/" + invoiceId, Invoice.class);
     }
 

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -1210,7 +1210,9 @@ public class TestRecurlyClient {
             final Subscription subscription = recurlyClient.createSubscription(subscriptionData);
 
             Assert.assertNotNull(subscription);
-            Assert.assertEquals(subscription.getTrialEndsAt().getMonthOfYear(), now.getMonthOfYear() + 3);
+
+            final int expectedMonth = (now.getMonthOfYear() + 3) % 12;
+            Assert.assertEquals(subscription.getTrialEndsAt().getMonthOfYear(), expectedMonth);
         } finally {
             recurlyClient.closeAccount(accountData.getAccountCode());
             recurlyClient.deletePlan(planData.getPlanCode());

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -287,7 +287,7 @@ public class TestUtils {
         address.setAddress1(randomAlphaNumericString(10, seed));
         address.setAddress2(randomAlphaNumericString(10, seed));
         address.setCity(randomAlphaNumericString(10, seed));
-        address.setState(randomAlphaString(2, seed));
+        address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setZip(49302);
         address.setCountry(randomAlphaString(2, seed).toUpperCase());
         address.setPhone(randomNumericString(10, seed));
@@ -316,7 +316,8 @@ public class TestUtils {
         address.setAddress1(randomAlphaNumericString(10, seed));
         address.setAddress2(randomAlphaNumericString(10, seed));
         address.setCity(randomAlphaNumericString(10, seed));
-        address.setState(randomAlphaString(2, seed));
+        address.setState(randomAlphaString(2, seed).toUpperCase());
+        address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setZip(49302);
         address.setCountry(randomAlphaString(2, seed).toUpperCase());
         address.setPhone(randomNumericString(10, seed));
@@ -384,9 +385,9 @@ public class TestUtils {
         info.setAddress1(randomAlphaNumericString(10, seed));
         info.setAddress2(randomAlphaNumericString(10, seed));
         info.setCity(randomAlphaNumericString(10, seed));
-        info.setState(randomAlphaNumericString(10, seed));
+        info.setState(randomAlphaNumericString(10, seed).toUpperCase());
         info.setZip(randomAlphaNumericString(5, seed));
-        info.setCountry(randomAlphaNumericString(5, seed));
+        info.setCountry(randomAlphaNumericString(5, seed).toUpperCase());
         info.setPhone(randomInteger(8, seed));
         info.setVatNumber(randomNumericString(8, seed));
         info.setYear(createTestCCYear());


### PR DESCRIPTION
Addresses issue https://github.com/killbilling/recurly-java-library/issues/147

Do we want to keep the old method and deprecate it? Should we have both methods supported and just add some more documentation into the methods?