### PR TITLE
Bumps to API v2.7

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -101,7 +101,7 @@ public class RecurlyClient {
     private static final Logger log = LoggerFactory.getLogger(RecurlyClient.class);
 
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
-    public static final String RECURLY_API_VERSION = "2.6";
+    public static final String RECURLY_API_VERSION = "2.7";
 
     private static final String X_RECORDS_HEADER_NAME = "X-Records";
     private static final String LINK_HEADER_NAME = "Link";

--- a/src/main/java/com/ning/billing/recurly/model/Purchase.java
+++ b/src/main/java/com/ning/billing/recurly/model/Purchase.java
@@ -17,7 +17,11 @@
 
 package com.ning.billing.recurly.model;
 
-import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlList;
 
 import com.google.common.base.Objects;
 
@@ -56,6 +60,7 @@ public class Purchase extends RecurlyObject {
 
     @XmlList
     @XmlElementWrapper(name = "coupon_codes")
+    @XmlElement(name = "coupon_code")
     private List<String> couponCodes;
 
     public void setAccount(final Account account) {

--- a/src/main/java/com/ning/billing/recurly/model/Purchase.java
+++ b/src/main/java/com/ning/billing/recurly/model/Purchase.java
@@ -17,12 +17,11 @@
 
 package com.ning.billing.recurly.model;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.*;
 
 import com.google.common.base.Objects;
+
+import java.util.List;
 
 @XmlRootElement(name = "purchase")
 public class Purchase extends RecurlyObject {
@@ -48,6 +47,17 @@ public class Purchase extends RecurlyObject {
     @XmlElement(name = "adjustment")
     private Adjustments adjustments;
 
+    @XmlElementWrapper(name = "subscriptions")
+    @XmlElement(name = "subscription")
+    private Subscriptions subscriptions;
+
+    @XmlElement(name = "gift_card")
+    private GiftCard giftCard;
+
+    @XmlList
+    @XmlElementWrapper(name = "coupon_codes")
+    private List<String> couponCodes;
+
     public void setAccount(final Account account) {
         this.account = account;
     }
@@ -70,6 +80,22 @@ public class Purchase extends RecurlyObject {
 
     public void setCollectionMethod(final Object collectionMethod) {
         this.collectionMethod = stringOrNull(collectionMethod);
+    }
+
+    public void setCouponCodes(final List<String> couponCodes) {
+        this.couponCodes = couponCodes;
+    }
+
+    public List<String> getCouponCodes() {
+        return this.couponCodes;
+    }
+
+    public GiftCard getGiftCard() {
+        return giftCard;
+    }
+
+    public void setGiftCard(final GiftCard giftCard) {
+        this.giftCard = giftCard;
     }
 
     public String getNetTerms() {
@@ -96,6 +122,14 @@ public class Purchase extends RecurlyObject {
         this.currency = stringOrNull(currency);
     }
 
+    public void setSubscriptions(final Subscriptions subscriptions) {
+        this.subscriptions = subscriptions;
+    }
+
+    public Subscriptions getSubscriptions() {
+        return subscriptions;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -106,6 +140,9 @@ public class Purchase extends RecurlyObject {
         sb.append(", currency='").append(currency).append('\'');
         sb.append(", poNumber='").append(poNumber).append('\'');
         sb.append(", netTerms='").append(netTerms).append('\'');
+        sb.append(", giftCard='").append(giftCard).append('\'');
+        sb.append(", subscriptions='").append(subscriptions).append('\'');
+        sb.append(", couponCodes='").append(couponCodes).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -126,13 +163,22 @@ public class Purchase extends RecurlyObject {
         if (collectionMethod != null ? !collectionMethod.equals(purchase.collectionMethod) : purchase.collectionMethod != null) {
             return false;
         }
+        if (couponCodes != null ? !couponCodes.equals(purchase.couponCodes) : purchase.couponCodes != null) {
+            return false;
+        }
         if (currency != null ? !currency.equals(purchase.currency) : purchase.currency != null) {
+            return false;
+        }
+        if (giftCard != null ? !giftCard.equals(purchase.giftCard) : purchase.giftCard != null) {
             return false;
         }
         if (poNumber != null ? !poNumber.equals(purchase.poNumber) : purchase.poNumber != null) {
             return false;
         }
         if (netTerms != null ? !netTerms.equals(purchase.netTerms) : purchase.netTerms != null) {
+            return false;
+        }
+        if (subscriptions != null ? !subscriptions.equals(purchase.subscriptions) : purchase.subscriptions != null) {
             return false;
         }
 
@@ -146,8 +192,11 @@ public class Purchase extends RecurlyObject {
                 adjustments,
                 collectionMethod,
                 currency,
+                giftCard,
                 poNumber,
-                netTerms
+                netTerms,
+                subscriptions,
+                couponCodes
         );
     }
 

--- a/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
@@ -18,9 +18,9 @@
 package com.ning.billing.recurly.model;
 
 import com.ning.billing.recurly.TestUtils;
-import org.joda.time.DateTime;
-import org.testng.Assert;
 import org.testng.annotations.Test;
+import java.util.List;
+import java.util.ArrayList;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
@@ -57,6 +57,18 @@ public class TestPurchase extends TestModelBase {
                 "      <product_code>product-code</product_code>" +
                 "    </adjustment>" +
                 "  </adjustments>" +
+                "  <subscriptions>" +
+                "    <subscription>" +
+                "       <plan_code>plan1</plan_code>" +
+                "    </subscription>" +
+                "    <subscription>" +
+                "       <plan_code>plan2</plan_code>" +
+                "    </subscription>" +
+                "  </subscriptions>" +
+                "  <coupon_codes>" +
+                "    <coupon_code>coupon1</coupon_code>" +
+                "    <coupon_code>coupon2</coupon_code>" +
+                "  </coupon_codes>" +
                 "</purchase>";
 
         final Purchase purchase = new Purchase();
@@ -88,8 +100,22 @@ public class TestPurchase extends TestModelBase {
         adjustment.setUnitAmountInCents(1000);
         adjustments.add(adjustment);
 
+        final Subscriptions subscriptions = new Subscriptions();
+        final Subscription sub1 = new Subscription();
+        sub1.setPlanCode("plan1");
+        final Subscription sub2 = new Subscription();
+        sub2.setPlanCode("plan2");
+        subscriptions.add(sub1);
+        subscriptions.add(sub2);
+
+        final List<String> couponCodes = new ArrayList<String>();
+        couponCodes.add("coupon1");
+        couponCodes.add("coupon2");
+
         purchase.setAccount(account);
         purchase.setAdjustments(adjustments);
+        purchase.setSubscriptions(subscriptions);
+        purchase.setCouponCodes(couponCodes);
 
         final String xml = xmlMapper.writeValueAsString(purchase);
         final Purchase purchaseExpected = xmlMapper.readValue(xml, Purchase.class);

--- a/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
@@ -69,6 +69,9 @@ public class TestPurchase extends TestModelBase {
                 "    <coupon_code>coupon1</coupon_code>" +
                 "    <coupon_code>coupon2</coupon_code>" +
                 "  </coupon_codes>" +
+                "  <gift_card>" +
+                "    <redemption_code>ABC1234</redemption_code>" +
+                "  </gift_card>" +
                 "</purchase>";
 
         final Purchase purchase = new Purchase();
@@ -112,10 +115,14 @@ public class TestPurchase extends TestModelBase {
         couponCodes.add("coupon1");
         couponCodes.add("coupon2");
 
+        final GiftCard giftCard = new GiftCard();
+        giftCard.setRedemptionCode("ABC1234");
+
         purchase.setAccount(account);
         purchase.setAdjustments(adjustments);
         purchase.setSubscriptions(subscriptions);
         purchase.setCouponCodes(couponCodes);
+        purchase.setGiftCard(giftCard);
 
         final String xml = xmlMapper.writeValueAsString(purchase);
         final Purchase purchaseExpected = xmlMapper.readValue(xml, Purchase.class);


### PR DESCRIPTION
This adds the new fields to the `Purchase` object.

- Changed `POST /v2/purchases` request:
  - Added `coupon_codes`
    - path: `<coupon_codes type="array"><coupon_code>COUPON1234</coupon_code></coupon_codes>`
    - description: A list of coupon codes to apply to this purchase.
  - Added `subscriptions`
    - path: `<subscriptions type="array"><subscription/></subscriptions>`
    - description: A list of Subscriptions to invoice in this purchase (currently only one subscription is allowed).
  - Added `gift_card`
    - path: `<gift_card><redemption_code>ABCD1234</redemption_code></gift_card>`
    - description: A gift card with a redemption code to apply to this purchase.