### PR TITLE
Custom Invoice Notes, ISO 3166 country codes

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -106,6 +106,15 @@ public class Invoice extends RecurlyObject {
     @XmlElement(name = "transaction")
     private Transactions transactions;
 
+    @XmlElement(name = "customer_notes")
+    private String customerNotes;
+
+    @XmlElement(name = "terms_and_conditions")
+    private String termsAndConditions;
+
+    @XmlElement(name = "vat_reverse_charge_notes")
+    private String vatReverseChargeNotes;
+
     public Account getAccount() {
         if (account != null && account.getCreatedAt() == null) {
             account = fetch(account, Account.class);
@@ -329,6 +338,30 @@ public class Invoice extends RecurlyObject {
         this.transactions = transactions;
     }
 
+    public String getCustomerNotes() {
+        return customerNotes;
+    }
+
+    public void setCustomerNotes(final Object customerNotes) {
+        this.customerNotes = stringOrNull(customerNotes);
+    }
+
+    public String getTermsAndConditions() {
+        return termsAndConditions;
+    }
+
+    public void setTermsAndConditions(final Object termsAndConditions) {
+        this.termsAndConditions = stringOrNull(termsAndConditions);
+    }
+
+    public String getVatReverseChargeNotes() {
+        return vatReverseChargeNotes;
+    }
+
+    public void setVatReverseChargeNotes(final Object vatReverseChargeNotes) {
+        this.vatReverseChargeNotes = stringOrNull(vatReverseChargeNotes);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("Invoice{");
@@ -357,6 +390,9 @@ public class Invoice extends RecurlyObject {
         sb.append(", recoveryReason=").append(recoveryReason);
         sb.append(", lineItems=").append(lineItems);
         sb.append(", transactions=").append(transactions);
+        sb.append(", customerNotes='").append(customerNotes).append('\'');
+        sb.append(", termsAndConditions='").append(termsAndConditions).append('\'');
+        sb.append(", vatReverseChargeNotes='").append(vatReverseChargeNotes).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -387,6 +423,9 @@ public class Invoice extends RecurlyObject {
             return false;
         }
         if (currency != null ? !currency.equals(invoice.currency) : invoice.currency != null) {
+            return false;
+        }
+        if (customerNotes != null ? !customerNotes.equals(invoice.customerNotes) : invoice.customerNotes != null) {
             return false;
         }
         if (invoiceNumber != null ? !invoiceNumber.equals(invoice.invoiceNumber) : invoice.invoiceNumber != null) {
@@ -431,6 +470,9 @@ public class Invoice extends RecurlyObject {
         if (taxRate != null ? !taxRate.equals(invoice.taxRate) : invoice.taxRate != null) {
           return false;
         }
+        if (termsAndConditions != null ? !termsAndConditions.equals(invoice.termsAndConditions) : invoice.termsAndConditions != null) {
+            return false;
+        }
         if (transactions != null ? !transactions.equals(invoice.transactions) : invoice.transactions != null) {
             return false;
         }
@@ -441,6 +483,9 @@ public class Invoice extends RecurlyObject {
             return false;
         }
         if (vatNumber != null ? !vatNumber.equals(invoice.vatNumber) : invoice.vatNumber != null) {
+            return false;
+        }
+        if (vatReverseChargeNotes != null ? !vatReverseChargeNotes.equals(invoice.vatReverseChargeNotes) : invoice.vatReverseChargeNotes != null) {
             return false;
         }
 
@@ -474,7 +519,10 @@ public class Invoice extends RecurlyObject {
                 attemptNextCollectionAt,
                 recoveryReason,
                 lineItems,
-                transactions
+                transactions,
+                customerNotes,
+                termsAndConditions,
+                vatReverseChargeNotes
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Purchase.java
+++ b/src/main/java/com/ning/billing/recurly/model/Purchase.java
@@ -58,6 +58,15 @@ public class Purchase extends RecurlyObject {
     @XmlElement(name = "gift_card")
     private GiftCard giftCard;
 
+    @XmlElement(name = "customer_notes")
+    private String customerNotes;
+
+    @XmlElement(name = "vat_reverse_charge_notes")
+    private String vatReverseChargeNotes;
+
+    @XmlElement(name = "terms_and_conditions")
+    private String termsAndConditions;
+
     @XmlList
     @XmlElementWrapper(name = "coupon_codes")
     @XmlElement(name = "coupon_code")
@@ -135,6 +144,30 @@ public class Purchase extends RecurlyObject {
         return subscriptions;
     }
 
+    public String getCustomerNotes() {
+        return customerNotes;
+    }
+
+    public void setCustomerNotes(final Object customerNotes) {
+        this.customerNotes = stringOrNull(customerNotes);
+    }
+
+    public String getTermsAndConditions() {
+        return termsAndConditions;
+    }
+
+    public void setTermsAndConditions(final Object termsAndConditions) {
+        this.termsAndConditions = stringOrNull(termsAndConditions);
+    }
+
+    public String getVatReverseChargeNotes() {
+        return vatReverseChargeNotes;
+    }
+
+    public void setVatReverseChargeNotes(final Object vatReverseChargeNotes) {
+        this.vatReverseChargeNotes = stringOrNull(vatReverseChargeNotes);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -148,6 +181,9 @@ public class Purchase extends RecurlyObject {
         sb.append(", giftCard='").append(giftCard).append('\'');
         sb.append(", subscriptions='").append(subscriptions).append('\'');
         sb.append(", couponCodes='").append(couponCodes).append('\'');
+        sb.append(", customerNotes='").append(customerNotes).append('\'');
+        sb.append(", termsAndConditions='").append(termsAndConditions).append('\'');
+        sb.append(", vatReverseChargeNotes='").append(vatReverseChargeNotes).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -174,6 +210,9 @@ public class Purchase extends RecurlyObject {
         if (currency != null ? !currency.equals(purchase.currency) : purchase.currency != null) {
             return false;
         }
+        if (customerNotes != null ? !customerNotes.equals(purchase.customerNotes) : purchase.customerNotes != null) {
+            return false;
+        }
         if (giftCard != null ? !giftCard.equals(purchase.giftCard) : purchase.giftCard != null) {
             return false;
         }
@@ -184,6 +223,12 @@ public class Purchase extends RecurlyObject {
             return false;
         }
         if (subscriptions != null ? !subscriptions.equals(purchase.subscriptions) : purchase.subscriptions != null) {
+            return false;
+        }
+        if (termsAndConditions != null ? !termsAndConditions.equals(purchase.termsAndConditions) : purchase.termsAndConditions != null) {
+            return false;
+        }
+        if (vatReverseChargeNotes != null ? !vatReverseChargeNotes.equals(purchase.vatReverseChargeNotes) : purchase.vatReverseChargeNotes != null) {
             return false;
         }
 
@@ -201,7 +246,10 @@ public class Purchase extends RecurlyObject {
                 poNumber,
                 netTerms,
                 subscriptions,
-                couponCodes
+                couponCodes,
+                customerNotes,
+                termsAndConditions,
+                vatReverseChargeNotes
         );
     }
 

--- a/src/main/java/com/ning/billing/recurly/model/Purchase.java
+++ b/src/main/java/com/ning/billing/recurly/model/Purchase.java
@@ -42,7 +42,7 @@ public class Purchase extends RecurlyObject {
     private String poNumber;
 
     @XmlElement(name = "net_terms")
-    private String netTerms;
+    private Integer netTerms;
 
     @XmlElement(name = "account")
     private Account account;
@@ -112,12 +112,12 @@ public class Purchase extends RecurlyObject {
         this.giftCard = giftCard;
     }
 
-    public String getNetTerms() {
+    public Integer getNetTerms() {
         return netTerms;
     }
 
     public void setNetTerms(final Object terms) {
-        this.netTerms = stringOrNull(terms);
+        this.netTerms = integerOrNull(terms);
     }
 
     public String getPoNumber() {

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -1622,6 +1622,9 @@ public class TestRecurlyClient {
             purchaseData.setSubscriptions(subscriptions);
             purchaseData.setGiftCard(redemptionData);
             purchaseData.setCouponCodes(couponCodes);
+            purchaseData.setCustomerNotes("Customer Notes");
+            purchaseData.setTermsAndConditions("Terms and Conditions");
+            purchaseData.setVatReverseChargeNotes("VAT Reverse Charge Notes");
 
             final Invoice invoice = recurlyClient.purchase(purchaseData);
             Assert.assertNotNull(invoice.getInvoiceNumber());

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -223,6 +223,19 @@ public class TestUtils {
         return random.nextInt(upperRange);
     }
 
+    /**
+     * Returns a random 2 character country code.
+     *
+     * @param seed The RNG seed
+     * @return The random country code
+     */
+    public static String randomCountry(final int seed) {
+        Random random = new Random(seed);
+        final String[] countries = {"US", "CA", "MX", "IT", "CH"};
+        final int position = random.nextInt(countries.length);
+        return countries[position];
+    }
+
     public static String createTestCCNumber() {
         return "4111-1111-1111-1111";
     }
@@ -293,7 +306,7 @@ public class TestUtils {
         address.setCity(randomAlphaNumericString(10, seed));
         address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setZip("94110");
-        address.setCountry(randomAlphaString(2, seed).toUpperCase());
+        address.setCountry(randomCountry(seed));
         address.setPhone(randomNumericString(10, seed));
 
         return address;
@@ -323,7 +336,7 @@ public class TestUtils {
         address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setZip("94110");
-        address.setCountry(randomAlphaString(2, seed).toUpperCase());
+        address.setCountry(randomCountry(seed));
         address.setPhone(randomNumericString(10, seed));
         address.setNickname(randomAlphaNumericString(10, seed));
         address.setFirstName(randomAlphaNumericString(10, seed));
@@ -390,7 +403,7 @@ public class TestUtils {
         info.setCity(randomAlphaNumericString(10, seed));
         info.setState("CA");
         info.setZip("94110");
-        info.setCountry("US");
+        info.setCountry(randomCountry(seed));
         info.setPhone(randomInteger(8, seed));
         info.setVatNumber(randomNumericString(8, seed));
         info.setYear(createTestCCYear());

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -735,6 +735,9 @@ public class TestUtils {
         invoice.setCreatedAt(NOW);
         invoice.setCollectionMethod("credit_card");
         invoice.setNetTerms(randomInteger(100, seed));
+        invoice.setCustomerNotes("Customer Notes " + randomAlphaString(20, seed));
+        invoice.setTermsAndConditions("Terms and Conditions " + randomAlphaString(20, seed));
+        invoice.setVatReverseChargeNotes("VAT Reverse Charge Notes " + randomAlphaString(20, seed));
 
         Adjustments adjustments = new Adjustments();
         for (int i = 0; i < 3; i++) {

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -223,19 +223,6 @@ public class TestUtils {
         return random.nextInt(upperRange);
     }
 
-    /**
-     * Returns a random 2 character country code.
-     *
-     * @param seed The RNG seed
-     * @return The random country code
-     */
-    public static String randomCountry(final int seed) {
-        Random random = new Random(seed);
-        final String[] countries = {"US", "CA", "MX", "IT", "CH"};
-        final int position = random.nextInt(countries.length);
-        return countries[position];
-    }
-
     public static String createTestCCNumber() {
         return "4111-1111-1111-1111";
     }
@@ -306,7 +293,7 @@ public class TestUtils {
         address.setCity(randomAlphaNumericString(10, seed));
         address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setZip("94110");
-        address.setCountry(randomCountry(seed));
+        address.setCountry("US");
         address.setPhone(randomNumericString(10, seed));
 
         return address;
@@ -336,7 +323,7 @@ public class TestUtils {
         address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setZip("94110");
-        address.setCountry(randomCountry(seed));
+        address.setCountry("US");
         address.setPhone(randomNumericString(10, seed));
         address.setNickname(randomAlphaNumericString(10, seed));
         address.setFirstName(randomAlphaNumericString(10, seed));
@@ -403,7 +390,7 @@ public class TestUtils {
         info.setCity(randomAlphaNumericString(10, seed));
         info.setState("CA");
         info.setZip("94110");
-        info.setCountry(randomCountry(seed));
+        info.setCountry("US");
         info.setPhone(randomInteger(8, seed));
         info.setVatNumber(randomNumericString(8, seed));
         info.setYear(createTestCCYear());

--- a/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
@@ -34,6 +34,9 @@ public class TestPurchase extends TestModelBase {
                 "  <collection_method>automatic</collection_method>" +
                 "  <net_terms>30</net_terms>" +
                 "  <currency>USD</currency>" +
+                "  <customer_notes>Customer Notes</customer_notes>" +
+                "  <terms_and_conditions>Terms and Conditions</terms_and_conditions>" +
+                "  <vat_reverse_charge_notes>VAT Reverse Charge Notes</vat_reverse_charge_notes>" +
                 "  <account>" +
                 "    <account_code>test</account_code>" +
                 "    <billing_info>" +
@@ -78,6 +81,9 @@ public class TestPurchase extends TestModelBase {
         purchase.setCollectionMethod("automatic");
         purchase.setCurrency("USD");
         purchase.setNetTerms(30);
+        purchase.setCustomerNotes("Customer Notes");
+        purchase.setTermsAndConditions("Terms and Conditions");
+        purchase.setVatReverseChargeNotes("VAT Reverse Charge Notes");
 
         final Account account = new Account();
         account.setAccountCode("test");
@@ -124,8 +130,7 @@ public class TestPurchase extends TestModelBase {
         purchase.setCouponCodes(couponCodes);
         purchase.setGiftCard(giftCard);
 
-        final String xml = xmlMapper.writeValueAsString(purchase);
-        final Purchase purchaseExpected = xmlMapper.readValue(xml, Purchase.class);
+        final Purchase purchaseExpected = xmlMapper.readValue(purchaseData, Purchase.class);
 
         assertEquals(purchase, purchaseExpected);
     }

--- a/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
@@ -18,6 +18,7 @@
 package com.ning.billing.recurly.model;
 
 import com.ning.billing.recurly.TestUtils;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import java.util.List;
 import java.util.ArrayList;
@@ -32,7 +33,7 @@ public class TestPurchase extends TestModelBase {
         final String purchaseData = "<purchase xmlns=\"\">" +
                 "<currency>USD</currency>" +
                 "  <collection_method>automatic</collection_method>" +
-                "  <net_terms>30</net_terms>" +
+                "  <net_terms type=\"integer\">30</net_terms>" +
                 "  <currency>USD</currency>" +
                 "  <customer_notes>Customer Notes</customer_notes>" +
                 "  <terms_and_conditions>Terms and Conditions</terms_and_conditions>" +
@@ -47,15 +48,15 @@ public class TestPurchase extends TestModelBase {
                 "      <state>CA</state>" +
                 "      <zip>94110</zip>" +
                 "      <country>US</country>" +
-                "      <year>2019</year>" +
-                "      <month>12</month>" +
+                "      <year type=\"integer\">2019</year>" +
+                "      <month type=\"integer\">12</month>" +
                 "      <number>4000-0000-0000-0000</number>" +
                 "    </billing_info>" +
                 "  </account>" +
                 "  <adjustments>" +
                 "    <adjustment>" +
-                "      <unit_amount_in_cents>1000</unit_amount_in_cents>" +
-                "      <quantity>1</quantity>" +
+                "      <unit_amount_in_cents type=\"integer\">1000</unit_amount_in_cents>" +
+                "      <quantity type=\"integer\">1</quantity>" +
                 "      <currency>USD</currency>" +
                 "      <product_code>product-code</product_code>" +
                 "    </adjustment>" +
@@ -77,62 +78,57 @@ public class TestPurchase extends TestModelBase {
                 "  </gift_card>" +
                 "</purchase>";
 
-        final Purchase purchase = new Purchase();
-        purchase.setCollectionMethod("automatic");
-        purchase.setCurrency("USD");
-        purchase.setNetTerms(30);
-        purchase.setCustomerNotes("Customer Notes");
-        purchase.setTermsAndConditions("Terms and Conditions");
-        purchase.setVatReverseChargeNotes("VAT Reverse Charge Notes");
+        // test serialization
+        final Purchase purchase = xmlMapper.readValue(purchaseData, Purchase.class);
+        verifyPurchase(purchase);
 
-        final Account account = new Account();
-        account.setAccountCode("test");
-
-        final BillingInfo billingInfo = new BillingInfo();
-        billingInfo.setAddress1("400 Alabama St");
-        billingInfo.setCity("San Francisco");
-        billingInfo.setCountry("US");
-        billingInfo.setFirstName("Benjamin");
-        billingInfo.setLastName("Du Monde");
-        billingInfo.setMonth(12);
-        billingInfo.setNumber("4000-0000-0000-0000");
-        billingInfo.setState("CA");
-        billingInfo.setYear(2019);
-        billingInfo.setZip("94110");
-        account.setBillingInfo(billingInfo);
-
-        final Adjustments adjustments = new Adjustments();
-        final Adjustment adjustment = new Adjustment();
-        adjustment.setCurrency("USD");
-        adjustment.setProductCode("product-code");
-        adjustment.setQuantity(1);
-        adjustment.setUnitAmountInCents(1000);
-        adjustments.add(adjustment);
-
-        final Subscriptions subscriptions = new Subscriptions();
-        final Subscription sub1 = new Subscription();
-        sub1.setPlanCode("plan1");
-        final Subscription sub2 = new Subscription();
-        sub2.setPlanCode("plan2");
-        subscriptions.add(sub1);
-        subscriptions.add(sub2);
-
-        final List<String> couponCodes = new ArrayList<String>();
-        couponCodes.add("coupon1");
-        couponCodes.add("coupon2");
-
-        final GiftCard giftCard = new GiftCard();
-        giftCard.setRedemptionCode("ABC1234");
-
-        purchase.setAccount(account);
-        purchase.setAdjustments(adjustments);
-        purchase.setSubscriptions(subscriptions);
-        purchase.setCouponCodes(couponCodes);
-        purchase.setGiftCard(giftCard);
-
+        // test deseralization
         final Purchase purchaseExpected = xmlMapper.readValue(purchaseData, Purchase.class);
-
         assertEquals(purchase, purchaseExpected);
+    }
+
+    public void verifyPurchase(final Purchase purchase) {
+        assertEquals(purchase.getCollectionMethod(), "automatic");
+        assertEquals(purchase.getCurrency(), "USD");
+        assertEquals(purchase.getNetTerms(), new Integer(30));
+        assertEquals(purchase.getCustomerNotes(), "Customer Notes");
+        assertEquals(purchase.getTermsAndConditions(), "Terms and Conditions");
+        assertEquals(purchase.getVatReverseChargeNotes(), "VAT Reverse Charge Notes");
+
+        final Account account = purchase.getAccount();
+        assertEquals(account.getAccountCode(), "test");
+
+
+        final BillingInfo billingInfo = purchase.getAccount().getBillingInfo();
+        assertEquals(billingInfo.getAddress1(), "400 Alabama St");
+        assertEquals(billingInfo.getCity(), "San Francisco");
+        assertEquals(billingInfo.getState(), "CA");
+        assertEquals(billingInfo.getCountry(), "US");
+        assertEquals(billingInfo.getZip(), "94110");
+        assertEquals(billingInfo.getFirstName(), "Benjamin");
+        assertEquals(billingInfo.getLastName(), "Du Monde");
+        assertEquals(billingInfo.getMonth(), new Integer(12));
+        assertEquals(billingInfo.getYear(), new Integer(2019));
+        assertEquals(billingInfo.getNumber(), "4000-0000-0000-0000");
+
+        final Adjustment adjustment = purchase.getAdjustments().get(0);
+        assertEquals(adjustment.getCurrency(), "USD");
+        assertEquals(adjustment.getProductCode(), "product-code");
+        assertEquals(adjustment.getQuantity(), new Integer(1));
+        assertEquals(adjustment.getUnitAmountInCents(), new Integer(1000));
+
+
+        final Subscription sub1 = purchase.getSubscriptions().get(0);
+        assertEquals(sub1.getPlanCode(), "plan1");
+        final Subscription sub2 = purchase.getSubscriptions().get(1);
+        assertEquals(sub2.getPlanCode(), "plan2");
+
+        final List<String> couponCodes = purchase.getCouponCodes();
+        assertEquals(couponCodes.get(0), "coupon1");
+        assertEquals(couponCodes.get(1), "coupon2");
+
+        final GiftCard giftCard = purchase.getGiftCard();
+        assertEquals(giftCard.getRedemptionCode(), "ABC1234");
     }
 
     @Test(groups = "fast")


### PR DESCRIPTION
**NOTE**: The tests will pass for this on Thursday or Friday. We can hold off until then.

This is for API v2.8 and is only going into the `api_version_2_8` branch for now.

* Added the ability to set custom invoice notes on the `Purchase` object. It seems we missed adding this in `Invoice` in a previous version so I added them there too.
* Updated the tests to use valid 2 character ISO 3166 country codes (which we now validate).
* Fixed a mistake I made in the `TestPurchase` file. We were not properly deserializing and testing the purchase object.