### PR TITLE
Fix revenue schedule type xml serialization and deserialization

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/AddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/AddOn.java
@@ -85,8 +85,8 @@ public class AddOn extends AbstractAddOn {
         return revenueScheduleType;
     }
 
-    public void setRevenueScheduleType(final String revenueScheduleType) {
-        this.revenueScheduleType = RevenueScheduleType.valueOf(revenueScheduleType.toUpperCase());
+    public void setRevenueScheduleType(final RevenueScheduleType revenueScheduleType) {
+        this.revenueScheduleType = revenueScheduleType;
     }
 
     public RecurlyUnitCurrency getUnitAmountInCents() {

--- a/src/main/java/com/ning/billing/recurly/model/Adjustment.java
+++ b/src/main/java/com/ning/billing/recurly/model/Adjustment.java
@@ -238,7 +238,7 @@ public class Adjustment extends RecurlyObject {
         return revenueScheduleType;
     }
 
-    public void setRevenueScheduleType(RevenueScheduleType revenueScheduleType) {
+    public void setRevenueScheduleType(final RevenueScheduleType revenueScheduleType) {
         this.revenueScheduleType = revenueScheduleType;
     }
 

--- a/src/main/java/com/ning/billing/recurly/model/Adjustment.java
+++ b/src/main/java/com/ning/billing/recurly/model/Adjustment.java
@@ -238,8 +238,8 @@ public class Adjustment extends RecurlyObject {
         return revenueScheduleType;
     }
 
-    public void setRevenueScheduleType(String revenueScheduleType) {
-        this.revenueScheduleType = RevenueScheduleType.valueOf(revenueScheduleType.toUpperCase());
+    public void setRevenueScheduleType(RevenueScheduleType revenueScheduleType) {
+        this.revenueScheduleType = revenueScheduleType;
     }
 
     @Override
@@ -264,6 +264,7 @@ public class Adjustment extends RecurlyObject {
         sb.append(", endDate=").append(endDate);
         sb.append(", createdAt=").append(createdAt);
         sb.append(", updatedAt=").append(updatedAt);
+        sb.append(", revenueScheduleType=").append(revenueScheduleType);
         sb.append('}');
         return sb.toString();
     }
@@ -330,6 +331,10 @@ public class Adjustment extends RecurlyObject {
             return false;
         }
 
+        if (revenueScheduleType != null ? !revenueScheduleType.equals(that.revenueScheduleType) : that.revenueScheduleType != null) {
+            return false;
+        }
+
         return true;
     }
 
@@ -353,7 +358,8 @@ public class Adjustment extends RecurlyObject {
                 startDate,
                 endDate,
                 createdAt,
-                updatedAt
+                updatedAt,
+                revenueScheduleType
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Plan.java
+++ b/src/main/java/com/ning/billing/recurly/model/Plan.java
@@ -273,8 +273,8 @@ public class Plan extends RecurlyObject {
         return setupFeeRevenueScheduleType;
     }
 
-    public void setSetupFeeRevenueScheduleType(final String setupFeeRevenueScheduleType) {
-        this.setupFeeRevenueScheduleType = RevenueScheduleType.valueOf(setupFeeRevenueScheduleType.toUpperCase());
+    public void setSetupFeeRevenueScheduleType(final RevenueScheduleType setupFeeRevenueScheduleType) {
+        this.setupFeeRevenueScheduleType = revenueScheduleType;
     }
 
     public RevenueScheduleType getRevenueScheduleType() {

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlTransient;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import org.joda.time.DateTime;
 
 import com.ning.billing.recurly.RecurlyClient;
@@ -78,6 +79,7 @@ public abstract class RecurlyObject {
         xmlMapper.registerModule(new JodaModule());
         xmlMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         xmlMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        xmlMapper.registerModule(new JaxbAnnotationModule());
 
         final SimpleModule m = new SimpleModule("module", new Version(1, 0, 0, null, null, null));
         m.addSerializer(Accounts.class, new RecurlyObjectsSerializer<Accounts, Account>(Accounts.class, "account"));

--- a/src/main/java/com/ning/billing/recurly/model/RevenueScheduleType.java
+++ b/src/main/java/com/ning/billing/recurly/model/RevenueScheduleType.java
@@ -22,27 +22,13 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @XmlEnum(String.class)
 public enum RevenueScheduleType {
     @XmlEnumValue("never")
-    NEVER("never"),
+    NEVER,
     @XmlEnumValue("evenly")
-    EVENLY("evenly"),
+    EVENLY,
     @XmlEnumValue("at_invoice")
-    AT_INVOICE("at_invoice"),
+    AT_INVOICE,
     @XmlEnumValue("at_range_end")
-    AT_RANGE_END("at_range_end"),
+    AT_RANGE_END,
     @XmlEnumValue("at_range_start")
-    AT_RANGE_START("at_range_start");
-
-    private final String type;
-
-    private RevenueScheduleType(final String type) {
-        this.type = type;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public static RevenueScheduleType from(String revenueScheduleType) {
-        return revenueScheduleType != null ? valueOf(revenueScheduleType.toUpperCase()) : null;
-    }
+    AT_RANGE_START
 }

--- a/src/main/java/com/ning/billing/recurly/model/RevenueScheduleType.java
+++ b/src/main/java/com/ning/billing/recurly/model/RevenueScheduleType.java
@@ -16,11 +16,20 @@
  */
 package com.ning.billing.recurly.model;
 
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+
+@XmlEnum(String.class)
 public enum RevenueScheduleType {
+    @XmlEnumValue("never")
     NEVER("never"),
+    @XmlEnumValue("evenly")
     EVENLY("evenly"),
+    @XmlEnumValue("at_invoice")
     AT_INVOICE("at_invoice"),
+    @XmlEnumValue("at_range_end")
     AT_RANGE_END("at_range_end"),
+    @XmlEnumValue("at_range_start")
     AT_RANGE_START("at_range_start");
 
     private final String type;
@@ -31,5 +40,9 @@ public enum RevenueScheduleType {
 
     public String getType() {
         return type;
+    }
+
+    public static RevenueScheduleType from(String revenueScheduleType) {
+        return revenueScheduleType != null ? valueOf(revenueScheduleType.toUpperCase()) : null;
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -379,10 +379,8 @@ public class Subscription extends AbstractSubscription {
         return revenueScheduleType;
     }
 
-    public void setRevenueScheduleType(final String revenueScheduleType) {
-        if (revenueScheduleType != null) {
-            this.revenueScheduleType = RevenueScheduleType.valueOf(revenueScheduleType.toUpperCase());
-        }
+    public void setRevenueScheduleType(final RevenueScheduleType revenueScheduleType) {
+        this.revenueScheduleType = revenueScheduleType;
     }
 
     public GiftCard getGiftCard() {

--- a/src/test/java/com/ning/billing/recurly/model/TestRevenueScheduleType.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestRevenueScheduleType.java
@@ -21,7 +21,7 @@ public class TestRevenueScheduleType extends TestModelBase {
     @Test(groups = "fast")
     public void testDeserializationAllValues() throws Exception {
         for (RevenueScheduleType revenueScheduleType : RevenueScheduleType.values()) {
-            testDeserializationCommon(revenueScheduleType, revenueScheduleType.name().toLowerCase());
+            testDeserializationCommon(revenueScheduleType.name().toLowerCase(), revenueScheduleType);
         }
     }
 
@@ -66,16 +66,16 @@ public class TestRevenueScheduleType extends TestModelBase {
         Adjustment adjustment = TestUtils.createRandomAdjustment();
         adjustment.setRevenueScheduleType(revenueScheduleType);
         String xml = xmlMapper.writeValueAsString(adjustment);
-        assert(xml.contains("<revenue_schedule_type>"+ expectedSerializedValue +"</revenue_schedule_type>"));
+        assert(xml.contains("<revenue_schedule_type>" + expectedSerializedValue + "</revenue_schedule_type>"));
     }
 
-     private void testDeserializationCommon(RevenueScheduleType revenueScheduleType, String value) throws Exception {
+     private void testDeserializationCommon(String value, RevenueScheduleType expectedRevenueScheduleType) throws Exception {
         String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                       "<adjustment type=\"credit\" href=\"https://api.recurly.com/v2/adjustments/626db120a84102b1809909071c701c60\">\n" +
                                         "<revenue_schedule_type>" + value + "</revenue_schedule_type>\n" +
                                       "</adjustment>";
 
         Adjustment adjustment = xmlMapper.readValue(xml, Adjustment.class);
-        assertEquals(adjustment.getRevenueScheduleType(), revenueScheduleType);
+        assertEquals(adjustment.getRevenueScheduleType(), expectedRevenueScheduleType);
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestRevenueScheduleType.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestRevenueScheduleType.java
@@ -1,0 +1,63 @@
+package com.ning.billing.recurly.model;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.ning.billing.recurly.TestUtils;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+public class TestRevenueScheduleType extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testSerializationAllValues() throws Exception {
+        for (RevenueScheduleType revenueScheduleType : RevenueScheduleType.values()) {
+            testSerializationCommon(revenueScheduleType, revenueScheduleType.name().toLowerCase());
+        }
+    }
+
+    @Test(groups = "fast")
+    public void testSerializationNullValue() throws Exception {
+        Adjustment adjustment = TestUtils.createRandomAdjustment();
+        adjustment.setRevenueScheduleType(null);
+        String xml = xmlMapper.writeValueAsString(adjustment);
+        assert(!xml.contains("<revenue_schedule_type>"));
+    }
+
+    @Test(groups = "fast")
+    public void testDeserializationWhenElementNotPresent() throws Exception {
+        final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                      "<adjustment type=\"credit\" href=\"https://api.recurly.com/v2/adjustments/626db120a84102b1809909071c701c60\">\n" +
+                                      "</adjustment>";
+        Adjustment adjustment = xmlMapper.readValue(xml, Adjustment.class);
+        assertEquals(adjustment.getRevenueScheduleType(), null);
+    }
+
+    @Test(groups = "fast")
+    public void testDeserializationWhenValueNotPresent() throws Exception {
+        final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                      "<adjustment type=\"credit\" href=\"https://api.recurly.com/v2/adjustments/626db120a84102b1809909071c701c60\">\n" +
+                                        "<revenue_schedule_type></revenue_schedule_type>\n" +
+                                      "</adjustment>";
+        Adjustment adjustment = xmlMapper.readValue(xml, Adjustment.class);
+        assertEquals(adjustment.getRevenueScheduleType(), null);
+    }
+
+    @Test(groups = "fast", expectedExceptions = InvalidFormatException.class)
+    public void testDeserializationWhenValueUnknown() throws IOException {
+        final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                      "<adjustment type=\"credit\" href=\"https://api.recurly.com/v2/adjustments/626db120a84102b1809909071c701c60\">\n" +
+                                        "<revenue_schedule_type>covfefe</revenue_schedule_type>\n" +
+                                      "</adjustment>";
+        xmlMapper.readValue(xml, Adjustment.class);
+
+    }
+
+    private void testSerializationCommon(RevenueScheduleType revenueScheduleType, String expectedSerializedValue) throws Exception {
+        Adjustment adjustment = TestUtils.createRandomAdjustment();
+        adjustment.setRevenueScheduleType(revenueScheduleType);
+        String xml = xmlMapper.writeValueAsString(adjustment);
+        assert(xml.contains("<revenue_schedule_type>"+ expectedSerializedValue +"</revenue_schedule_type>"));
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestRevenueScheduleType.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestRevenueScheduleType.java
@@ -1,3 +1,20 @@
+/*
+  * Copyright 2010-2014 Ning, Inc.
+  * Copyright 2014-2015 The Billing Project, LLC
+  *
+  * The Billing Project licenses this file to you under the Apache License, version 2.0
+  * (the "License"); you may not use this file except in compliance with the
+  * License.  You may obtain a copy of the License at:
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  * License for the specific language governing permissions and limitations
+  * under the License.
+  */
+
 package com.ning.billing.recurly.model;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;

--- a/src/test/java/com/ning/billing/recurly/model/TestRevenueScheduleType.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestRevenueScheduleType.java
@@ -17,6 +17,14 @@ public class TestRevenueScheduleType extends TestModelBase {
         }
     }
 
+
+    @Test(groups = "fast")
+    public void testDeserializationAllValues() throws Exception {
+        for (RevenueScheduleType revenueScheduleType : RevenueScheduleType.values()) {
+            testDeserializationCommon(revenueScheduleType, revenueScheduleType.name().toLowerCase());
+        }
+    }
+
     @Test(groups = "fast")
     public void testSerializationNullValue() throws Exception {
         Adjustment adjustment = TestUtils.createRandomAdjustment();
@@ -59,5 +67,15 @@ public class TestRevenueScheduleType extends TestModelBase {
         adjustment.setRevenueScheduleType(revenueScheduleType);
         String xml = xmlMapper.writeValueAsString(adjustment);
         assert(xml.contains("<revenue_schedule_type>"+ expectedSerializedValue +"</revenue_schedule_type>"));
+    }
+
+     private void testDeserializationCommon(RevenueScheduleType revenueScheduleType, String value) throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                      "<adjustment type=\"credit\" href=\"https://api.recurly.com/v2/adjustments/626db120a84102b1809909071c701c60\">\n" +
+                                        "<revenue_schedule_type>" + value + "</revenue_schedule_type>\n" +
+                                      "</adjustment>";
+
+        Adjustment adjustment = xmlMapper.readValue(xml, Adjustment.class);
+        assertEquals(adjustment.getRevenueScheduleType(), revenueScheduleType);
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -166,39 +166,6 @@ public class TestSubscription extends TestModelBase {
         assertEquals(subscription.hashCode(), otherSubscription.hashCode());
         assertEquals(subscription, otherSubscription);
     }
-    
-    @Test(groups = "fast")
-    public void testSetRevenueScheduleType() throws Exception {
-        Subscription subscription = new Subscription();
-        subscription.setRevenueScheduleType(null);
-        assertEquals(subscription.getRevenueScheduleType(), null );
-        
-        verifyRevenueScheduleTypeWithInvalidValue("INVALID_STRING");
-        verifyRevenueScheduleTypeWithInvalidValue("");
-        verifyRevenueScheduleTypeWithInvalidValue(" ");
-        
-        for (RevenueScheduleType revenueScheduleType : RevenueScheduleType.values()) {
-            verifyRevenueScheduleType(revenueScheduleType);
-        }
-    }
-    
-    private void verifyRevenueScheduleTypeWithInvalidValue(String invalidValue){
-    	Subscription subscription = new Subscription();
-
-        try {
-            //we expect an exception here
-            subscription.setRevenueScheduleType(invalidValue);
-            Assert.fail();
-        } catch (IllegalArgumentException iae) {
-            //iae.printStackTrace();
-        }
-    }
-    
-    private void verifyRevenueScheduleType(RevenueScheduleType revenueScheduleType){
-        Subscription subscription = new Subscription();
-        subscription.setRevenueScheduleType(revenueScheduleType.getType());
-        assertEquals(subscription.getRevenueScheduleType(), revenueScheduleType);
-    }
 
     private void verifySubscriptionAddons(final Subscription subscription) {
         Assert.assertEquals(subscription.getAddOns().size(), 2);


### PR DESCRIPTION
- Earlier `Plan`, `Subscription`, `Addon` and `Adjustment` serialized `RevenueScheduleType` incorrectly. 
- `getRevenueScheduleType()` returned the enum constant for serialization but Recurly expects lower-cased values of the enums
- Centralized the enum serialization deserialization on the class itself