### PR TITLE
Remove X-Records parsing and add count methods

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObjects.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObjects.java
@@ -50,8 +50,6 @@ public abstract class RecurlyObjects<T extends RecurlyObject> extends ArrayList<
     @XmlTransient
     private String nextUrl;
 
-    @XmlTransient
-    private Integer nbRecords;
 
     @JsonIgnore
     <U extends RecurlyObjects> U getStart(final Class<U> clazz) {
@@ -96,16 +94,6 @@ public abstract class RecurlyObjects<T extends RecurlyObject> extends ArrayList<
     @JsonIgnore
     public void setNextUrl(final String nextUrl) {
         this.nextUrl = nextUrl;
-    }
-
-    @JsonIgnore
-    public Integer getNbRecords() {
-        return nbRecords;
-    }
-
-    @JsonIgnore
-    public void setNbRecords(final Integer nbRecords) {
-        this.nbRecords = nbRecords;
     }
 
     @Override

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -386,7 +386,6 @@ public class TestRecurlyClient {
 
         for (int i = 0; i < minNumberOfAccounts; i++) {
             // If the environment is used, we will have more than the ones we created
-            Assert.assertTrue(accounts.getNbRecords() >= minNumberOfAccounts);
             Assert.assertEquals(accounts.size(), 1);
             accountCodes.add(accounts.get(0).getAccountCode());
             if (i < minNumberOfAccounts - 1) {
@@ -1553,5 +1552,22 @@ public class TestRecurlyClient {
             recurlyClient.closeAccount(accountData.getAccountCode());
             recurlyClient.deletePlan(planData.getPlanCode());
         }
+    }
+
+    @Test(groups = "integration")
+    public void testCounts() throws Exception {
+        final QueryParams qp = new QueryParams();
+        qp.setBeginTime(new DateTime("2017-01-01T00:00:00Z"));
+
+        Integer accountCount = recurlyClient.getAccountsCount(qp);
+        Assert.assertNotNull(accountCount);
+        Integer couponsCount = recurlyClient.getCouponsCount(qp);
+        Assert.assertNotNull(couponsCount);
+        Integer transactionsCount = recurlyClient.getTransactionsCount(qp);
+        Assert.assertNotNull(transactionsCount);
+        Integer plansCount = recurlyClient.getPlansCount(qp);
+        Assert.assertNotNull(plansCount);
+        Integer giftCardsCount = recurlyClient.getGiftCardsCount(qp);
+        Assert.assertNotNull(giftCardsCount);
     }
 }


### PR DESCRIPTION
This is a new change in API version 2.6 and is going into the `api_version_2_6` branch.

We no longer return `X-Records` on every page. Instead, if you wish to get the count you must explicitly call the server with a `HEAD` request and parse the `X-Records` header.

This will be a breaking change because we no longer will support `RecurlyObjects#getNbRecords()`.

The integration tests will be healed by this: https://github.com/killbilling/recurly-java-library/pull/188