### PR TITLE
API Version 2.9

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -102,7 +102,7 @@ public class RecurlyClient {
     private static final Logger log = LoggerFactory.getLogger(RecurlyClient.class);
 
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
-    public static final String RECURLY_API_VERSION = "2.8";
+    public static final String RECURLY_API_VERSION = "2.9";
 
     private static final String X_RECORDS_HEADER_NAME = "X-Records";
     private static final String LINK_HEADER_NAME = "Link";
@@ -534,6 +534,22 @@ public class RecurlyClient {
     public Subscriptions getSubscriptions() {
         return doGET(Subscriptions.SUBSCRIPTIONS_RESOURCE,
                 Subscriptions.class);
+    }
+
+    /**
+     * Get all the subscriptions on the site given some sort and filter params.
+     * <p>
+     * Returns all the subscriptions on the site
+     *
+     * @param state {@link SubscriptionState}
+     * @param params {@link QueryParams}
+     * @return Subscriptions on the site
+     */
+    public Subscriptions getSubscriptions(final SubscriptionState state, final QueryParams params) {
+        if (state != null) { params.put("state", state.getType()); }
+
+        return doGET(Subscriptions.SUBSCRIPTIONS_RESOURCE,
+                Subscriptions.class, params);
     }
 
     /**
@@ -1496,6 +1512,25 @@ public class RecurlyClient {
      */
     public Invoice previewPurchase(final Purchase purchase) {
         return doPOST(Purchase.PURCHASES_ENDPOINT + "/preview", purchase, Invoice.class);
+    }
+
+    /**
+     * Purchases authorize endpoint.
+     *
+     * Generate an authorized invoice for the purchase. Runs validations
+     + but does not run any transactions. This endpoint will create a
+     + pending purchase that can be activated at a later time once payment
+     + has been completed on an external source (e.g. Adyen's Hosted
+     + Payment Pages).
+     *
+     * <p>
+     * https://dev.recurly.com/docs/authorize-purchase
+     *
+     * @param purchase The purchase data
+     * @return The authorized invoice
+     */
+    public Invoice authorizePurchase(final Purchase purchase) {
+        return doPOST(Purchase.PURCHASES_ENDPOINT + "/authorize", purchase, Invoice.class);
     }
 
     /**

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -106,6 +106,8 @@ public class BillingInfo extends RecurlyObject {
     @XmlElement(name = "updated_at")
     private DateTime updatedAt;
 
+    @XmlElement(name = "external_hpp_type")
+    private String externalHppType;
 
     public String getType() {
         return type;
@@ -313,6 +315,10 @@ public class BillingInfo extends RecurlyObject {
         this.updatedAt = dateTimeOrNull(updatedAt);
     }
 
+    public String getExternalHppType() { return externalHppType; }
+
+    public void setExternalHppType(final Object externalHppType) { this.externalHppType = stringOrNull(externalHppType); }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -339,6 +345,7 @@ public class BillingInfo extends RecurlyObject {
         sb.append(", lastFour='").append(lastFour).append('\'');
         sb.append(", geoCode='").append(geoCode).append('\'');
         sb.append(", updatedAt='").append(updatedAt).append('\'');
+        sb.append(", externalHppType='").append(externalHppType).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -416,6 +423,9 @@ public class BillingInfo extends RecurlyObject {
         if (updatedAt != null ? updatedAt.compareTo(that.updatedAt) != 0 : that.updatedAt != null) {
             return false;
         }
+        if (externalHppType != null ? !externalHppType.equals(that.externalHppType) : that.externalHppType != null) {
+            return false;
+        }
 
         return true;
     }
@@ -444,7 +454,8 @@ public class BillingInfo extends RecurlyObject {
                 lastFour,
                 updatedAt,
                 geoCode,
-                type
+                type,
+                externalHppType
         );
     }
 }

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -1654,6 +1654,59 @@ public class TestRecurlyClient {
     }
 
     @Test(groups = "integration")
+    public void testAuthorizePurchase() throws Exception {
+        final Plan planData = TestUtils.createRandomPlan(CURRENCY);
+        final Account accountData = TestUtils.createRandomAccount();
+        final BillingInfo billingInfoData = TestUtils.createRandomBillingInfo();
+        final Adjustments adjustmentsData = new Adjustments();
+        final Adjustment adjustmentData = TestUtils.createRandomAdjustment();
+        final GiftCard giftCardData = TestUtils.createRandomGiftCard();
+
+        giftCardData.setProductCode("test_gift_card");
+        giftCardData.setCurrency("USD");
+
+        adjustmentData.setCurrency(null); // this one accepted by site
+        adjustmentsData.add(adjustmentData);
+
+        billingInfoData.setAccount(null); // null out random account fixture
+        accountData.setBillingInfo(billingInfoData); // add the billing info to account data
+
+        // these 2 things are required by this endpoint
+        billingInfoData.setExternalHppType("adyen"); // set the external hpp collection to adyen
+        accountData.setEmail("benjamin.dumonde@example.com");
+
+        try {
+            final Plan plan = recurlyClient.createPlan(planData);
+            final GiftCard purchasedGiftCard = recurlyClient.purchaseGiftCard(giftCardData);
+            final GiftCard redemptionData = new GiftCard();
+            redemptionData.setRedemptionCode(purchasedGiftCard.getRedemptionCode());
+            final ArrayList<String> couponCodes = new ArrayList<String>(Arrays.asList("ascu2wprjk", "vttx1luuwz"));
+            final Subscription subscriptionData = new Subscription();
+            subscriptionData.setPlanCode(plan.getPlanCode());
+            final Subscriptions subscriptions = new Subscriptions();
+            subscriptions.add(subscriptionData);
+
+            final Purchase purchaseData = new Purchase();
+            purchaseData.setAccount(accountData);
+            purchaseData.setAdjustments(adjustmentsData);
+            purchaseData.setCollectionMethod("automatic");
+            purchaseData.setAdjustments(adjustmentsData);
+            purchaseData.setCurrency("USD");
+            purchaseData.setSubscriptions(subscriptions);
+            purchaseData.setGiftCard(redemptionData);
+            purchaseData.setCouponCodes(couponCodes);
+            purchaseData.setCustomerNotes("Customer Notes");
+            purchaseData.setTermsAndConditions("Terms and Conditions");
+            purchaseData.setVatReverseChargeNotes("VAT Reverse Charge Notes");
+
+            final Invoice invoice = recurlyClient.authorizePurchase(purchaseData);
+            Assert.assertNotNull(invoice.getUuid());
+        } finally {
+            recurlyClient.deletePlan(planData.getPlanCode());
+        }
+    }
+
+        @Test(groups = "integration")
     public void testAccountAcquisition() throws Exception {
         final Account accountData = TestUtils.createRandomAccount();
 


### PR DESCRIPTION
This PR contains the changes needed for API version 2.9.

1. Added the `authorize` endpoint for purchases. This endpoint allows collection with an external HPP. Currently only Adyen supported and we're still in beta.
2. Any subscription endpoint now accepts the `started_with_gift` parameter to filter out subscriptions that started with a gift card.

```java
final QueryParams params = new QueryParams();
params.put("started_with_gift", true);
```

There are breaking changes with the links in the XML API, however this library does not use the links so there should be no breaking changes this release.