### PR TITLE
support coupon enum type unique_code

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Coupon.java
+++ b/src/main/java/com/ning/billing/recurly/model/Coupon.java
@@ -53,7 +53,7 @@ public class Coupon extends RecurlyObject {
     }
 
     public enum Type {
-        single_code, bulk
+        single_code, bulk, unique_code
     }
 
     @XmlTransient


### PR DESCRIPTION
Resolves #235 

Issue:

`com.ning.billing.recurly.shaded.com.fasterxml.jackson.databind.exc.InvalidFormatException: Can not construct instance of com.ning.billing.recurly.model.Coupon$Type from String value 'unique_code': value not one of declared Enum instance names: [single_code, bulk]`