### PR TITLE
Make travis badge reflect master branch only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-recurly-java-library [![Build Status](https://travis-ci.org/killbilling/recurly-java-library.svg)](https://travis-ci.org/killbilling/recurly-java-library)
+recurly-java-library [![Build Status](https://travis-ci.org/killbilling/recurly-java-library.svg?branch=master)](https://travis-ci.org/killbilling/recurly-java-library)
 ====================
 
 Java library for Recurly, originally developed for [Kill Bill](http://killbill.io), an open-source subscription management and billing system.


### PR DESCRIPTION
The travis badge was just showing the latest build (which would include
failing experiemental branches). We want it to only show master which is
green and makes people feel good when they see the README :)