### PR TITLE
Add ability to set subscription UUID when redeeming a coupon

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Redemption.java
+++ b/src/main/java/com/ning/billing/recurly/model/Redemption.java
@@ -82,8 +82,8 @@ public class Redemption extends RecurlyObject {
         return subscriptionUuid;
     }
 
-    public void setSubscriptionUuid(String subscriptionUuid) {
-        this.subscriptionUuid = subscriptionUuid;
+    public void setSubscriptionUuid(final Object subscriptionUuid) {
+        this.subscriptionUuid = stringOrNull(subscriptionUuid);
     }
 
     public Coupon getCoupon() {

--- a/src/main/java/com/ning/billing/recurly/model/Redemption.java
+++ b/src/main/java/com/ning/billing/recurly/model/Redemption.java
@@ -43,6 +43,9 @@ public class Redemption extends RecurlyObject {
     @XmlElement(name = "account_code")
     private String accountCode;
 
+    @XmlElement(name = "subscription_uuid")
+    private String subscriptionUuid;
+
     @XmlElement(name = "coupon")
     private Coupon coupon;
 
@@ -73,6 +76,14 @@ public class Redemption extends RecurlyObject {
 
     public void setAccountCode(final Object accountCode) {
         this.accountCode = stringOrNull(accountCode);
+    }
+
+    public String getSubscriptionUuid() {
+        return subscriptionUuid;
+    }
+
+    public void setSubscriptionUuid(String subscriptionUuid) {
+        this.subscriptionUuid = subscriptionUuid;
     }
 
     public Coupon getCoupon() {
@@ -158,6 +169,7 @@ public class Redemption extends RecurlyObject {
         final StringBuilder sb = new StringBuilder();
         sb.append("Redemption");
         sb.append("{accountCode=").append(accountCode);
+        sb.append(", subscriptionUuid=").append(subscriptionUuid);
         sb.append(", coupon=").append(coupon);
         sb.append(", account=").append(account);
         sb.append(", uuid=").append(uuid);
@@ -179,6 +191,9 @@ public class Redemption extends RecurlyObject {
         final Redemption that = (Redemption) o;
 
         if (accountCode != null ? !accountCode.equals(that.accountCode) : that.accountCode != null) {
+            return false;
+        }
+        if (subscriptionUuid != null ? !subscriptionUuid.equals(that.subscriptionUuid) : that.subscriptionUuid != null) {
             return false;
         }
         if (coupon != null ? !coupon.equals(that.coupon) : that.coupon != null) {
@@ -217,6 +232,7 @@ public class Redemption extends RecurlyObject {
     public int hashCode() {
         return Objects.hashCode(
                 accountCode,
+                subscriptionUuid,
                 coupon,
                 account,
                 singleUse,

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -769,6 +769,7 @@ public class TestUtils {
 
         redemption.setAccount(account);
         redemption.setAccountCode(account.getAccountCode());
+        redemption.setSubscriptionUuid(randomAlphaNumericString(10, seed));
         redemption.setCoupon(createRandomCoupon(seed));
         redemption.setSingleUse(true);
         redemption.setState("redeemed");

--- a/src/test/java/com/ning/billing/recurly/model/TestRedemption.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestRedemption.java
@@ -54,12 +54,24 @@ public class TestRedemption extends TestModelBase {
         final Redemption redemption = new Redemption();
         redemption.setAccountCode("1");
         redemption.setCurrency("USD");
+        redemption.setSubscriptionUuid("374a1c75374bd81493a3f7425db0a2b8");
 
         final String xml = xmlMapper.writeValueAsString(redemption);
         Assert.assertEquals(xml, "<redemption xmlns=\"\">" +
                 "<account_code>1</account_code>" +
+                "<subscription_uuid>374a1c75374bd81493a3f7425db0a2b8</subscription_uuid>" +
                 "<currency>USD</currency>" +
                 "</redemption>");
+
+        final Redemption redemptionWithoutUuid = new Redemption();
+        redemptionWithoutUuid.setAccountCode("1");
+        redemptionWithoutUuid.setCurrency("USD");
+
+        final String secondXml = xmlMapper.writeValueAsString(redemptionWithoutUuid);
+        Assert.assertEquals(secondXml, "<redemption xmlns=\"\">" +
+            "<account_code>1</account_code>" +
+            "<currency>USD</currency>" +
+            "</redemption>");
     }
 
     @Test(groups = "fast")


### PR DESCRIPTION
Context:

As per https://dev.recurly.com/docs/redeem-a-coupon-before-or-after-a-subscription, the Recurly API supports the ability to pass in a subscription_uuid as part of the request to redeem a coupon. I noticed that there was no ability to do that through this library, so I implemented that ability. Please let me know if there are any changes you'd like me to make as part of code review and I'd be happy to add them. I've run the test suite locally and everything passes.