### PR TITLE
Add product_code for Vertex integration

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Adjustment.java
+++ b/src/main/java/com/ning/billing/recurly/model/Adjustment.java
@@ -65,6 +65,9 @@ public class Adjustment extends RecurlyObject {
     @XmlElement(name = "tax_exempt")
     private Boolean taxExempt;
 
+    @XmlElement(name = "product_code")
+    private String productCode;
+
     @XmlElement(name = "start_date")
     private DateTime startDate;
 
@@ -184,6 +187,10 @@ public class Adjustment extends RecurlyObject {
         this.taxExempt = booleanOrNull(taxExempt);
     }
 
+    public String getProductCode() { return productCode; }
+
+    public void setProductCode(final Object productCode) { this.productCode = stringOrNull(productCode); }
+
     public DateTime getStartDate() {
         return startDate;
     }
@@ -233,6 +240,7 @@ public class Adjustment extends RecurlyObject {
         sb.append(", totalInCents=").append(totalInCents);
         sb.append(", currency='").append(currency).append('\'');
         sb.append(", taxable=").append(taxable);
+        sb.append(", productCode=").append(productCode);
         sb.append(", startDate=").append(startDate);
         sb.append(", endDate=").append(endDate);
         sb.append(", createdAt=").append(createdAt);
@@ -270,6 +278,9 @@ public class Adjustment extends RecurlyObject {
             return false;
         }
         if (origin != null ? !origin.equals(that.origin) : that.origin != null) {
+            return false;
+        }
+        if (productCode != null ? !productCode.equals(that.productCode) : that.productCode != null) {
             return false;
         }
         if (quantity != null ? !quantity.equals(that.quantity) : that.quantity != null) {
@@ -313,6 +324,7 @@ public class Adjustment extends RecurlyObject {
                 origin,
                 unitAmountInCents,
                 quantity,
+                productCode,
                 discountInCents,
                 taxInCents,
                 totalInCents,

--- a/src/main/java/com/ning/billing/recurly/model/Transaction.java
+++ b/src/main/java/com/ning/billing/recurly/model/Transaction.java
@@ -51,6 +51,9 @@ public class Transaction extends AbstractTransaction {
     @XmlElement(name = "recurring")
     private Boolean recurring;
 
+    @XmlElement(name = "product_code")
+    private String productCode;
+
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
@@ -132,9 +135,11 @@ public class Transaction extends AbstractTransaction {
         return recurring;
     }
 
-    public void setRecurring(final Object recurring) {
-        this.recurring = booleanOrNull(recurring);
-    }
+    public void setRecurring(final Object recurring) { this.recurring = booleanOrNull(recurring); }
+
+    public String getProductCode() { return productCode; }
+
+    public void setProductCode(final Object productCode) { this.productCode = stringOrNull(productCode); }
 
     public DateTime getCreatedAt() {
         return createdAt;
@@ -188,6 +193,7 @@ public class Transaction extends AbstractTransaction {
         sb.append(", currency='").append(currency).append('\'');
         sb.append(", description='").append(description).append('\'');
         sb.append(", recurring=").append(recurring);
+        sb.append(", productCode=").append(productCode);
         sb.append(", createdAt=").append(createdAt);
         sb.append(", details=").append(details);
         sb.append(", paymentMethod=").append(paymentMethod);
@@ -225,6 +231,9 @@ public class Transaction extends AbstractTransaction {
         if (recurring != null ? !recurring.equals(that.recurring) : that.recurring != null) {
             return false;
         }
+        if (productCode != null ? !productCode.equals(that.productCode) : that.productCode != null) {
+            return false;
+        }
         if (subscription != null ? !subscription.equals(that.subscription) : that.subscription != null) {
             return false;
         }
@@ -257,6 +266,7 @@ public class Transaction extends AbstractTransaction {
                 taxInCents,
                 currency,
                 description,
+                productCode,
                 recurring,
                 createdAt,
                 updatedAt,

--- a/src/main/java/com/ning/billing/recurly/model/Transaction.java
+++ b/src/main/java/com/ning/billing/recurly/model/Transaction.java
@@ -137,7 +137,7 @@ public class Transaction extends AbstractTransaction {
 
     public void setRecurring(final Object recurring) { this.recurring = booleanOrNull(recurring); }
 
-    public String getProductCode() { return productCode; }
+    protected String getProductCode() { return productCode; }
 
     public void setProductCode(final Object productCode) { this.productCode = stringOrNull(productCode); }
 

--- a/src/test/java/com/ning/billing/recurly/model/TestAdjustment.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAdjustment.java
@@ -39,6 +39,7 @@ public class TestAdjustment extends TestModelBase {
                                       "  <tax_in_cents type=\"integer\">0</tax_in_cents>\n" +
                                       "  <total_in_cents type=\"integer\">5000</total_in_cents>\n" +
                                       "  <currency>USD</currency>\n" +
+                                      "  <product_code>product123</product_code>\n" +
                                       "  <taxable type=\"boolean\">false</taxable>\n" +
                                       "  <start_date type=\"datetime\">2011-08-31T03:30:00Z</start_date>\n" +
                                       "  <end_date nil=\"nil\"></end_date>\n" +
@@ -58,6 +59,7 @@ public class TestAdjustment extends TestModelBase {
         Assert.assertEquals((int) adjustment.getTotalInCents(), 5000);
         Assert.assertEquals(adjustment.getCurrency(), "USD");
         Assert.assertEquals((boolean) adjustment.getTaxable(), false);
+        Assert.assertEquals(adjustment.getProductCode(), "product123");
         Assert.assertEquals(adjustment.getStartDate(), new DateTime("2011-08-31T03:30:00Z"));
         Assert.assertNull(adjustment.getEndDate());
         Assert.assertEquals(adjustment.getCreatedAt(), new DateTime("2011-08-31T03:30:00Z"));

--- a/src/test/java/com/ning/billing/recurly/model/TestTransaction.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestTransaction.java
@@ -51,7 +51,6 @@ public class TestTransaction extends TestModelBase {
                                        "  <avs_result code=\"\" nil=\"nil\"></avs_result>" +
                                        "  <avs_result_street nil=\"nil\"></avs_result_street>" +
                                        "  <avs_result_postal nil=\"nil\"></avs_result_postal>" +
-                                       "  <product_code>product123</product_code>" +
                                        "  <created_at type=\"datetime\">2015-06-19T03:01:33Z</created_at>\n" +
                                        "  <updated_at type=\"datetime\">2015-06-19T03:01:33Z</updated_at>\n" +
                                        "  <details>\n" +
@@ -88,7 +87,6 @@ public class TestTransaction extends TestModelBase {
         Assert.assertEquals(transaction.getTest(), new Boolean(true));
         Assert.assertEquals(transaction.getVoidable(), new Boolean(true));
         Assert.assertEquals(transaction.getRefundable(), new Boolean(true));
-        Assert.assertEquals(transaction.getProductCode(), "product123");
         Assert.assertNull(transaction.getIpAddress());
         Assert.assertNull(transaction.getAvsResult());
         Assert.assertNull(transaction.getAvsResultPostal());

--- a/src/test/java/com/ning/billing/recurly/model/TestTransaction.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestTransaction.java
@@ -51,6 +51,7 @@ public class TestTransaction extends TestModelBase {
                                        "  <avs_result code=\"\" nil=\"nil\"></avs_result>" +
                                        "  <avs_result_street nil=\"nil\"></avs_result_street>" +
                                        "  <avs_result_postal nil=\"nil\"></avs_result_postal>" +
+                                       "  <product_code>product123</product_code>" +
                                        "  <created_at type=\"datetime\">2015-06-19T03:01:33Z</created_at>\n" +
                                        "  <updated_at type=\"datetime\">2015-06-19T03:01:33Z</updated_at>\n" +
                                        "  <details>\n" +
@@ -87,6 +88,7 @@ public class TestTransaction extends TestModelBase {
         Assert.assertEquals(transaction.getTest(), new Boolean(true));
         Assert.assertEquals(transaction.getVoidable(), new Boolean(true));
         Assert.assertEquals(transaction.getRefundable(), new Boolean(true));
+        Assert.assertEquals(transaction.getProductCode(), "product123");
         Assert.assertNull(transaction.getIpAddress());
         Assert.assertNull(transaction.getAvsResult());
         Assert.assertNull(transaction.getAvsResultPostal());


### PR DESCRIPTION
This adds `product_code` on Transaction and Adjustment as needed for Vertex integration.