### PR TITLE
Purchases [API v2.6]

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -56,6 +56,7 @@ import com.ning.billing.recurly.model.InvoiceState;
 import com.ning.billing.recurly.model.Invoices;
 import com.ning.billing.recurly.model.Plan;
 import com.ning.billing.recurly.model.Plans;
+import com.ning.billing.recurly.model.Purchase;
 import com.ning.billing.recurly.model.RecurlyAPIError;
 import com.ning.billing.recurly.model.RecurlyObject;
 import com.ning.billing.recurly.model.RecurlyObjects;
@@ -1461,7 +1462,6 @@ public class RecurlyClient {
         return doGET(MeasuredUnits.MEASURED_UNITS_RESOURCE, MeasuredUnits.class);
     }
 
-
     /**
      * Create a MeasuredUnit's info
      * <p>
@@ -1471,6 +1471,30 @@ public class RecurlyClient {
      */
     public MeasuredUnit createMeasuredUnit(final MeasuredUnit measuredUnit) {
         return doPOST(MeasuredUnit.MEASURED_UNITS_RESOURCE, measuredUnit, MeasuredUnit.class);
+    }
+
+    /**
+     * Purchases endpoint
+     * <p>
+     * https://dev.recurly.com/docs/create-purchase
+     *
+     * @param purchase The purchase data
+     * @return The created invoice
+     */
+    public Invoice purchase(final Purchase purchase) {
+        return doPOST(Purchase.PURCHASES_ENDPOINT, purchase, Invoice.class);
+    }
+
+    /**
+     * Purchases preview endpoint
+     * <p>
+     * https://dev.recurly.com/docs/preview-purchase
+     *
+     * @param purchase The purchase data
+     * @return The preview invoice
+     */
+    public Invoice previewPurchase(final Purchase purchase) {
+        return doPOST(Purchase.PURCHASES_ENDPOINT + "/preview", purchase, Invoice.class);
     }
 
     private <T> T fetch(final String recurlyToken, final Class<T> clazz) {

--- a/src/main/java/com/ning/billing/recurly/model/Purchase.java
+++ b/src/main/java/com/ning/billing/recurly/model/Purchase.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+import com.google.common.base.Objects;
+
+@XmlRootElement(name = "purchase")
+public class Purchase extends RecurlyObject {
+    @XmlTransient
+    public static final String PURCHASES_ENDPOINT = "/purchases";
+
+    @XmlElement(name = "currency")
+    private String currency;
+
+    @XmlElement(name = "collection_method")
+    private String collectionMethod;
+
+    @XmlElement(name = "po_number")
+    private String poNumber;
+
+    @XmlElement(name = "terms")
+    private String terms;
+
+    @XmlElement(name = "account")
+    private Account account;
+
+    @XmlElementWrapper(name = "adjustments")
+    @XmlElement(name = "adjustment")
+    private Adjustments adjustments;
+
+    public void setAccount(final Account account) {
+        this.account = account;
+    }
+
+    public Account getAccount() {
+        return account;
+    }
+
+    public void setAdjustments(final Adjustments adjustments) {
+        this.adjustments = adjustments;
+    }
+
+    public Adjustments getAdjustments() {
+        return adjustments;
+    }
+
+    public String getCollectionMethod() {
+        return collectionMethod;
+    }
+
+    public void setCollectionMethod(final Object collectionMethod) {
+        this.collectionMethod = stringOrNull(collectionMethod);
+    }
+
+    public String getTerms() {
+        return terms;
+    }
+
+    public void setTerms(final Object terms) {
+        this.terms = stringOrNull(terms);
+    }
+
+    public String getPoNumber() {
+        return poNumber;
+    }
+
+    public void setPoNumber(final Object poNumber) {
+        this.poNumber = stringOrNull(poNumber);
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(final Object currency) {
+        this.currency = stringOrNull(currency);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("Purchase");
+        sb.append("{account=").append(account);
+        sb.append(", adjustments=").append(adjustments);
+        sb.append(", collectionMethod='").append(collectionMethod).append('\'');
+        sb.append(", currency='").append(currency).append('\'');
+        sb.append(", poNumber='").append(poNumber).append('\'');
+        sb.append(", terms='").append(terms).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final Purchase purchase = (Purchase) o;
+
+        if (account != null ? !account.equals(purchase.account) : purchase.account != null) {
+            return false;
+        }
+        if (adjustments != null ? !adjustments.equals(purchase.adjustments) : purchase.adjustments != null) {
+            return false;
+        }
+        if (collectionMethod != null ? !collectionMethod.equals(purchase.collectionMethod) : purchase.collectionMethod != null) {
+            return false;
+        }
+        if (currency != null ? !currency.equals(purchase.currency) : purchase.currency != null) {
+            return false;
+        }
+        if (poNumber != null ? !poNumber.equals(purchase.poNumber) : purchase.poNumber != null) {
+            return false;
+        }
+        if (terms != null ? !terms.equals(purchase.terms) : purchase.terms != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(
+                account,
+                adjustments,
+                collectionMethod,
+                currency,
+                poNumber,
+                terms
+        );
+    }
+
+}
+
+

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -18,30 +18,29 @@
 package com.ning.billing.recurly;
 
 import java.util.Random;
-
-import com.ning.billing.recurly.model.Adjustment;
-import com.ning.billing.recurly.model.Adjustments;
-import com.ning.billing.recurly.model.Delivery;
-import com.ning.billing.recurly.model.GiftCard;
-import com.ning.billing.recurly.model.Invoice;
-import com.ning.billing.recurly.model.Redemption;
-import com.ning.billing.recurly.model.ShippingAddress;
-import com.ning.billing.recurly.model.Transactions;
-import com.ning.billing.recurly.model.Usage;
 import org.joda.time.DateTime;
-
 import com.ning.billing.recurly.model.Account;
 import com.ning.billing.recurly.model.AddOn;
 import com.ning.billing.recurly.model.Address;
 import com.ning.billing.recurly.model.BillingInfo;
 import com.ning.billing.recurly.model.Coupon;
+import com.ning.billing.recurly.model.Adjustment;
+import com.ning.billing.recurly.model.Adjustments;
+import com.ning.billing.recurly.model.Delivery;
+import com.ning.billing.recurly.model.GiftCard;
+import com.ning.billing.recurly.model.Invoice;
+import com.ning.billing.recurly.model.MeasuredUnit;
 import com.ning.billing.recurly.model.Plan;
+import com.ning.billing.recurly.model.Purchase;
 import com.ning.billing.recurly.model.RecurlyUnitCurrency;
+import com.ning.billing.recurly.model.Redemption;
+import com.ning.billing.recurly.model.ShippingAddress;
 import com.ning.billing.recurly.model.Subscription;
 import com.ning.billing.recurly.model.SubscriptionAddOn;
 import com.ning.billing.recurly.model.SubscriptionAddOns;
 import com.ning.billing.recurly.model.Transaction;
-import com.ning.billing.recurly.model.MeasuredUnit;
+import com.ning.billing.recurly.model.Transactions;
+import com.ning.billing.recurly.model.Usage;
 
 public class TestUtils {
 
@@ -332,6 +331,15 @@ public class TestUtils {
     }
 
     /**
+     * Creates a random {@link com.ning.billing.recurly.model.Adjustment} object for testing use
+     *
+     * @return The random {@link com.ning.billing.recurly.model.Adjustment} object
+     */
+    public static Adjustment createRandomAdjustment() {
+        return createRandomAdjustment(randomSeed());
+    }
+
+    /**
      * Creates a random {@link com.ning.billing.recurly.model.Adjustment} object for testing use given a seed
      *
      * @param seed The RNG seed
@@ -340,25 +348,16 @@ public class TestUtils {
     public static Adjustment createRandomAdjustment(final int seed) {
         final Adjustment adjustment = new Adjustment();
 
-        adjustment.setAccount(createRandomAccount(seed));
-        adjustment.setUuid(randomAlphaNumericString(20, seed));
         adjustment.setDescription(randomAlphaNumericString(50, seed));
         adjustment.setAccountingCode(randomAlphaNumericString(10, seed));
-        adjustment.setOrigin(randomAlphaNumericString(10, seed));
         adjustment.setUnitAmountInCents(randomInteger(1000, seed));
         adjustment.setQuantity(1 + randomInteger(10, seed));
-        adjustment.setDiscountInCents(randomInteger(1000, seed));
-        adjustment.setTaxInCents(randomInteger(1000, seed));
-        adjustment.setTotalInCents(randomInteger(1000, seed));
         adjustment.setCurrency(randomCurrency(seed));
-        adjustment.setTaxable(true);
         adjustment.setStartDate(NOW);
         adjustment.setStartDate(TOMORROW);
-        adjustment.setCreatedAt(NOW);
 
         return adjustment;
     }
-
 
     /**
      * Creates a random {@link com.ning.billing.recurly.model.BillingInfo} object for testing use.
@@ -851,7 +850,6 @@ public class TestUtils {
         return giftCardData;
     }
 
-
     /**
      * Creates a random {@link Usage} object for use in Tests
      *
@@ -894,5 +892,37 @@ public class TestUtils {
         measuredUnit.setDescription(randomAlphaNumericString(50, seed));
 
         return measuredUnit;
+    }
+
+    /**
+     * Creates a random {@link Purchase} object for use in Tests
+     *
+     * @return The random {@link Purchase} object
+     */
+    public static Purchase createRandomPurchase() {
+        return createRandomPurchase(randomSeed());
+    }
+
+    /**
+     * Creates a random {@link Purchase} object for use in Tests given a seed
+     *
+     * @param seed The RNG seed
+     * @return The random {@link Purchase} object
+     */
+    public static Purchase createRandomPurchase(final int seed) {
+        final Purchase purchase = new Purchase();
+
+        purchase.setAccount(createRandomAccount(seed));
+
+        Adjustments adjustments = new Adjustments();
+        adjustments.add(createRandomAdjustment(seed));
+        purchase.setAdjustments(adjustments);
+
+        purchase.setCurrency("USD");
+        purchase.setCollectionMethod("automatic");
+        purchase.setPoNumber("PO12345");
+        purchase.setTerms(30);
+
+        return purchase;
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.ning.billing.recurly.TestUtils;
+import org.joda.time.DateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+public class TestPurchase extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testSerialization() throws Exception {
+        final String purchaseData = "<purchase xmlns=\"\">" +
+                "<currency>USD</currency>" +
+                "  <collection_method>automatic</collection_method>" +
+                "  <account>" +
+                "    <account_code>test</account_code>" +
+                "    <billing_info>" +
+                "      <first_name>Benjamin</first_name>" +
+                "      <last_name>Du Monde</last_name>" +
+                "      <address1>400 Alabama St</address1>" +
+                "      <city>San Francisco</city>" +
+                "      <state>CA</state>" +
+                "      <zip>94110</zip>" +
+                "      <country>US</country>" +
+                "      <year>2019</year>" +
+                "      <month>12</month>" +
+                "      <number>4000-0000-0000-0000</number>" +
+                "    </billing_info>" +
+                "  </account>" +
+                "  <adjustments>" +
+                "    <adjustment>" +
+                "      <unit_amount_in_cents>1000</unit_amount_in_cents>" +
+                "      <quantity>1</quantity>" +
+                "      <currency>USD</currency>" +
+                "      <product_code>product-code</product_code>" +
+                "    </adjustment>" +
+                "  </adjustments>" +
+                "</purchase>";
+
+        final Purchase purchase = new Purchase();
+        purchase.setCollectionMethod("automatic");
+        purchase.setCurrency("USD");
+
+        final Account account = new Account();
+        account.setAccountCode("test");
+
+        final BillingInfo billingInfo = new BillingInfo();
+        billingInfo.setAddress1("400 Alabama St");
+        billingInfo.setCity("San Francisco");
+        billingInfo.setCountry("US");
+        billingInfo.setFirstName("Benjamin");
+        billingInfo.setLastName("Du Monde");
+        billingInfo.setMonth(12);
+        billingInfo.setNumber("4000-0000-0000-0000");
+        billingInfo.setState("CA");
+        billingInfo.setYear(2019);
+        billingInfo.setZip("94110");
+        account.setBillingInfo(billingInfo);
+
+        final Adjustments adjustments = new Adjustments();
+        final Adjustment adjustment = new Adjustment();
+        adjustment.setCurrency("USD");
+        adjustment.setProductCode("product-code");
+        adjustment.setQuantity(1);
+        adjustment.setUnitAmountInCents(1000);
+        adjustments.add(adjustment);
+
+        purchase.setAccount(account);
+        purchase.setAdjustments(adjustments);
+
+        final String xml = xmlMapper.writeValueAsString(purchase);
+        final Purchase purchaseExpected = xmlMapper.readValue(xml, Purchase.class);
+
+        assertEquals(purchase, purchaseExpected);
+    }
+
+    @Test(groups = "fast")
+    public void testHashCodeAndEquality() throws Exception {
+        // create purchase of the same value but difference references
+        final Purchase purchase = TestUtils.createRandomPurchase(0);
+        final Purchase otherPurchase = TestUtils.createRandomPurchase(0);
+
+        assertNotEquals(System.identityHashCode(purchase), System.identityHashCode(otherPurchase));
+        assertEquals(purchase.hashCode(), otherPurchase.hashCode());
+        assertEquals(purchase, otherPurchase);
+    }
+}


### PR DESCRIPTION
Another 2.6 change. The `/purchases` endpoint allows you to build up a bunch of resources to send all at once and returns a new `Invoice`. For now we are just supporting `Account` (new or existing) and a list of `Adjusments`. In 2.7 we will add support for multiple `Subscriptions`, `GiftCards`, and `Coupons`. 