### PR TITLE
Update dependencies failing owasp dependency-check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
   ~ under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
@@ -64,7 +65,7 @@
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson.version>2.5.0</jackson.version>
+        <jackson.version>2.9.5</jackson.version>
         <guava.version>18.0</guava.version>
         <slf4j.version>1.7.10</slf4j.version>
     </properties>
@@ -110,9 +111,9 @@
             <version>2.0.3</version>
         </dependency>
         <dependency>
-            <groupId>com.ning</groupId>
+            <groupId>org.asynchttpclient</groupId>
             <artifactId>async-http-client</artifactId>
-            <version>1.9.8</version>
+            <version>2.4.5</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
@@ -162,9 +163,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.ning.maven.plugins</groupId>
-                <artifactId>maven-duplicate-finder-plugin</artifactId>
-                <version>1.0.3</version>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <version>1.3.0</version>
                 <configuration>
                     <failBuildInCaseOfConflict>true</failBuildInCaseOfConflict>
                 </configuration>
@@ -491,7 +492,8 @@
                 </executions>
                 <configuration>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                    <generateGitPropertiesFilename>src/main/resources/com/ning/billing/recurly/git.properties</generateGitPropertiesFilename>
+                    <generateGitPropertiesFilename>src/main/resources/com/ning/billing/recurly/git.properties
+                    </generateGitPropertiesFilename>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/ning/billing/recurly/model/jackson/RecurlyObjectsSerializer.java
+++ b/src/main/java/com/ning/billing/recurly/model/jackson/RecurlyObjectsSerializer.java
@@ -17,17 +17,16 @@
 
 package com.ning.billing.recurly.model.jackson;
 
-import java.io.IOException;
-
-import javax.xml.namespace.QName;
-
-import com.ning.billing.recurly.model.RecurlyObject;
-import com.ning.billing.recurly.model.RecurlyObjects;
-
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.json.JsonWriteContext;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import com.ning.billing.recurly.model.RecurlyObject;
+import com.ning.billing.recurly.model.RecurlyObjects;
+
+import javax.xml.namespace.QName;
+import java.io.IOException;
 
 public class RecurlyObjectsSerializer<T extends RecurlyObjects<U>, U extends RecurlyObject> extends StdSerializer<T> {
 
@@ -39,7 +38,8 @@ public class RecurlyObjectsSerializer<T extends RecurlyObjects<U>, U extends Rec
     }
 
     @Override
