### PR TITLE
Fix integration test by ensuring giftcard.deliver_at always in future

### DIFF
--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -804,7 +804,7 @@ public class TestUtils {
         delivery.setGifterName(randomAlphaNumericString(5, seed));
         delivery.setMethod("email");
         delivery.setPersonalMessage(randomAlphaNumericString(100, seed));
-        delivery.setDeliverAt(new DateTime("2016-12-27T07:00:00Z"));
+        delivery.setDeliverAt(new DateTime().plusDays(5)); // needs to be at least 1 hour in future
 
         return delivery;
     }


### PR DESCRIPTION
This fixes the integration test. I had unfortunately added a static datetime for deliver_at but that value needs to always be 1 hour in the future. This sets it to 5 days from the day of running.