### PR TITLE
Rethrow ConnectExceptions as runtime exceptions

### DIFF
--- a/src/main/java/com/ning/billing/recurly/ConnectionErrorException.java
+++ b/src/main/java/com/ning/billing/recurly/ConnectionErrorException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly;
+
+import com.ning.billing.recurly.model.Errors;
+
+public class ConnectionErrorException extends RuntimeException {
+
+    public ConnectionErrorException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -90,6 +90,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.net.ConnectException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.security.KeyManagementException;
@@ -2036,7 +2037,10 @@ public class RecurlyClient {
             return null;
         } catch (ExecutionException e) {
             // Extract the errors exception, if any
-            if (e.getCause() != null &&
+            if (e.getCause() instanceof ConnectException) {
+                // See https://github.com/killbilling/recurly-java-library/issues/185
+                throw new ConnectionErrorException(e.getCause());
+            } else if (e.getCause() != null &&
                 e.getCause().getCause() != null &&
                 e.getCause().getCause() instanceof TransactionErrorException) {
                 throw (TransactionErrorException) e.getCause().getCause();


### PR DESCRIPTION
Fixes #185 

To test, configure the RecurlyClient to attempt to connect to an unsupported port (such as 81) and you will reliably get a "Connection Refused" error, which is an instance of `java.net.ConnectException`. A timeout error is also a `java.net.ConnectException`, though I haven't found a reliable way to test that particular one. If anyone has suggestions on a setup where a timeout can be reliable generated, please feel free to comment.