### PR TITLE
Support coupon code field in GET account's coupon redemptions

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Redemption.java
+++ b/src/main/java/com/ning/billing/recurly/model/Redemption.java
@@ -64,6 +64,9 @@ public class Redemption extends RecurlyObject {
     @XmlElement(name = "state")
     private String state;
 
+    @XmlElement(name = "coupon_code")
+    private String couponCode;
+
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
@@ -140,6 +143,14 @@ public class Redemption extends RecurlyObject {
         this.state = stringOrNull(state);
     }
 
+    public String getCouponCode() {
+        return couponCode;
+    }
+
+    public void setCouponCode(final Object couponCode) {
+        this.couponCode = stringOrNull(couponCode);
+    }
+
     public String getUuid() {
         return uuid;
     }
@@ -177,6 +188,7 @@ public class Redemption extends RecurlyObject {
         sb.append(", totalDiscountedInCents=").append(totalDiscountedInCents);
         sb.append(", currency='").append(currency).append('\'');
         sb.append(", state='").append(state).append('\'');
+        sb.append(", couponCode='").append(couponCode).append('\'');
         sb.append(", createdAt=").append(createdAt);
         sb.append(", updatedAt=").append(updatedAt);
         sb.append('}');
@@ -215,6 +227,9 @@ public class Redemption extends RecurlyObject {
         if (state != null ? !state.equals(that.state) : that.state != null) {
             return false;
         }
+        if (couponCode != null ? !couponCode.equals(that.couponCode) : that.couponCode != null) {
+            return false;
+        }
         if (createdAt != null ? createdAt.compareTo(that.createdAt) != 0 : that.createdAt != null) {
             return false;
         }
@@ -239,6 +254,7 @@ public class Redemption extends RecurlyObject {
                 totalDiscountedInCents,
                 currency,
                 state,
+                couponCode,
                 uuid,
                 createdAt,
                 updatedAt

--- a/src/test/java/com/ning/billing/recurly/model/TestRedemptions.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestRedemptions.java
@@ -37,6 +37,7 @@ public class TestRedemptions extends TestModelBase {
                 "    <total_discounted_in_cents type=\"integer\">0</total_discounted_in_cents>\n" +
                 "    <currency>USD</currency>\n" +
                 "    <state>active</state>\n" +
+                "    <coupon_code>special</coupon_code>\n" +
                 "    <created_at type=\"dateTime\">2015-09-23T17:13:30Z</created_at>\n" +
                 "    <updated_at type=\"dateTime\">2015-09-23T17:13:30Z</updated_at>\n" +
                 "  </redemption>\n" +
@@ -48,6 +49,7 @@ public class TestRedemptions extends TestModelBase {
                 "    <total_discounted_in_cents type=\"integer\">1500</total_discounted_in_cents>\n" +
                 "    <currency>USD</currency>\n" +
                 "    <state>active</state>\n" +
+                "    <coupon_code>special2</coupon_code>\n" +
                 "    <created_at type=\"dateTime\">2011-06-27T12:34:56Z</created_at>\n" +
                 "    <updated_at type=\"dateTime\">2011-06-27T12:34:56Z</updated_at>\n" +
                 "  </redemption>\n" +
@@ -62,6 +64,7 @@ public class TestRedemptions extends TestModelBase {
         Assert.assertEquals(redemption.getAccountCode(), "1");
         Assert.assertEquals(redemption.getState(), "active");
         Assert.assertEquals(redemption.getCurrency(), "USD");
+        Assert.assertEquals(redemption.getCouponCode(), "special");
         Assert.assertEquals(redemption.getCreatedAt(), new DateTime("2015-09-23T17:13:30Z"));
         Assert.assertEquals(redemption.getUpdatedAt(), new DateTime("2015-09-23T17:13:30Z"));
     }


### PR DESCRIPTION
Issue: coupon code field is not supported in the `Redemption` model. 

Link: https://dev.recurly.com/docs/coupon-redemption-object

Sample payload:
```<?xml version="1.0" encoding="UTF-8"?>
<redemptions type="array">
  <redemption href="https://your-domain.recurly.com/v2/accounts/123/redemptions/123456">
    <coupon href="https://your-domain.recurly.com/v2/coupons/special"/>
    <account href="https://your-domain.recurly.com/v2/accounts/123"/>
    <uuid>123456</uuid>
    <single_use type="boolean">true</single_use>
    <total_discounted_in_cents type="integer">0</total_discounted_in_cents>
    <currency>USD</currency>
    <state>active</state>
    <coupon_code>special</coupon_code>
    <created_at type="datetime">2017-03-25T22:18:23Z</created_at>
    <updated_at type="datetime">2017-03-25T22:18:23Z</updated_at>
  </redemption>
  <redemption href="https://your-domain.recurly.com/v2/accounts/123/redemptions/123457">
    <coupon href="https://your-domain.recurly.com/v2/coupons/special2"/>
    <account href="https://your-domain.recurly.com/v2/accounts/123"/>
    <subscription href="https://your-domain.recurly.com/v2/subscriptions/100000"/>
    <uuid>123400</uuid>
    <single_use type="boolean">false</single_use>
    <total_discounted_in_cents type="integer">23880</total_discounted_in_cents>
    <currency>USD</currency>
    <state>inactive</state>
    <coupon_code>special2</coupon_code>
    <created_at type="datetime">2016-12-06T23:08:36Z</created_at>
    <updated_at type="datetime">2017-01-30T15:45:11Z</updated_at>
  </redemption>
</redemptions>
```