-    public void serialize(final T values, final JsonGenerator jgen, final SerializerProvider provider) throws IOException {
+    public void serialize(final T values, final JsonGenerator jgen, final SerializerProvider provider)
+            throws IOException {
         if (values.isEmpty()) {
             jgen.writeStartArray();
             jgen.writeEndArray();
@@ -48,7 +48,8 @@ public class RecurlyObjectsSerializer<T extends RecurlyObjects<U>, U extends Rec
 
         final ToXmlGenerator xmlgen = (ToXmlGenerator) jgen;
         // Nested RecurlyObjects
-        xmlgen.getOutputContext().writeFieldName(elementName);
+        JsonWriteContext jsonWriteContext = ((JsonWriteContext) xmlgen.getOutputContext());
+        jsonWriteContext.writeFieldName(elementName);
         boolean firstValue = true;
         for (final U value : values) {
             if (firstValue) {

--- a/src/main/java/com/ning/billing/recurly/util/http/SslUtils.java
+++ b/src/main/java/com/ning/billing/recurly/util/http/SslUtils.java
@@ -18,15 +18,16 @@
 package com.ning.billing.recurly.util.http;
 
 
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import javax.net.ssl.SSLContext;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+
+import javax.net.ssl.SSLException;
 
 public class SslUtils {
 
     private static final String TLS_PROTOCOL_KEY = "killbill.payment.recurly.tlsProtocol";
     private static final String TLS_PROTOCOL_DEFAULT = "TLSv1.2";
-    private SSLContext context;
+    private SslContext context;
 
     private static class SingletonHolder {
         public static final SslUtils instance = new SslUtils();
@@ -36,12 +37,12 @@ public class SslUtils {
         return SingletonHolder.instance;
     }
 
-    public SSLContext getSSLContext() throws NoSuchAlgorithmException, KeyManagementException {
+    public SslContext getSslContext() throws SSLException {
         if (context != null) return this.context;
 
         final String protocol = System.getProperty(TLS_PROTOCOL_KEY, TLS_PROTOCOL_DEFAULT);
-        context = SSLContext.getInstance(protocol);
-        context.init(null, null, null);
+
+        context = SslContextBuilder.forClient().protocols(protocol).build();
 
         return context;
     }

--- a/src/test/java/com/ning/billing/recurly/model/TestRedemption.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestRedemption.java
@@ -57,7 +57,7 @@ public class TestRedemption extends TestModelBase {
         redemption.setSubscriptionUuid("374a1c75374bd81493a3f7425db0a2b8");
 
         final String xml = xmlMapper.writeValueAsString(redemption);
-        Assert.assertEquals(xml, "<redemption xmlns=\"\">" +
+        Assert.assertEquals(xml, "<redemption>" +
                 "<account_code>1</account_code>" +
                 "<subscription_uuid>374a1c75374bd81493a3f7425db0a2b8</subscription_uuid>" +
                 "<currency>USD</currency>" +
@@ -68,7 +68,7 @@ public class TestRedemption extends TestModelBase {
         redemptionWithoutUuid.setCurrency("USD");
 
         final String secondXml = xmlMapper.writeValueAsString(redemptionWithoutUuid);
-        Assert.assertEquals(secondXml, "<redemption xmlns=\"\">" +
+        Assert.assertEquals(secondXml, "<redemption>" +
             "<account_code>1</account_code>" +
             "<currency>USD</currency>" +
             "</redemption>");

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
@@ -52,7 +52,7 @@ public class TestSubscriptionUpdate extends TestModelBase {
         subscription.setQuantity(1);
 
         final String xml = xmlMapper.writeValueAsString(subscription);
-        Assert.assertEquals(xml, "<subscription xmlns=\"\">" +
+        Assert.assertEquals(xml, "<subscription>" +
                                  "<timeframe>now</timeframe>" +
                                  "<unit_amount_in_cents>800</unit_amount_in_cents>" +
                                  "<quantity>1</quantity>" +
@@ -70,11 +70,11 @@ public class TestSubscriptionUpdate extends TestModelBase {
         subscription.setAddOns(new SubscriptionAddOns());
 
         final String xml = xmlMapper.writeValueAsString(subscription);
-        Assert.assertEquals(xml, "<subscription xmlns=\"\">" +
+        Assert.assertEquals(xml, "<subscription>" +
                                  "<timeframe>now</timeframe>" +
                                  "<unit_amount_in_cents>800</unit_amount_in_cents>" +
                                  "<quantity>1</quantity>" +
-                                 "<subscription_add_ons></subscription_add_ons>" +
+                                 "<subscription_add_ons/>" +
                                  "<plan_code>gold</plan_code>" +
                                  "</subscription>");
     }
@@ -95,7 +95,7 @@ public class TestSubscriptionUpdate extends TestModelBase {
         subscription.setAddOns(addOns);
 
         final String xml = xmlMapper.writeValueAsString(subscription);
-        Assert.assertEquals(xml, "<subscription xmlns=\"\">" +
+        Assert.assertEquals(xml, "<subscription>" +
                                  "<timeframe>now</timeframe>" +
                                  "<unit_amount_in_cents>800</unit_amount_in_cents>" +
                                  "<quantity>1</quantity>" +
@@ -120,7 +120,7 @@ public class TestSubscriptionUpdate extends TestModelBase {
         subscription.setCouponCode("my_coupon");
 
         final String xml = xmlMapper.writeValueAsString(subscription);
-        Assert.assertEquals(xml, "<subscription xmlns=\"\">" +
+        Assert.assertEquals(xml, "<subscription>" +
                                  "<timeframe>now</timeframe>" +
                                  "<unit_amount_in_cents>800</unit_amount_in_cents>" +
                                  "<quantity>1</quantity>" +


### PR DESCRIPTION
The old async-http-client and jackson dependencies used by recurly-java-library are failing owasp dependency-check because of some vulnerabilities present in the libraries, with the following output:

```
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:3.1.2:check (default) on project:
[ERROR] 
[ERROR] One or more dependencies were identified with vulnerabilities:
[ERROR] 
[ERROR] netty-3.10.0.Final.jar: CVE-2015-2156
[ERROR] async-http-client-1.9.8.jar: CVE-2017-14063
[ERROR] recurly-java-library-0.15.0.jar/META-INF/maven/com.fasterxml.jackson.core/jackson-databind/pom.xml: CVE-2017-15095, CVE-2017-17485, CVE-2017-7525, CVE-2018-7489, CVE-2018-5968
[ERROR] recurly-java-library-0.15.0.jar/META-INF/maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/pom.xml: CVE-2017-15095, CVE-2017-17485, CVE-2017-7525, CVE-2016-7051, CVE-2016-3720
```

In this PR I have updated the dependencies: async-http-client 1.9.8 to 2.4.5, jackson from 2.5.0 to 2.9.5 and maven-duplicate-finder-plugin 1.0.3 to duplicate-finder-maven-plugin 1.3.0. The updated jackson resulted in some cosmetic changes in xml serialization/deserialization, so the test changes should be reviewed (and probably the StringSanitizerModule removed from RecurlyObject class). 