### PR TITLE
Change travis profile to run all test groups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.11</version>
                         <configuration>
-                            <groups>fast</groups>
+                            <groups>integration,fast,enterprise</groups>
                             <systemPropertyVariables>
                                 <file.encoding>UTF-8</file.encoding>
                                 <user.timezone>GMT</user.timezone>

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -1,5 +1,5 @@
 if [ -z "$API_KEY" ]; then
   mvn clean test
 else
-  mvn clean test -Pintegration -Dkillbill.payment.recurly.apiKey=$API_KEY -Dkillbill.payment.recurly.subDomain=$SUBDOMAIN
+  mvn clean test -Ptravis -Dkillbill.payment.recurly.apiKey=$API_KEY -Dkillbill.payment.recurly.subDomain=$SUBDOMAIN
 fi


### PR DESCRIPTION
It seems that for repo owners (@pierre and myself), travis was only running the integration group. This makes sure we run every test group in travis when the keys are available to do so.