### PR TITLE
fix autoRenew parameter

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -511,7 +511,7 @@ public class Subscription extends AbstractSubscription {
         return this.autoRenew;
     }
 
-    public void setAutoRenew(final Object trialRequiresBillingInfo) {
+    public void setAutoRenew(final Object autoRenew) {
         this.autoRenew = booleanOrNull(autoRenew);
     }
 


### PR DESCRIPTION
The setAutoRenew function in subscription has the wrong parameter name.