### PR TITLE
Remove travis badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-recurly-java-library [![Build Status](https://travis-ci.org/killbilling/recurly-java-library.svg?branch=master)](https://travis-ci.org/killbilling/recurly-java-library)
+recurly-java-library
 ====================
 
 Java library for Recurly, originally developed for [Kill Bill](http://killbill.io), an open-source subscription management and billing system.


### PR DESCRIPTION
This always says the build is failing and I can't figure out why. It's
makes it look like the master build has always failed even though it
hasn't. I'd rather remove this than fix it.