### PR TITLE
Fully support Invoice prefixes (and deprecate using integer as invoice id)

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -725,19 +725,23 @@ public class RecurlyClient {
      * <p>
      * Returns the invoice given an integer id
      *
+     * @deprecated Please switch to using a string for invoice ids
+     *
      * @param invoiceId Recurly Invoice ID
      * @return the invoice
      */
+    @Deprecated
     public Invoice getInvoice(final Integer invoiceId) {
         return getInvoice(invoiceId.toString());
     }
 
     /**
-     * Lookup an invoice (with or without prefix)
+     * Lookup an invoice given an invoice id
+     *
      * <p>
      * Returns the invoice given a string id.
      * The invoice may or may not have acountry code prefix (ex: IE1023).
-     * Use this if you ever expect to use invoice prefixes:
+     * For more information on invoicing and prefixes, see:
      * https://docs.recurly.com/docs/site-settings#section-invoice-prefixing
      *
      * @param invoiceId String Recurly Invoice ID
@@ -752,10 +756,25 @@ public class RecurlyClient {
      * <p>
      * Returns the invoice pdf as an inputStream
      *
+     * @deprecated Prefer using Invoice#getId() as the id param (which is a String)
+     *
      * @param invoiceId Recurly Invoice ID
      * @return the invoice pdf as an inputStream
      */
+    @Deprecated
     public InputStream getInvoicePdf(final Integer invoiceId) {
+        return getInvoicePdf(invoiceId.toString());
+    }
+
+    /**
+     * Fetch invoice pdf
+     * <p>
+     * Returns the invoice pdf as an inputStream
+     *
+     * @param invoiceId String Recurly Invoice ID
+     * @return the invoice pdf as an inputStream
+     */
+    public InputStream getInvoicePdf(final String invoiceId) {
         return doGETPdf(Invoices.INVOICES_RESOURCE + "/" + invoiceId);
     }
 
@@ -816,28 +835,65 @@ public class RecurlyClient {
     /**
      * Mark an invoice as paid successfully - Recurly Enterprise Feature
      *
+     * @deprecated Prefer using Invoice#getId() as the id param (which is a String)
+     *
      * @param invoiceId Recurly Invoice ID
      */
+    @Deprecated
     public Invoice markInvoiceSuccessful(final Integer invoiceId) {
+        return markInvoiceSuccessful(invoiceId.toString());
+    }
+
+    /**
+     * Mark an invoice as paid successfully - Recurly Enterprise Feature
+     *
+     * @param invoiceId String Recurly Invoice ID
+     */
+    public Invoice markInvoiceSuccessful(final String invoiceId) {
         return doPUT(Invoices.INVOICES_RESOURCE + "/" + invoiceId + "/mark_successful", null, Invoice.class);
     }
 
     /**
      * Mark an invoice as failed collection
      *
+     * @deprecated Prefer using Invoice#getId() as the id param (which is a String)
+     *
      * @param invoiceId Recurly Invoice ID
      */
+    @Deprecated
     public Invoice markInvoiceFailed(final Integer invoiceId) {
+        return markInvoiceFailed(invoiceId.toString());
+    }
+
+    /**
+     * Mark an invoice as failed collection
+     *
+     * @param invoiceId String Recurly Invoice ID
+     */
+    public Invoice markInvoiceFailed(final String invoiceId) {
         return doPUT(Invoices.INVOICES_RESOURCE + "/" + invoiceId + "/mark_failed", null, Invoice.class);
     }
 
     /**
      * Enter an offline payment for a manual invoice (beta) - Recurly Enterprise Feature
      *
+     * @deprecated Prefer using Invoice#getId() as the id param (which is a String)
+     *
      * @param invoiceId Recurly Invoice ID
      * @param payment   The external payment
      */
+    @Deprecated
     public Transaction enterOfflinePayment(final Integer invoiceId, final Transaction payment) {
+        return enterOfflinePayment(invoiceId.toString(), payment);
+    }
+
+    /**
+     * Enter an offline payment for a manual invoice (beta) - Recurly Enterprise Feature
+     *
+     * @param invoiceId String Recurly Invoice ID
+     * @param payment   The external payment
+     */
+    public Transaction enterOfflinePayment(final String invoiceId, final Transaction payment) {
         return doPOST(Invoices.INVOICES_RESOURCE + "/" + invoiceId + "/transactions", payment, Transaction.class);
     }
 
@@ -1076,33 +1132,74 @@ public class RecurlyClient {
     /**
      * Lookup the first coupon redemption on an invoice.
      *
+     * @deprecated Prefer using Invoice#getId() as the id param (which is a String)
+     *
      * @param invoiceNumber invoice number
      * @return the coupon redemption for this invoice on success, null otherwise
      */
+    @Deprecated
     public Redemption getCouponRedemptionByInvoice(final Integer invoiceNumber) {
-        return doGET(Invoices.INVOICES_RESOURCE + "/" + invoiceNumber + Redemption.REDEMPTION_RESOURCE,
+        return getCouponRedemptionByInvoice(invoiceNumber.toString());
+    }
+
+    /**
+     * Lookup the first coupon redemption on an invoice.
+     *
+     * @param invoiceId String invoice id
+     * @return the coupon redemption for this invoice on success, null otherwise
+     */
+    public Redemption getCouponRedemptionByInvoice(final String invoiceId) {
+        return doGET(Invoices.INVOICES_RESOURCE + "/" + invoiceId + Redemption.REDEMPTION_RESOURCE,
                 Redemption.class);
+    }
+
+
+    /**
+     * Lookup all coupon redemptions on an invoice.
+     *
+     * @deprecated Prefer using Invoice#getId() as the id param (which is a String)
+     *
+     * @param invoiceNumber invoice number
+     * @return the coupon redemptions for this invoice on success, null otherwise
+     */
+    @Deprecated
+    public Redemptions getCouponRedemptionsByInvoice(final Integer invoiceNumber) {
+        return getCouponRedemptionsByInvoice(invoiceNumber.toString(), new QueryParams());
     }
 
     /**
      * Lookup all coupon redemptions on an invoice.
      *
-     * @param invoiceNumber invoice number
+     * @param invoiceId String invoice id
      * @return the coupon redemptions for this invoice on success, null otherwise
      */
-    public Redemptions getCouponRedemptionsByInvoice(final Integer invoiceNumber) {
-        return getCouponRedemptionsByInvoice(invoiceNumber, new QueryParams());
+    public Redemptions getCouponRedemptionsByInvoice(final String invoiceId) {
+        return getCouponRedemptionsByInvoice(invoiceId, new QueryParams());
     }
 
     /**
      * Lookup all coupon redemptions on an invoice given query params.
      *
+     * @deprecated Prefer using Invoice#getId() as the id param (which is a String)
+     *
      * @param invoiceNumber invoice number
      * @param params {@link QueryParams}
      * @return the coupon redemptions for this invoice on success, null otherwise
      */
+    @Deprecated
     public Redemptions getCouponRedemptionsByInvoice(final Integer invoiceNumber, final QueryParams params) {
-        return doGET(Invoices.INVOICES_RESOURCE + "/" + invoiceNumber + Redemption.REDEMPTION_RESOURCE,
+        return getCouponRedemptionsByInvoice(invoiceNumber.toString(), params);
+    }
+
+    /**
+     * Lookup all coupon redemptions on an invoice given query params.
+     *
+     * @param invoiceId String invoice id
+     * @param params {@link QueryParams}
+     * @return the coupon redemptions for this invoice on success, null otherwise
+     */
+    public Redemptions getCouponRedemptionsByInvoice(final String invoiceId, final QueryParams params) {
+        return doGET(Invoices.INVOICES_RESOURCE + "/" + invoiceId + Redemption.REDEMPTION_RESOURCE,
                 Redemptions.class, params);
     }
 

--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -44,6 +44,9 @@ public class Invoice extends RecurlyObject {
     @XmlElement(name = "invoice_number")
     private Integer invoiceNumber;
 
+    @XmlElement(name = "invoice_number_prefix")
+    private String invoiceNumberPrefix;
+
     @XmlElement(name = "po_number")
     private String poNumber;
 
@@ -101,26 +104,33 @@ public class Invoice extends RecurlyObject {
         return account;
     }
 
-  /**
-   * Set this original invoice to the passed in original invoice.
-   *
-   * @param originalInvoice original invoice
-   */
-  public void setOriginalInvoice(Invoice originalInvoice) {
+    /**
+     * Set this original invoice to the passed in original invoice.
+     *
+     * @param originalInvoice original invoice
+     *
+     */
+    public void setOriginalInvoice(Invoice originalInvoice) {
         this.originalInvoice = originalInvoice;
-  }
+    }
 
-  /**
-   * Fetches the original invoice if the href is populated, otherwise return the current original invoice.
-   *
-   * @return fully loaded original invoice
-   */
-  public Invoice getOriginalInvoice() {
+    /**
+     * Fetches the original invoice if the href is populated, otherwise return the current original invoice.
+     *
+     * @return fully loaded original invoice
+     */
+    public Invoice getOriginalInvoice() {
         if (originalInvoice != null && originalInvoice.getHref() != null && !originalInvoice.getHref().isEmpty()) {
             originalInvoice = fetch(originalInvoice, Invoice.class);
         }
         return originalInvoice;
-  }
+    }
+
+    public String getId() {
+        if (invoiceNumber == null) return null;
+        if (invoiceNumberPrefix == null) return invoiceNumber.toString();
+        return invoiceNumberPrefix + invoiceNumber.toString();
+    }
 
     public void setAccount(final Account account) {
         this.account = account;
@@ -148,6 +158,14 @@ public class Invoice extends RecurlyObject {
 
     public void setInvoiceNumber(final Object invoiceNumber) {
         this.invoiceNumber = integerOrNull(invoiceNumber);
+    }
+
+    public String getInvoiceNumberPrefix() {
+        return invoiceNumberPrefix;
+    }
+
+    public void setInvoiceNumberPrefix(final Object invoiceNumberPrefix) {
+        this.invoiceNumberPrefix = stringOrNull(invoiceNumberPrefix);
     }
 
     public String getPoNumber() {
@@ -286,6 +304,7 @@ public class Invoice extends RecurlyObject {
         sb.append(", uuid='").append(uuid).append('\'');
         sb.append(", state='").append(state).append('\'');
         sb.append(", invoiceNumber=").append(invoiceNumber);
+        sb.append(", invoiceNumberPrefix=").append(invoiceNumberPrefix);
         sb.append(", poNumber=").append(poNumber);
         sb.append(", vatNumber='").append(vatNumber).append('\'');
         sb.append(", subtotalInCents=").append(subtotalInCents);
@@ -332,6 +351,9 @@ public class Invoice extends RecurlyObject {
             return false;
         }
         if (invoiceNumber != null ? !invoiceNumber.equals(invoice.invoiceNumber) : invoice.invoiceNumber != null) {
+            return false;
+        }
+        if (invoiceNumberPrefix != null ? !invoiceNumberPrefix.equals(invoice.invoiceNumberPrefix) : invoice.invoiceNumberPrefix != null) {
             return false;
         }
         if (lineItems != null ? !lineItems.equals(invoice.lineItems) : invoice.lineItems != null) {
@@ -388,6 +410,7 @@ public class Invoice extends RecurlyObject {
                 uuid,
                 state,
                 invoiceNumber,
+                invoiceNumberPrefix,
                 poNumber,
                 vatNumber,
                 subtotalInCents,

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -175,7 +175,7 @@ public class TestRecurlyClient {
             Assert.assertNotNull(subInvoice);
             
             // Refetch the invoice using the getInvoice method
-            final int invoiceID = subInvoice.getInvoiceNumber();
+            final String invoiceID = subInvoice.getId();
             final Invoice gotInvoice = recurlyClient.getInvoice(invoiceID);
 
             Assert.assertEquals(subInvoice.hashCode(), gotInvoice.hashCode());
@@ -833,17 +833,17 @@ public class TestRecurlyClient {
             final Invoice invoice = recurlyClient.postAccountInvoice(accountData.getAccountCode(), invoiceData);
             Assert.assertNotNull(invoice);
 
-            InputStream pdfInputStream = recurlyClient.getInvoicePdf(invoice.getInvoiceNumber());
+            InputStream pdfInputStream = recurlyClient.getInvoicePdf(invoice.getId());
             Assert.assertNotNull(pdfInputStream);
 
             pdDocument = PDDocument.load(pdfInputStream);
             String pdfString = new PDFTextStripper().getText(pdDocument);
 
             Assert.assertNotNull(pdfString);
-            Assert.assertTrue(pdfString.contains("Invoice # " + invoice.getInvoiceNumber()));
+            Assert.assertTrue(pdfString.contains("Invoice # " + invoice.getId()));
             Assert.assertTrue(pdfString.contains("Subtotal $" + 1.5));
             // Attempt to close the invoice
-            final Invoice closedInvoice = recurlyClient.markInvoiceSuccessful(invoice.getInvoiceNumber());
+            final Invoice closedInvoice = recurlyClient.markInvoiceSuccessful(invoice.getId());
             Assert.assertEquals(closedInvoice.getState(), "collected", "Invoice not closed successfully");
 
         } finally {
@@ -878,7 +878,7 @@ public class TestRecurlyClient {
             Assert.assertNotNull(invoice);
 
             // Attempt to close the invoice
-            final Invoice closedInvoice = recurlyClient.markInvoiceSuccessful(invoice.getInvoiceNumber());
+            final Invoice closedInvoice = recurlyClient.markInvoiceSuccessful(invoice.getId());
             Assert.assertEquals(closedInvoice.getState(), "collected", "Invoice not closed successfully");
 
             // Create an Adjustment
@@ -896,7 +896,7 @@ public class TestRecurlyClient {
             Assert.assertNotNull(invoiceFail);
 
             // Attempt to fail the invoice
-            final Invoice failedInvoice = recurlyClient.markInvoiceFailed(invoiceFail.getInvoiceNumber());
+            final Invoice failedInvoice = recurlyClient.markInvoiceFailed(invoiceFail.getId());
             Assert.assertEquals(failedInvoice.getState(), "failed", "Invoice not failed successfully");
 
             // Create an Adjustment
@@ -920,7 +920,7 @@ public class TestRecurlyClient {
             externalPaymentData.setCollectedAt(collectionDateTime);
             externalPaymentData.setAmountInCents(450);
 
-            final Transaction externalPayment = recurlyClient.enterOfflinePayment(invoiceExternal.getInvoiceNumber(), externalPaymentData);
+            final Transaction externalPayment = recurlyClient.enterOfflinePayment(invoiceExternal.getId(), externalPaymentData);
             Assert.assertNotNull(externalPayment);
             Assert.assertEquals(externalPayment.getInvoice().getState(), "collected", "Invoice not closed successfully");
 

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -289,7 +289,7 @@ public class TestUtils {
         address.setAddress2(randomAlphaNumericString(10, seed));
         address.setCity(randomAlphaNumericString(10, seed));
         address.setState(randomAlphaString(2, seed).toUpperCase());
-        address.setZip(49302);
+        address.setZip("94110");
         address.setCountry(randomAlphaString(2, seed).toUpperCase());
         address.setPhone(randomNumericString(10, seed));
 
@@ -319,7 +319,7 @@ public class TestUtils {
         address.setCity(randomAlphaNumericString(10, seed));
         address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setState(randomAlphaString(2, seed).toUpperCase());
-        address.setZip(49302);
+        address.setZip("94110");
         address.setCountry(randomAlphaString(2, seed).toUpperCase());
         address.setPhone(randomNumericString(10, seed));
         address.setNickname(randomAlphaNumericString(10, seed));
@@ -387,7 +387,7 @@ public class TestUtils {
         info.setAddress2(randomAlphaNumericString(10, seed));
         info.setCity(randomAlphaNumericString(10, seed));
         info.setState(randomAlphaNumericString(10, seed).toUpperCase());
-        info.setZip(randomAlphaNumericString(5, seed));
+        info.setZip("94110");
         info.setCountry(randomAlphaNumericString(2, seed).toUpperCase());
         info.setPhone(randomInteger(8, seed));
         info.setVatNumber(randomNumericString(8, seed));
@@ -805,7 +805,11 @@ public class TestUtils {
         delivery.setGifterName(randomAlphaNumericString(5, seed));
         delivery.setMethod("email");
         delivery.setPersonalMessage(randomAlphaNumericString(100, seed));
-        delivery.setDeliverAt(new DateTime().plusDays(5)); // needs to be at least 1 hour in future
+        if (seed == 0) { // we want it to be deterministic
+            delivery.setDeliverAt(new DateTime("2020-01-01T00:00:00Z"));
+        } else {
+            delivery.setDeliverAt(new DateTime().plusDays(5)); // needs to be at least 1 hour in future
+        }
 
         return delivery;
     }

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
@@ -39,6 +39,7 @@ public class TestInvoice extends TestModelBase {
                                    + "  <uuid>421f7b7d414e4c6792938e7c49d552e9</uuid>\n"
                                    + "  <state>open</state>\n"
                                    + "  <invoice_number type=\"integer\">1402</invoice_number>\n"
+                                   + "  <invoice_number_prefix>FR</invoice_number_prefix>\n"
                                    + "  <po_number>abc-123</po_number>\n"
                                    + "  <vat_number></vat_number>\n"
                                    + "  <subtotal_in_cents type=\"integer\">9900</subtotal_in_cents>\n"
@@ -95,6 +96,8 @@ public class TestInvoice extends TestModelBase {
         Assert.assertEquals(invoice.getClosedAt(), new DateTime("2011-08-25T12:00:00Z"));
         Assert.assertNotNull(invoice.getLineItems());
         Assert.assertEquals(invoice.getLineItems().size(), 1);
+        Assert.assertEquals(invoice.getInvoiceNumberPrefix(), "FR");
+        Assert.assertEquals(invoice.getId(), "FR1402");
 
         final Adjustment adjustment = invoice.getLineItems().get(0);
         Assert.assertEquals(adjustment.getDescription(), "Charge for extra bandwidth");
@@ -102,6 +105,16 @@ public class TestInvoice extends TestModelBase {
         Assert.assertEquals(adjustment.getStartDate(), new DateTime("2011-08-31T03:30:00Z"));
 
         Assert.assertEquals(invoice.getTransactions().size(), 0);
+    }
+
+    @Test(groups = "fast")
+    public void testGetId() throws Exception {
+        final Invoice invoice = new Invoice();
+        Assert.assertNull(invoice.getId());
+        invoice.setInvoiceNumber(9999);
+        Assert.assertEquals(invoice.getId(), "9999");
+        invoice.setInvoiceNumberPrefix("FR");
+        Assert.assertEquals(invoice.getId(), "FR9999");
     }
 
     @Test(groups = "fast")


### PR DESCRIPTION
This adds support for invoices which may have prefixes. It builds on #148 by only accepting invoice ids as Strings for every invoice method. We are also now parsing `invoice_number_prefix` and including it in a new method `getId()` that returns the prefixed or non prefixed id. Example:

```java
final Invoice invoice = new Invoice();
Assert.assertNull(invoice.getId());
invoice.setInvoiceNumber(9999);
Assert.assertEquals(invoice.getId(), "9999");
invoice.setInvoiceNumberPrefix("FR");
Assert.assertEquals(invoice.getId(), "FR9999");
```

I've deprecated all methods using an `Integer` for invoiceId and added new methods using `String`. These are all `RecurlyClient` instance methods:

* getInvoice(Integer invoiceId) => getInvoice(String invoiceId)
* getInvoicePdf(Integer invoiceId) => getInvoicePdf(String invoiceId)
* markInvoiceSuccessful(Integer invoiceId) => markInvoiceSuccessful(String invoiceId)
* markInvoiceFailed(Integer invoiceId) => markInvoiceFailed(String invoiceId)
* enterOfflinePayment(Integer invoiceId, Transaction payment) => enterOfflinePayment(String invoiceId, Transaction payment)
* getCouponRedemptionByInvoice(Integer invoiceId) => getCouponRedemptionByInvoice(String invoiceId)
* getCouponRedemptionsByInvoice(Integer invoiceId) => getCouponRedemptionsByInvoice(String invoiceId)
* getCouponRedemptionsByInvoice(Integer invoiceNumber, QueryParams params) => getCouponRedemptionsByInvoice(String invoiceNumber, QueryParams params)

We can remove the deprecated invoice methods in 1.0 whenever we get there.
