### PR TITLE
Add support for subscription ids array in invoice related webhooks

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/push/invoice/PushInvoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/invoice/PushInvoice.java
@@ -18,10 +18,17 @@ package com.ning.billing.recurly.model.push.invoice;
 
 import com.ning.billing.recurly.model.Invoice;
 import org.joda.time.DateTime;
+import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlList;
 
 public class PushInvoice extends Invoice {
+
+    @XmlList
+    @XmlElementWrapper(name = "subscription_ids")
+    private List<String> subscriptionIds;
 
     @XmlElement(name = "subscription_id")
     private String subscriptionId;
@@ -41,10 +48,26 @@ public class PushInvoice extends Invoice {
     @XmlElement(name = "final_dunning_event")
     private Boolean isFinalDunningEvent;
 
+    public List<String> getSubscriptionIds() {
+        return subscriptionIds;
+    }
+
+    public void setSubscriptionIds(final List<String> subscriptionIds) {
+        this.subscriptionIds = subscriptionIds;
+    }
+
+    /**
+     * @deprecated Use getSubscriptionIds instead
+     */
+    @Deprecated
     public String getSubscriptionId() {
         return subscriptionId;
     }
 
+    /**
+     * @deprecated Use setSubscriptionIds instead
+     */
+    @Deprecated
     public void setSubscriptionId(final Object subscriptionId) {
         this.subscriptionId = stringOrNull(subscriptionId);
     }
@@ -103,6 +126,10 @@ public class PushInvoice extends Invoice {
 
         final PushInvoice that = (PushInvoice) o;
 
+        if (subscriptionIds != null ? !subscriptionIds.equals(that.subscriptionIds) : that.subscriptionIds != null) {
+            return false;
+        }
+
         if (subscriptionId != null ? !subscriptionId.equals(that.subscriptionId) : that.subscriptionId != null) {
             return false;
         }
@@ -125,6 +152,7 @@ public class PushInvoice extends Invoice {
     @Override
     public int hashCode() {
         int result = super.hashCode();
+        result = 31 * result + (subscriptionIds != null ? subscriptionIds.hashCode() : 0);
         result = 31 * result + (subscriptionId != null ? subscriptionId.hashCode() : 0);
         result = 31 * result + (invoiceNumberPrefix != null ? invoiceNumberPrefix.hashCode() : 0);
         result = 31 * result + (date != null ? date.hashCode() : 0);

--- a/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
@@ -105,6 +105,10 @@ public class TestNotification extends TestModelBase {
                                               "  <invoice_number type=\"integer\">1000</invoice_number>\n" +
                                               "  <po_number>PO-12345</po_number>\n" +
                                               "  <vat_number></vat_number>\n" +
+                                              "  <subscription_ids type=\"array\">\n" +
+                                              "    <subscription_id>40b8f5e99df03b8684b99d4993b6e088</subscription_id>\n" +
+                                              "    <subscription_id>40b8f5e99df03b8684b99d4993b6e089</subscription_id>\n" +
+                                              "  </subscription_ids>\n" +
                                               "  <total_in_cents type=\"integer\">1100</total_in_cents>\n" +
                                               "  <currency>USD</currency>\n" +
                                               "  <date type=\"dateTime\">2014-01-01T20:20:29Z</date>\n" +
@@ -331,7 +335,7 @@ public class TestNotification extends TestModelBase {
         PushInvoice invoice = invoiceNotification.getInvoice();
         Assert.assertNotNull(invoice);
         Assert.assertEquals(invoice.getUuid(), "ffc64d71d4b5404e93f13aac9c63b007");
-        Assert.assertNull(invoice.getSubscriptionId());
+        Assert.assertEquals(invoice.getSubscriptionIds().get(0), "40b8f5e99df03b8684b99d4993b6e088");
         Assert.assertEquals(invoice.getState(), "collected");
         Assert.assertNull(invoice.getInvoiceNumberPrefix());
         Assert.assertEquals(invoice.getInvoiceNumber(), new Integer(1000));


### PR DESCRIPTION
Fixes #286 

The new Credit and Charge invoice webhooks provide an array of subscription IDs rather than a single subscription ID. This adds support for that new array.