### PR TITLE
Add coupon_code to SubscriptionUpdate

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
@@ -54,6 +54,17 @@ public class SubscriptionUpdate extends AbstractSubscription {
         this.collectionMethod = stringOrNull(collectionMethod);
     }
 
+    @XmlElement(name = "coupon_code")
+    private String couponCode;
+
+    public String getCouponCode() {
+        return couponCode;
+    }
+
+    public void setCouponCode(String couponCode) {
+        this.couponCode = couponCode;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
@@ -67,6 +78,9 @@ public class SubscriptionUpdate extends AbstractSubscription {
         if (timeframe != that.timeframe) {
             return false;
         }
+        if (couponCode != null ? !couponCode.equals(that.couponCode) : that.couponCode != null) {
+            return false;
+        }
 
         return true;
     }
@@ -75,6 +89,7 @@ public class SubscriptionUpdate extends AbstractSubscription {
     public int hashCode() {
         return Objects.hashCode(
                 timeframe,
+                couponCode,
                 collectionMethod
         );
     }

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
@@ -109,4 +109,23 @@ public class TestSubscriptionUpdate extends TestModelBase {
                                  "<plan_code>gold</plan_code>" +
                                  "</subscription>");
     }
+
+    @Test(groups = "fast")
+    public void testSerializationWithCoupons() throws Exception {
+        final SubscriptionUpdate subscription = new SubscriptionUpdate();
+        subscription.setPlanCode("gold");
+        subscription.setTimeframe(SubscriptionUpdate.Timeframe.now);
+        subscription.setUnitAmountInCents(800);
+        subscription.setQuantity(1);
+        subscription.setCouponCode("my_coupon");
+
+        final String xml = xmlMapper.writeValueAsString(subscription);
+        Assert.assertEquals(xml, "<subscription xmlns=\"\">" +
+                                 "<timeframe>now</timeframe>" +
+                                 "<unit_amount_in_cents>800</unit_amount_in_cents>" +
+                                 "<quantity>1</quantity>" +
+                                 "<plan_code>gold</plan_code>" +
+                                 "<coupon_code>my_coupon</coupon_code>" +
+                                 "</subscription>");
+    }
 }


### PR DESCRIPTION
Currently, there is no way to add a coupon when updating a subscription. In order to transfer to a subscription with a coupon, users need to terminate the existing subscription and create a new one.

This PR adds the field for the supported coupon_code attribute on subscription updates.