### PR TITLE
API Version 2.6 Changes

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -99,7 +99,7 @@ public class RecurlyClient {
     private static final Logger log = LoggerFactory.getLogger(RecurlyClient.class);
 
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
-    public static final String RECURLY_API_VERSION = "2.5";
+    public static final String RECURLY_API_VERSION = "2.6";
 
     private static final String X_RECORDS_HEADER_NAME = "X-Records";
     private static final String LINK_HEADER_NAME = "Link";

--- a/src/main/java/com/ning/billing/recurly/model/Purchase.java
+++ b/src/main/java/com/ning/billing/recurly/model/Purchase.java
@@ -38,8 +38,8 @@ public class Purchase extends RecurlyObject {
     @XmlElement(name = "po_number")
     private String poNumber;
 
-    @XmlElement(name = "terms")
-    private String terms;
+    @XmlElement(name = "net_terms")
+    private String netTerms;
 
     @XmlElement(name = "account")
     private Account account;
@@ -72,12 +72,12 @@ public class Purchase extends RecurlyObject {
         this.collectionMethod = stringOrNull(collectionMethod);
     }
 
-    public String getTerms() {
-        return terms;
+    public String getNetTerms() {
+        return netTerms;
     }
 
-    public void setTerms(final Object terms) {
-        this.terms = stringOrNull(terms);
+    public void setNetTerms(final Object terms) {
+        this.netTerms = stringOrNull(terms);
     }
 
     public String getPoNumber() {
@@ -105,7 +105,7 @@ public class Purchase extends RecurlyObject {
         sb.append(", collectionMethod='").append(collectionMethod).append('\'');
         sb.append(", currency='").append(currency).append('\'');
         sb.append(", poNumber='").append(poNumber).append('\'');
-        sb.append(", terms='").append(terms).append('\'');
+        sb.append(", netTerms='").append(netTerms).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -132,7 +132,7 @@ public class Purchase extends RecurlyObject {
         if (poNumber != null ? !poNumber.equals(purchase.poNumber) : purchase.poNumber != null) {
             return false;
         }
-        if (terms != null ? !terms.equals(purchase.terms) : purchase.terms != null) {
+        if (netTerms != null ? !netTerms.equals(purchase.netTerms) : purchase.netTerms != null) {
             return false;
         }
 
@@ -147,7 +147,7 @@ public class Purchase extends RecurlyObject {
                 collectionMethod,
                 currency,
                 poNumber,
-                terms
+                netTerms
         );
     }
 

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObjects.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObjects.java
@@ -50,8 +50,6 @@ public abstract class RecurlyObjects<T extends RecurlyObject> extends ArrayList<
     @XmlTransient
     private String nextUrl;
 
-    @XmlTransient
-    private Integer nbRecords;
 
     @JsonIgnore
     <U extends RecurlyObjects> U getStart(final Class<U> clazz) {
@@ -96,16 +94,6 @@ public abstract class RecurlyObjects<T extends RecurlyObject> extends ArrayList<
     @JsonIgnore
     public void setNextUrl(final String nextUrl) {
         this.nextUrl = nextUrl;
-    }
-
-    @JsonIgnore
-    public Integer getNbRecords() {
-        return nbRecords;
-    }
-
-    @JsonIgnore
-    public void setNbRecords(final Integer nbRecords) {
-        this.nbRecords = nbRecords;
     }
 
     @Override

--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -142,6 +142,9 @@ public class Subscription extends AbstractSubscription {
     @XmlElement(name = "shipping_address_id")
     private Long shippingAddressId;
 
+    @XmlElement(name = "no_billing_info_reason")
+    public String noBillingInfoReason;
+
     public Account getAccount() {
         if (account != null && account.getHref() != null && !account.getHref().isEmpty()) {
             account = fetch(account, Account.class);
@@ -422,6 +425,14 @@ public class Subscription extends AbstractSubscription {
         this.convertedAt = dateTimeOrNull(convertedAt);
     }
 
+    public String getNoBillingInfoReason() {
+        return this.noBillingInfoReason;
+    }
+
+    public void setNoBillingInfoReason(final Object noBillingInfoReason) {
+        this.noBillingInfoReason = stringOrNull(noBillingInfoReason);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -459,6 +470,7 @@ public class Subscription extends AbstractSubscription {
         sb.append(", shippingAddressId=").append(shippingAddressId);
         sb.append(", startedWithGift=").append(startedWithGift);
         sb.append(", convertedAt=").append(convertedAt);
+        sb.append(", noBillingInfoReason=").append(noBillingInfoReason);
         sb.append('}');
         return sb.toString();
     }
@@ -572,6 +584,9 @@ public class Subscription extends AbstractSubscription {
         if (shippingAddressId != null ? !shippingAddressId.equals(that.shippingAddressId) : that.shippingAddressId != null) {
             return false;
         }
+        if (noBillingInfoReason != null ? !noBillingInfoReason.equals(that.noBillingInfoReason) : that.noBillingInfoReason != null) {
+            return false;
+        }
 
         return true;
     }
@@ -612,7 +627,8 @@ public class Subscription extends AbstractSubscription {
                 couponCode,
                 couponCodes,
                 convertedAt,
-                startedWithGift
+                startedWithGift,
+                noBillingInfoReason
         );
     }
 

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -386,7 +386,6 @@ public class TestRecurlyClient {
 
         for (int i = 0; i < minNumberOfAccounts; i++) {
             // If the environment is used, we will have more than the ones we created
-            Assert.assertTrue(accounts.getNbRecords() >= minNumberOfAccounts);
             Assert.assertEquals(accounts.size(), 1);
             accountCodes.add(accounts.get(0).getAccountCode());
             if (i < minNumberOfAccounts - 1) {
@@ -1553,5 +1552,22 @@ public class TestRecurlyClient {
             recurlyClient.closeAccount(accountData.getAccountCode());
             recurlyClient.deletePlan(planData.getPlanCode());
         }
+    }
+
+    @Test(groups = "integration")
+    public void testCounts() throws Exception {
+        final QueryParams qp = new QueryParams();
+        qp.setBeginTime(new DateTime("2017-01-01T00:00:00Z"));
+
+        Integer accountCount = recurlyClient.getAccountsCount(qp);
+        Assert.assertNotNull(accountCount);
+        Integer couponsCount = recurlyClient.getCouponsCount(qp);
+        Assert.assertNotNull(couponsCount);
+        Integer transactionsCount = recurlyClient.getTransactionsCount(qp);
+        Assert.assertNotNull(transactionsCount);
+        Integer plansCount = recurlyClient.getPlansCount(qp);
+        Assert.assertNotNull(plansCount);
+        Integer giftCardsCount = recurlyClient.getGiftCardsCount(qp);
+        Assert.assertNotNull(giftCardsCount);
     }
 }

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -921,7 +921,7 @@ public class TestUtils {
         purchase.setCurrency("USD");
         purchase.setCollectionMethod("automatic");
         purchase.setPoNumber("PO12345");
-        purchase.setTerms(30);
+        purchase.setNetTerms(30);
 
         return purchase;
     }

--- a/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
@@ -32,6 +32,8 @@ public class TestPurchase extends TestModelBase {
         final String purchaseData = "<purchase xmlns=\"\">" +
                 "<currency>USD</currency>" +
                 "  <collection_method>automatic</collection_method>" +
+                "  <net_terms>30</net_terms>" +
+                "  <currency>USD</currency>" +
                 "  <account>" +
                 "    <account_code>test</account_code>" +
                 "    <billing_info>" +
@@ -60,6 +62,7 @@ public class TestPurchase extends TestModelBase {
         final Purchase purchase = new Purchase();
         purchase.setCollectionMethod("automatic");
         purchase.setCurrency("USD");
+        purchase.setNetTerms(30);
 
         final Account account = new Account();
         account.setAccountCode("test");

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -68,6 +68,7 @@ public class TestSubscription extends TestModelBase {
                                         "  <first_renewal_date type=\"datetime\">2011-07-01T07:00:00Z</first_renewal_date>\n" +
                                         "  <started_with_gift type=\"boolean\">true</started_with_gift>\n" +
                                         "  <converted_at type=\"datetime\">2017-06-27T00:00:00Z</converted_at>" +
+                                        "  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>" +
                                         "  <subscription_add_ons type=\"array\">\n" +
                                         "  </subscription_add_ons>\n" +
                                         "  <coupon_codes type=\"array\">\n" +
@@ -130,6 +131,7 @@ public class TestSubscription extends TestModelBase {
                                         "  <revenue_schedule_type>evenly</revenue_schedule_type>\n" +
                                         "  <started_with_gift type=\"boolean\">true</started_with_gift>\n" +
                                         "  <converted_at type=\"datetime\">2017-06-27T00:00:00Z</converted_at>" +
+                                        "  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>" +
                                         "  <subscription_add_ons type=\"array\">\n" +
                                         "    <subscription_add_on>\n" +
                                         "      <add_on_code>extra_users</add_on_code>\n" +
@@ -235,6 +237,7 @@ public class TestSubscription extends TestModelBase {
         Assert.assertEquals(subscription.getTaxRate(), new BigDecimal("0.0875"));
         Assert.assertEquals(subscription.getConvertedAt(), new DateTime("2017-06-27T00:00:00Z"));
         Assert.assertTrue(subscription.getStartedWithGift());
+        Assert.assertEquals(subscription.getNoBillingInfoReason(), "plan_free_trial");
 
         return subscription;
     }


### PR DESCRIPTION
Here we have all the changes required to get master up to API Version 2.6. Note that there are 2 breaking changes:

1. `RecurlyObjects#getNbRecords` is not longer supported. We removed the X-Records header from the pagination responses which greatly improves response times. https://github.com/killbilling/recurly-java-library/commit/50dfa32778af4fb6ba214a14515801e7a47ca0b7#diff-eab0eaf4b89b6e014e97fb7ca9d7fd4dL102
2. For `POST /v2/subscriptions` Sending `null` for `total_billing_cycles` attribute will now override plan `total_billing_cycles` setting and will make subscription renew forever.  Omitting the attribute will cause the setting to default to the value of plan `total_billing_cycles`.

### Changelog

- Changed Plan request/response:
  - Added `<trial_requires_billing_info>` element.
- Changed Subscription response:
  - Added `<no_billing_info_reason>` element.
- Added `POST /v2/purchases`
- Added `POST /v2/purchases/preview`
- Changed Subscription behavior
  - For `POST /v2/subscriptions`
    Sending NULL for `total_billing_cycles` attribute
    will now override plan `total_billing_cycles` setting
    and will make subscription renew forever.  Omitting
    the attribute will cause the setting to default to
    the value of plan `total_billing_cycles`