### PR TITLE
Support total_billing_cycles and setup_fee_accounting_code in GET /plans

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Plan.java
+++ b/src/main/java/com/ning/billing/recurly/model/Plan.java
@@ -77,11 +77,17 @@ public class Plan extends RecurlyObject {
     @XmlElement(name = "trial_interval_unit")
     private String trialIntervalUnit;
 
+    @XmlElement(name = "total_billing_cycles")
+    private Integer totalBillingCycles;
+
     @XmlElement(name = "trial_requires_billing_info")
     private Boolean trialRequiresBillingInfo;
 
     @XmlElement(name = "accounting_code")
     private String accountingCode;
+
+    @XmlElement(name = "setup_fee_accounting_code")
+    private String setupFeeAccountingCode;
 
     @XmlElement(name = "revenue_schedule_type")
     private RevenueScheduleType revenueScheduleType;
@@ -208,6 +214,14 @@ public class Plan extends RecurlyObject {
         this.trialIntervalUnit = stringOrNull(trialIntervalUnit);
     }
 
+    public Integer getTotalBillingCycles() {
+        return totalBillingCycles;
+    }
+
+    public void setTotalBillingCycles(final Object totalBillingCycles) {
+        this.totalBillingCycles = integerOrNull(totalBillingCycles);
+    }
+
     public Boolean getTrialRequiresBillingInfo() {
         return this.trialRequiresBillingInfo;
     }
@@ -230,6 +244,14 @@ public class Plan extends RecurlyObject {
 
     public void setAccountingCode(final Object accountingCode) {
         this.accountingCode = stringOrNull(accountingCode);
+    }
+
+    public String getSetupFeeAccountingCode() {
+        return setupFeeAccountingCode;
+    }
+
+    public void setSetupFeeAccountingCode(final Object setupFeeAccountingCode) {
+        this.setupFeeAccountingCode = stringOrNull(setupFeeAccountingCode);
     }
 
     public DateTime getCreatedAt() {
@@ -315,8 +337,10 @@ public class Plan extends RecurlyObject {
         sb.append(", planIntervalLength=").append(planIntervalLength);
         sb.append(", trialIntervalLength=").append(trialIntervalLength);
         sb.append(", trialIntervalUnit='").append(trialIntervalUnit).append('\'');
+        sb.append(", totalBillingCycles").append(totalBillingCycles);
         sb.append(", trialRequiresBillingInfo='").append(trialRequiresBillingInfo).append('\'');
         sb.append(", accountingCode='").append(accountingCode).append('\'');
+        sb.append(", setupFeeAccountingCode='").append(setupFeeAccountingCode).append('\'');
         sb.append(", createdAt=").append(createdAt);
         sb.append(", updatedAt=").append(updatedAt);
         sb.append(", unitAmountInCents=").append(unitAmountInCents);
@@ -407,6 +431,12 @@ public class Plan extends RecurlyObject {
         if (updatedAt != null ? updatedAt.compareTo(plan.updatedAt) != 0: plan.updatedAt != null) {
             return false;
         }
+        if (totalBillingCycles != null ? totalBillingCycles.compareTo(plan.totalBillingCycles) != 0: plan.totalBillingCycles != null) {
+            return false;
+        }
+        if (setupFeeAccountingCode != null ? setupFeeAccountingCode.compareTo(plan.setupFeeAccountingCode) != 0: plan.setupFeeAccountingCode != null) {
+            return false;
+        }
 
         return true;
     }
@@ -429,7 +459,9 @@ public class Plan extends RecurlyObject {
                 planIntervalLength,
                 trialIntervalUnit,
                 trialIntervalLength,
+                totalBillingCycles,
                 accountingCode,
+                setupFeeAccountingCode,
                 createdAt,
                 updatedAt,
                 unitAmountInCents,

--- a/src/test/java/com/ning/billing/recurly/model/TestPlan.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPlan.java
@@ -48,7 +48,9 @@ public class TestPlan extends TestModelBase {
                                 "  <plan_interval_unit>months</plan_interval_unit>\n" +
                                 "  <trial_interval_length type=\"integer\">0</trial_interval_length>\n" +
                                 "  <trial_interval_unit>days</trial_interval_unit>\n" +
+                                "  <total_billing_cycles type=\"integer\">24</total_billing_cycles>\n" +
                                 "  <accounting_code nil=\"nil\"></accounting_code>\n" +
+                                "  <setup_fee_accounting_code nil=\"nil\"></setup_fee_accounting_code>\n" +
                                 "  <created_at type=\"dateTime\">2011-04-19T07:00:00Z</created_at>\n" +
                                 "  <updated_at type=\"dateTime\">2011-04-19T07:00:00Z</updated_at>\n" +
                                 "  <unit_amount_in_cents>\n" +
@@ -79,7 +81,9 @@ public class TestPlan extends TestModelBase {
         Assert.assertNull(plan.getDescription());
         Assert.assertNull(plan.getSuccessLink());
         Assert.assertNull(plan.getCancelLink());
+        Assert.assertEquals(24, (int) plan.getTotalBillingCycles());
         Assert.assertNull(plan.getAccountingCode());
+        Assert.assertNull(plan.getSetupFeeAccountingCode());
     }
 
     @Test(groups = "fast")
@@ -103,7 +107,9 @@ public class TestPlan extends TestModelBase {
                                 "  <plan_interval_unit>months</plan_interval_unit>\n" +
                                 "  <trial_interval_length type=\"integer\">0</trial_interval_length>\n" +
                                 "  <trial_interval_unit>days</trial_interval_unit>\n" +
+                                "  <total_billing_cycles type=\"integer\">24</total_billing_cycles>\n" +
                                 "  <accounting_code nil=\"nil\"></accounting_code>\n" +
+                                "  <setup_fee_accounting_code nil=\"nil\"></setup_fee_accounting_code>\n" +
                                 "  <revenue_schedule_type>evenly</revenue_schedule_type>\n" +
                                 "  <setup_fee_revenue_schedule_type>evenly</setup_fee_revenue_schedule_type>>\n" +
                                 "  <created_at type=\"dateTime\">2011-04-19T07:00:00Z</created_at>\n" +
@@ -130,7 +136,9 @@ public class TestPlan extends TestModelBase {
         Assert.assertNull(plan.getDescription());
         Assert.assertNull(plan.getSuccessLink());
         Assert.assertNull(plan.getCancelLink());
+        Assert.assertEquals(24, (int) plan.getTotalBillingCycles());
         Assert.assertNull(plan.getAccountingCode());
+        Assert.assertNull(plan.getSetupFeeAccountingCode());
         Assert.assertEquals(plan.getRevenueScheduleType(), RevenueScheduleType.EVENLY);
         Assert.assertEquals(plan.getSetupFeeRevenueScheduleType(), RevenueScheduleType.EVENLY);
     }


### PR DESCRIPTION
Hey maintainers, thank you for the continued work! We continue to use this library in production today.

Slight addition to the `Plans` model, as the Plans API now supports two additional fields, `total_billing_cycles` and `setup_fee_accounting_code`. 

GET recurly plan API: https://dev.recurly.com/docs/lookup-plan-details

sample payload I've obtained via curling recurly directly
```
<?xml version="1.0" encoding="UTF-8"?>
<plan href="https://asdf.recurly.com/v2/plans/asdf-plan">
  <add_ons href="https://asdf.recurly.com/v2/plans/asdf-plan/add_ons"/>
  <plan_code>asdf-plan</plan_code>
  <name>The Default Four Letter Plan</name>
  <description nil="nil"></description>
  <success_url nil="nil"></success_url>
  <cancel_url nil="nil"></cancel_url>
  <display_donation_amounts type="boolean">false</display_donation_amounts>
  <display_quantity type="boolean">false</display_quantity>
  <display_phone_number type="boolean">false</display_phone_number>
  <bypass_hosted_confirmation type="boolean">false</bypass_hosted_confirmation>
  <unit_name>unit</unit_name>
  <payment_page_tos_link nil="nil"></payment_page_tos_link>
  <plan_interval_length type="integer">1</plan_interval_length>
  <plan_interval_unit>months</plan_interval_unit>
  <trial_interval_length type="integer">0</trial_interval_length>
  <trial_interval_unit>days</trial_interval_unit>
  <total_billing_cycles type="integer">24</total_billing_cycles>
  <accounting_code nil="nil"></accounting_code>
  <setup_fee_accounting_code nil="nil"></setup_fee_accounting_code>
  <created_at type="datetime">2018-10-20T08:30:49Z</created_at>
  <updated_at type="datetime">2018-10-20T08:30:49Z</updated_at>
  <revenue_schedule_type>evenly</revenue_schedule_type>
  <setup_fee_revenue_schedule_type>evenly</setup_fee_revenue_schedule_type>
  <trial_requires_billing_info type="boolean">true</trial_requires_billing_info>
  <unit_amount_in_cents>
    <USD type="integer">1000</USD>
  </unit_amount_in_cents>
  <setup_fee_in_cents>
    <USD type="integer">0</USD>
  </setup_fee_in_cents>
</plan>
```

Fast test cases passed. Thanks again!