### PR TITLE
Added null check for revenueScheduleType

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -341,7 +341,9 @@ public class Subscription extends AbstractSubscription {
     }
 
     public void setRevenueScheduleType(final String revenueScheduleType) {
-        this.revenueScheduleType = RevenueScheduleType.valueOf(revenueScheduleType.toUpperCase());
+    	if( revenueScheduleType != null ){
+    		this.revenueScheduleType = RevenueScheduleType.valueOf(revenueScheduleType.toUpperCase());
+    	}
     }
 
     public GiftCard getGiftCard() {

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -177,7 +177,7 @@ public class TestSubscription extends TestModelBase {
     	try{
         	//we expect an exception here
         	subscription.setRevenueScheduleType( invalidValue );
-        	assertEquals(true, false );
+        	Assert.fail();
         }
         catch( IllegalArgumentException iae ){
         	//iae.printStackTrace();

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -156,6 +156,40 @@ public class TestSubscription extends TestModelBase {
         assertEquals(subscription.hashCode(), otherSubscription.hashCode());
         assertEquals(subscription, otherSubscription);
     }
+    
+    @Test(groups = "fast")
+    public void testSetRevenueScheduleType() throws Exception {
+        Subscription subscription = new Subscription();
+        subscription.setRevenueScheduleType(null);
+        assertEquals(subscription.getRevenueScheduleType(), null );
+        
+        verifyRevenueScheduleTypeWithInvalidValue("INVALID_STRING");
+        verifyRevenueScheduleTypeWithInvalidValue("");
+        verifyRevenueScheduleTypeWithInvalidValue(" ");
+        
+        for(RevenueScheduleType revenueScheduleType : RevenueScheduleType.values() ){
+        	verifyRevenueScheduleType( revenueScheduleType );
+        }
+    }
+    
+    private void verifyRevenueScheduleTypeWithInvalidValue( String invalidValue ){
+    	Subscription subscription = new Subscription();
+    	try{
+        	//we expect an exception here
+        	subscription.setRevenueScheduleType( invalidValue );
+        	assertEquals(true, false );
+        }
+        catch( IllegalArgumentException iae ){
+        	//iae.printStackTrace();
+        }
+    }
+    
+    private void verifyRevenueScheduleType(RevenueScheduleType revenueScheduleType){
+    	Subscription subscription = new Subscription();
+    	subscription.setRevenueScheduleType(revenueScheduleType.getType());
+    	assertEquals(subscription.getRevenueScheduleType(), revenueScheduleType );
+    	
+    }
 
     private void verifySubscriptionAddons(final Subscription subscription) {
         Assert.assertEquals(subscription.getAddOns().size(), 2);


### PR DESCRIPTION
Resolves: https://github.com/killbilling/recurly-java-library/issues/152

Added a null check for the String revenueScheduleType.

You may want to consider updating the enum RevenueScheduleType to return a default value if the string is empty