### PR TITLE
Add vat_number to Account

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Account.java
+++ b/src/main/java/com/ning/billing/recurly/model/Account.java
@@ -114,6 +114,9 @@ public class Account extends RecurlyObject {
     @XmlElement(name = "has_past_due_invoice")
     private Boolean hasPastDueInvoice;
 
+    @XmlElement(name = "vat_number")
+    private String vatNumber;
+
     @Override
     public void setHref(final Object href) {
         super.setHref(href);
@@ -320,6 +323,14 @@ public class Account extends RecurlyObject {
         this.shippingAddresses = shippingAddresses;
     }
 
+    public String getVatNumber() {
+        return vatNumber;
+    }
+
+    public void setVatNumber(final Object vatNumber) {
+        this.vatNumber = stringOrNull(vatNumber);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("Account{");
@@ -348,6 +359,7 @@ public class Account extends RecurlyObject {
         sb.append(", hasFutureSubscription=").append(hasFutureSubscription);
         sb.append(", hasCanceledSubscription=").append(hasCanceledSubscription);
         sb.append(", hasPastDueInvoice=").append(hasPastDueInvoice);
+        sb.append(", vatNumber=").append(vatNumber);
         sb.append('}');
         return sb.toString();
     }
@@ -431,6 +443,9 @@ public class Account extends RecurlyObject {
         if (shippingAddresses != null ? !shippingAddresses.equals(account.shippingAddresses) : account.shippingAddresses != null) {
             return false;
         }
+        if (vatNumber != null ? !vatNumber.equals(account.vatNumber) : account.vatNumber != null) {
+            return false;
+        }
 
         return true;
     }
@@ -462,7 +477,8 @@ public class Account extends RecurlyObject {
                 billingInfo,
                 updatedAt,
                 taxExempt,
-                shippingAddresses
+                shippingAddresses,
+                vatNumber
         );
     }
 }

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -262,6 +262,7 @@ public class TestUtils {
         account.setFirstName(randomAlphaNumericString(5, seed));
         account.setLastName(randomAlphaNumericString(6, seed));
         account.setAddress(createRandomAddress(seed));
+        account.setVatNumber(randomAlphaNumericString(15, seed));
 
         return account;
     }

--- a/src/test/java/com/ning/billing/recurly/model/TestAccount.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccount.java
@@ -53,6 +53,7 @@ public class TestAccount extends TestModelBase {
                                    "  <has_future_subscription type=\"boolean\">false</has_future_subscription>\n" +
                                    "  <has_canceled_subscription type=\"boolean\">false</has_canceled_subscription>\n" +
                                    "  <has_past_due_invoice type=\"boolean\">false</has_past_due_invoice>\n" +
+                                   "  <vat_number>U12345678</vat_number>\n" +
                                    "  <address>\n" +
                                    "      <address1>123 Main St.</address1>\n" +
                                    "      <address2 nil=\"nil\"></address2>\n" +
@@ -109,6 +110,7 @@ public class TestAccount extends TestModelBase {
         Assert.assertFalse(account.getHasFutureSubscription());
         Assert.assertFalse(account.getHasCanceledSubscription());
         Assert.assertFalse(account.getHasPastDueInvoice());
+        Assert.assertEquals(account.getVatNumber(), "U12345678");
     }
 
 }


### PR DESCRIPTION
Resolves #193 

It looks like the `vat_number` field was never added to the `Account` model. This adds that field to the model and tests.