### PR TITLE
Save value of X-RateLimit-Remaining

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -174,7 +174,7 @@ public class RecurlyClient {
 
     /**
      * Returns the number of requests remaining until requests will be denied by rate limiting.
-     * @return Number of request remaining. Value is valid (> -1) after a successful API call.
+     * @return Number of requests remaining. Value is valid (> -1) after a successful API call.
      */
     public int getRateLimitRemaining() {
         return rateLimitRemaining;
@@ -1963,7 +1963,7 @@ public class RecurlyClient {
                 }
             }
 
-            // set rate limit header
+            // Save value of rate limit remaining header
             String rateLimitRemainingString = response.getHeader(X_RATELIMIT_REMAINING_HEADER_NAME);
             if (rateLimitRemainingString != null)
                 rateLimitRemaining = Integer.parseInt(rateLimitRemainingString);

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -105,6 +105,7 @@ public class RecurlyClient {
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
     public static final String RECURLY_API_VERSION = "2.11";
 
+    private static final String X_RATELIMIT_REMAINING_HEADER_NAME = "X-RateLimit-Remaining";
     private static final String X_RECORDS_HEADER_NAME = "X-Records";
     private static final String LINK_HEADER_NAME = "Link";
 
@@ -132,6 +133,9 @@ public class RecurlyClient {
     private final String baseUrl;
     private AsyncHttpClient client;
 
+    // Stores the number of requests remaining before rate limiting takes effect
+    private int rateLimitRemaining;
+
     public RecurlyClient(final String apiKey) {
         this(apiKey, "api");
     }
@@ -149,6 +153,7 @@ public class RecurlyClient {
         this.baseUrl = String.format("%s://%s:%d/%s", scheme, host, port, version);
         this.xmlMapper = RecurlyObject.newXmlMapper();
         this.userAgent = buildUserAgent();
+        this.rateLimitRemaining = -1;
     }
 
     /**
@@ -165,6 +170,14 @@ public class RecurlyClient {
         if (client != null) {
             client.close();
         }
+    }
+
+    /**
+     * Returns the number of requests remaining until requests will be denied by rate limiting.
+     * @return Number of request remaining. Value is valid (> -1) after a successful API call.
+     */
+    public int getRateLimitRemaining() {
+        return rateLimitRemaining;
     }
 
     /**
@@ -1949,6 +1962,12 @@ public class RecurlyClient {
                     recurlyObjects.setNextUrl(links[1]);
                 }
             }
+
+            // set rate limit header
+            String rateLimitRemainingString = response.getHeader(X_RATELIMIT_REMAINING_HEADER_NAME);
+            if (rateLimitRemainingString != null)
+                rateLimitRemaining = Integer.parseInt(rateLimitRemainingString);
+
             return obj;
         } finally {
             closeStream(in);


### PR DESCRIPTION
For each successful api XML request, save the value of X-RateLimit-Remaining (see: https://dev.recurly.com/docs/rate-limits).  This is helpful for implementing custom throttling.