### PR TITLE
Support line item refunds

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.Scanner;
@@ -41,6 +42,7 @@ import com.ning.billing.recurly.model.Accounts;
 import com.ning.billing.recurly.model.AddOn;
 import com.ning.billing.recurly.model.AddOns;
 import com.ning.billing.recurly.model.Adjustment;
+import com.ning.billing.recurly.model.AdjustmentRefund;
 import com.ning.billing.recurly.model.Adjustments;
 import com.ning.billing.recurly.model.BillingInfo;
 import com.ning.billing.recurly.model.Coupon;
@@ -805,6 +807,24 @@ public class RecurlyClient {
         final InvoiceRefund invoiceRefund = new InvoiceRefund();
         invoiceRefund.setRefundApplyOrder(order);
         invoiceRefund.setAmountInCents(amountInCents);
+
+        return doPOST(Invoices.INVOICES_RESOURCE + "/" + invoiceId + "/refund", invoiceRefund, Invoice.class);
+    }
+
+    /**
+     * Refund an invoice given some line items
+     * <p/>
+     * Returns the refunded invoice
+     *
+     * @param invoiceId The id of the invoice to refund
+     * @param lineItems The list of adjustment refund objects
+     * @param order If credit line items exist on the invoice, this parameter specifies which refund method to use first
+     * @return the refunded invoice
+     */
+    public Invoice refundInvoice(final String invoiceId, List<AdjustmentRefund> lineItems, final RefundApplyOrder order) {
+        final InvoiceRefund invoiceRefund = new InvoiceRefund();
+        invoiceRefund.setRefundApplyOrder(order);
+        invoiceRefund.setLineItems(lineItems);
 
         return doPOST(Invoices.INVOICES_RESOURCE + "/" + invoiceId + "/refund", invoiceRefund, Invoice.class);
     }

--- a/src/main/java/com/ning/billing/recurly/model/Adjustment.java
+++ b/src/main/java/com/ning/billing/recurly/model/Adjustment.java
@@ -216,6 +216,14 @@ public class Adjustment extends RecurlyObject {
         this.updatedAt = dateTimeOrNull(updatedAt);
     }
 
+    public AdjustmentRefund toAdjustmentRefund() {
+        final AdjustmentRefund adjustmentRefund = new AdjustmentRefund();
+        adjustmentRefund.setUuid(uuid);
+        adjustmentRefund.setQuantity(quantity);
+        adjustmentRefund.setProrate(false);
+        return adjustmentRefund;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/ning/billing/recurly/model/AdjustmentRefund.java
+++ b/src/main/java/com/ning/billing/recurly/model/AdjustmentRefund.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.google.common.base.Objects;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "adjustment")
+public class AdjustmentRefund extends RecurlyObject {
+
+    @XmlElement(name = "uuid")
+    private String uuid;
+
+    @XmlElement(name = "quantity")
+    private Integer quantity;
+
+    @XmlElement(name = "prorate")
+    private Boolean prorate;
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(final Object uuid) {
+        this.uuid = stringOrNull(uuid);
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(final Object quantity) {
+        this.quantity = integerOrNull(quantity);
+    }
+
+    public Boolean getProrate() {
+        return prorate;
+    }
+
+    public void setProrate(final Object prorate) {
+        this.prorate = booleanOrNull(prorate);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("AdjustmentRefund");
+        sb.append("{uuid='").append(uuid).append('\'');
+        sb.append(", quantity=").append(quantity);
+        sb.append(", prorate=").append(prorate);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final AdjustmentRefund that = (AdjustmentRefund) o;
+
+        if (prorate != null ? !prorate.equals(that.prorate) : that.prorate != null) {
+            return false;
+        }
+        if (quantity != null ? !quantity.equals(that.quantity) : that.quantity != null) {
+            return false;
+        }
+        if (uuid != null ? !uuid.equals(that.uuid) : that.uuid != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(
+                prorate,
+                quantity,
+                uuid
+
+        );
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/InvoiceRefund.java
+++ b/src/main/java/com/ning/billing/recurly/model/InvoiceRefund.java
@@ -20,7 +20,9 @@ package com.ning.billing.recurly.model;
 import com.google.common.base.Objects;
 
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
 
 @XmlRootElement(name = "invoice")
 public class InvoiceRefund extends RecurlyObject {
@@ -29,6 +31,10 @@ public class InvoiceRefund extends RecurlyObject {
 
     @XmlElement(name = "amount_in_cents")
     private Integer amountInCents;
+
+    @XmlElementWrapper(name = "line_items")
+    @XmlElement(name = "adjustment")
+    private List<AdjustmentRefund> lineItems;
 
     public void setRefundApplyOrder(final RefundApplyOrder refundApplyOrder) {
         this.refundApplyOrder = refundApplyOrder;
@@ -44,6 +50,14 @@ public class InvoiceRefund extends RecurlyObject {
 
     public Integer getAmountInCents() {
         return this.amountInCents;
+    }
+
+    public void setLineItems(final List<AdjustmentRefund> lineItems) {
+        this.lineItems = lineItems;
+    }
+
+    public List<AdjustmentRefund> getLineItems() {
+        return this.lineItems;
     }
 
     @Override


### PR DESCRIPTION
This adds line item invoice refunds as discussed in #169 . https://dev.recurly.com/docs/line-item-refunds

You have to pass in a list of `AdjustmentRefund`s because they have some fields that don't really belong in `Adjustment`. I've created a convenience method for turning an `Adjustment` into an `AdjustmentRefund`.  You can see the integration test to get an idea how to use it.

```java
final invoice = recurlyClient.getInvoice("1234");
final ArrayList<AdjustmentRefund> lineItems = new ArrayList<AdjustmentRefund>();

// let's just refund the first adjustment
// we can use "toAdjustmentRefund" on the adjustment to turn it
// into an AdjustmentRefund  
final AdjustmentRefund adjustmentRefund = invoice.getLineItems().get(0).toAdjustmentRefund();

// we could change the quantity here or the prorating settings if we want, defaults to full quantity
// adjustmentRefund.setQuantity(1);
lineItems.add(adjustmentRefund);

final Invoice refundInvoice = recurlyClient.refundInvoice(invoice.getId(), lineItems, RefundApplyOrder.transaction);
```
