### PR TITLE
Fix warnings given by compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,10 +304,6 @@
                     <source>1.6</source>
                     <encoding>UTF-8</encoding>
                     <maxmemory>2g</maxmemory>
-                    <links>
-                        <link>http://commons.apache.org/lang/api/</link>
-                        <link>http://download.oracle.com/javase/6/docs/api/</link>
-                    </links>
                     <linksource>true</linksource>
                     <show>public</show>
                     <!-- That's for https://github.com/github/maven-plugins/issues/2 -->
@@ -368,106 +364,6 @@
                     <chmod>true</chmod>
                     <inputEncoding>UTF-8</inputEncoding>
                     <outputEncoding>UTF-8</outputEncoding>
-                    <reportPlugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-changelog-plugin</artifactId>
-                            <version>2.2</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-checkstyle-plugin</artifactId>
-                            <version>2.8</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <additionalparam>-quiet</additionalparam>
-                            </configuration>
-                            <reportSets>
-                                <reportSet>
-                                    <id>html</id>
-                                    <reports>
-                                        <report>javadoc</report>
-                                        <report>test-javadoc</report>
-                                    </reports>
-                                </reportSet>
-                            </reportSets>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-jxr-plugin</artifactId>
-                            <version>2.3</version>
-                            <configuration>
-                                <linkJavadoc>true</linkJavadoc>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-report-plugin</artifactId>
-                            <version>2.10</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-project-info-reports-plugin</artifactId>
-                            <version>2.4</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.rat</groupId>
-                            <artifactId>apache-rat-plugin</artifactId>
-                            <configuration>
-                                <excludes>
-                                    <!-- For some reason, useIdeaDefaultExcludes doesn't pick up .idea directory -->
-                                    <exclude>.idea/**</exclude>
-                                    <exclude>.git/**</exclude>
-                                    <exclude>.gitignore</exclude>
-                                    <exclude>README.*</exclude>
-                                    <exclude>doc/**</exclude>
-                                    <exclude>src/site/**</exclude>
-                                    <exclude>*.log</exclude>
-                                </excludes>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.codehaus.mojo</groupId>
-                            <artifactId>cobertura-maven-plugin</artifactId>
-                            <version>2.5.1</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.codehaus.mojo</groupId>
-                            <artifactId>findbugs-maven-plugin</artifactId>
-                            <version>2.3.2</version>
-                            <configuration>
-                                <threshold>Low</threshold>
-                                <effort>Max</effort>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.codehaus.mojo</groupId>
-                            <artifactId>taglist-maven-plugin</artifactId>
-                            <version>2.4</version>
-                            <configuration>
-                                <tagListOptions>
-                                    <tagClasses>
-                                        <tagClass>
-                                            <displayName>Todo Work</displayName>
-                                            <tags>
-                                                <tag>
-                                                    <matchString>todo</matchString>
-                                                    <matchType>ignoreCase</matchType>
-                                                </tag>
-                                                <tag>
-                                                    <matchString>FIXME</matchString>
-                                                    <matchType>exact</matchType>
-                                                </tag>
-                                            </tags>
-                                        </tagClass>
-                                    </tagClasses>
-                                </tagListOptions>
-                            </configuration>
-                        </plugin>
-                    </reportPlugins>
                 </configuration>
             </plugin>
             <plugin>
@@ -602,6 +498,108 @@
             </build>
         </profile>
     </profiles>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-changelog-plugin</artifactId>
+                <version>2.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.8</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalparam>-quiet</additionalparam>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <id>html</id>
+                        <reports>
+                            <report>javadoc</report>
+                            <report>test-javadoc</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>2.3</version>
+                <configuration>
+                    <linkJavadoc>true</linkJavadoc>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>2.10</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <!-- For some reason, useIdeaDefaultExcludes doesn't pick up .idea directory -->
+                        <exclude>.idea/**</exclude>
+                        <exclude>.git/**</exclude>
+                        <exclude>.gitignore</exclude>
+                        <exclude>README.*</exclude>
+                        <exclude>doc/**</exclude>
+                        <exclude>src/site/**</exclude>
+                        <exclude>*.log</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.5.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <threshold>Low</threshold>
+                    <effort>Max</effort>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>taglist-maven-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <tagListOptions>
+                        <tagClasses>
+                            <tagClass>
+                                <displayName>Todo Work</displayName>
+                                <tags>
+                                    <tag>
+                                        <matchString>todo</matchString>
+                                        <matchType>ignoreCase</matchType>
+                                    </tag>
+                                    <tag>
+                                        <matchString>FIXME</matchString>
+                                        <matchType>exact</matchType>
+                                    </tag>
+                                </tags>
+                            </tagClass>
+                        </tagClasses>
+                    </tagListOptions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
     <mailingLists>
         <mailingList>
             <name>Killbilling users</name>

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -332,7 +332,7 @@ public class RecurlyClient {
      * <p>
      *
      * @param accountCode recurly account id
-     * @param type {@link Adjustments.AdjustmentType}
+     * @param type {@link com.ning.billing.recurly.model.Adjustments.AdjustmentType}
      * @return the adjustments on the account
      */
     public Adjustments getAccountAdjustments(final String accountCode, final Adjustments.AdjustmentType type) {
@@ -344,8 +344,8 @@ public class RecurlyClient {
      * <p>
      *
      * @param accountCode recurly account id
-     * @param type {@link Adjustments.AdjustmentType}
-     * @param state {@link Adjustments.AdjustmentState}
+     * @param type {@link com.ning.billing.recurly.model.Adjustments.AdjustmentType}
+     * @param state {@link com.ning.billing.recurly.model.Adjustments.AdjustmentState}
      * @return the adjustments on the account
      */
     public Adjustments getAccountAdjustments(final String accountCode, final Adjustments.AdjustmentType type, final Adjustments.AdjustmentState state) {
@@ -357,8 +357,8 @@ public class RecurlyClient {
      * <p>
      *
      * @param accountCode recurly account id
-     * @param type {@link Adjustments.AdjustmentType}
-     * @param state {@link Adjustments.AdjustmentState}
+     * @param type {@link com.ning.billing.recurly.model.Adjustments.AdjustmentType}
+     * @param state {@link com.ning.billing.recurly.model.Adjustments.AdjustmentState}
      * @param params {@link QueryParams}
      * @return the adjustments on the account
      */
@@ -1844,7 +1844,6 @@ public class RecurlyClient {
      * https://dev.recurly.com/docs/clear-account-acquisition
      *
      * @param accountCode The account's account code
-     * @return The cleared AccountAcquisition object
      */
     public void deleteAccountAcquisition(final String accountCode) {
         doDELETE(Account.ACCOUNT_RESOURCE + "/" + accountCode + AccountAcquisition.ACCOUNT_ACQUISITION_RESOURCE);


### PR DESCRIPTION
I noticed some compiler warnings when building the project that I wanted to address.

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for com.ning.billing:recurly-java-library:jar:0.20.1-SNAPSHOT
[WARNING] Reporting configuration should be done in <reporting> section, not in maven-site-plugin <configuration> as reportPlugins parameter. @ line 367, column 32
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[WARNING] Javadoc Warnings
[WARNING] javadoc: warning - Error fetching URL: http://commons.apache.org/lang/api/
[WARNING] /Users/asuarez/code/v2/clients/java/src/main/java/com/ning/billing/recurly/RecurlyClient.java:338: warning - Tag @link: reference not found: Adjustments.AdjustmentType
[WARNING] /Users/asuarez/code/v2/clients/java/src/main/java/com/ning/billing/recurly/RecurlyClient.java:351: warning - Tag @link: reference not found: Adjustments.AdjustmentType
[WARNING] /Users/asuarez/code/v2/clients/java/src/main/java/com/ning/billing/recurly/RecurlyClient.java:351: warning - Tag @link: reference not found: Adjustments.AdjustmentState
[WARNING] /Users/asuarez/code/v2/clients/java/src/main/java/com/ning/billing/recurly/RecurlyClient.java:365: warning - Tag @link: reference not found: Adjustments.AdjustmentType
[WARNING] /Users/asuarez/code/v2/clients/java/src/main/java/com/ning/billing/recurly/RecurlyClient.java:365: warning - Tag @link: reference not found: Adjustments.AdjustmentState
[WARNING] /Users/asuarez/code/v2/clients/java/src/main/java/com/ning/billing/recurly/RecurlyClient.java:1849: warning - @return tag cannot be used in method with void return type.
```