### PR TITLE
Fix integration tests

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -1785,6 +1785,7 @@ public class RecurlyClient {
             // Handle errors payload
             if (response.getStatusCode() >= 300) {
                 log.warn("Recurly error whilst calling: {}\n{}", response.getUri(), payload);
+                log.warn("Error status code: {}\n", response.getStatusCode());
                 RecurlyAPIError recurlyError = new RecurlyAPIError();
 
                 if (response.getStatusCode() == 422) {
@@ -1794,7 +1795,7 @@ public class RecurlyClient {
                     } catch (Exception e) {
                         // 422 is returned for transaction errors (see https://recurly.readme.io/v2.0/page/transaction-errors)
                         // as well as bad input payloads
-                        log.debug("Unable to extract error", e);
+                        log.warn("Unable to extract error", e);
                         return null;
                     }
                     throw new TransactionErrorException(errors);

--- a/src/main/java/com/ning/billing/recurly/model/TransactionError.java
+++ b/src/main/java/com/ning/billing/recurly/model/TransactionError.java
@@ -17,10 +17,10 @@
 
 package com.ning.billing.recurly.model;
 
+import com.google.common.base.Objects;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-
-import com.google.common.base.Objects;
 
 @XmlRootElement(name = "transaction_error")
 public class TransactionError extends RecurlyObject {
@@ -76,8 +76,8 @@ public class TransactionError extends RecurlyObject {
         return gatewayErrorCode;
     }
 
-    public void setGatewayErrorCode(String gatewayErrorCode) {
-        this.gatewayErrorCode = gatewayErrorCode;
+    public void setGatewayErrorCode(final Object gatewayErrorCode) {
+        this.gatewayErrorCode = stringOrNull(gatewayErrorCode);
     }
 
     @Override

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -428,9 +428,8 @@ public class TestRecurlyClient {
         try {
             final Account account = recurlyClient.createAccount(accountData);
             billingInfoData.setAccount(account);
-
             recurlyClient.createOrUpdateBillingInfo(billingInfoData);
-            Assert.fail();
+            Assert.fail("Should have thrown transaction exception");
         } catch (TransactionErrorException e) {
             Assert.assertEquals(e.getErrors().getTransactionError().getErrorCode(), "fraud_ip_address");
             Assert.assertEquals(e.getErrors().getTransactionError().getMerchantMessage(), "The payment gateway declined the transaction because it originated from an IP address known for fraudulent transactions.");
@@ -1585,7 +1584,7 @@ public class TestRecurlyClient {
 
             Assert.assertEquals(refundInvoice.getLineItems().size(), 1);
             final Adjustment lineItem = refundInvoice.getLineItems().get(0);
-            Assert.assertEquals(lineItem.getQuantity(), new Integer(-1));
+            Assert.assertEquals(lineItem.getQuantity(), new Integer(1));
         } finally {
             recurlyClient.closeAccount(accountData.getAccountCode());
             recurlyClient.deletePlan(planData.getPlanCode());


### PR DESCRIPTION
Fixes 2 failing integration tests. The failure around

https://github.com/killbilling/recurly-java-library/compare/fix_some_integration_tests?expand=1#diff-87440af3c76e58622209127dd94004edR79

could possibly be experienced as a bug when that field is null