### PR TITLE
Add Custom Fields support to updateNotes

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionNotes.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionNotes.java
@@ -17,9 +17,10 @@
 
 package com.ning.billing.recurly.model;
 
-import javax.xml.bind.annotation.XmlElement;
-
 import com.google.common.base.Objects;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 
 public class SubscriptionNotes extends AbstractSubscription {
 
@@ -30,7 +31,11 @@ public class SubscriptionNotes extends AbstractSubscription {
     private String customerNotes;
     
     @XmlElement(name = "vat_reverse_charge_notes")
-    private String vatReverseChargeNotes;    
+    private String vatReverseChargeNotes;
+
+    @XmlElementWrapper(name = "custom_fields")
+    @XmlElement(name = "custom_field")
+    private CustomFields customFields;
 
     public String getTermsAndConditions() {
         return termsAndConditions;
@@ -55,13 +60,22 @@ public class SubscriptionNotes extends AbstractSubscription {
     public void setVatReverseChargeNotes(final Object getVatReverseChargeNotes) {
         this.vatReverseChargeNotes = stringOrNull(vatReverseChargeNotes);
     }
-    
+
+    public CustomFields getCustomFields() {
+        return customFields;
+    }
+
+    public void setCustomFields(final CustomFields customFields) {
+        this.customFields = customFields;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("Subscription{");
         sb.append("termsAndConditions=").append(termsAndConditions).append('\'');
         sb.append(", customerNotes=").append(customerNotes).append('\'');
         sb.append(", vatReverseChargeNotes=").append(vatReverseChargeNotes).append('\'');
+        sb.append(", customFields=").append(customFields);
         sb.append('}');
         return sb.toString();
     }
@@ -79,6 +93,9 @@ public class SubscriptionNotes extends AbstractSubscription {
         if (customerNotes != null ? !customerNotes.equals(that.customerNotes) : that.customerNotes != null) {
             return false;
         }
+        if (customFields != null ? !customFields.equals(that.customFields) : that.customFields != null) {
+            return false;
+        }
         if (vatReverseChargeNotes != null ? !vatReverseChargeNotes.equals(that.vatReverseChargeNotes) : that.vatReverseChargeNotes != null) {
             return false;
         }
@@ -91,7 +108,8 @@ public class SubscriptionNotes extends AbstractSubscription {
         return Objects.hashCode(
                 termsAndConditions,
                 customerNotes,
-                vatReverseChargeNotes
+                vatReverseChargeNotes,
+                customFields
         );
     }
 }

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -727,6 +727,9 @@ public class TestRecurlyClient {
             final SubscriptionNotes subscriptionNotesData = new SubscriptionNotes();
             subscriptionNotesData.setTermsAndConditions("New Terms and Conditions");
             subscriptionNotesData.setCustomerNotes("New Customer Notes");
+            final CustomFields customFields = new CustomFields();
+            customFields.add(TestUtils.createRandomCustomField("food"));
+            subscriptionNotesData.setCustomFields(customFields);
 
             recurlyClient.updateSubscriptionNotes(subscription.getUuid(), subscriptionNotesData);
             final Subscription subscriptionWithNotes = recurlyClient.getSubscription(subscription.getUuid());
@@ -735,6 +738,7 @@ public class TestRecurlyClient {
             Assert.assertNotNull(subscriptionWithNotes);
             Assert.assertEquals(subscriptionWithNotes.getTermsAndConditions(), subscriptionNotesData.getTermsAndConditions());
             Assert.assertEquals(subscriptionWithNotes.getCustomerNotes(), subscriptionNotesData.getCustomerNotes());
+            Assert.assertEquals(subscriptionWithNotes.getCustomFields().get(0).getValue(), subscriptionNotesData.getCustomFields().get(0).getValue());
 
             // Cancel a Subscription
             recurlyClient.cancelSubscription(subscription);


### PR DESCRIPTION
This is for API version 2.14. Adds Custom Fields support on `updateNotes`.