### PR TITLE
Update refund calls to support credit memos

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -30,8 +30,6 @@ import com.ning.billing.recurly.model.BillingInfo;
 import com.ning.billing.recurly.model.Coupon;
 import com.ning.billing.recurly.model.Coupons;
 import com.ning.billing.recurly.model.CreditPayments;
-import com.ning.billing.recurly.model.CustomField;
-import com.ning.billing.recurly.model.CustomFields;
 import com.ning.billing.recurly.model.Errors;
 import com.ning.billing.recurly.model.GiftCard;
 import com.ning.billing.recurly.model.GiftCards;
@@ -1029,17 +1027,20 @@ public class RecurlyClient {
      * <p/>
      * Returns the refunded invoice
      *
+     * @deprecated Please use refundInvoice(String, InvoiceRefund)
+     *
      * @param invoiceId The id of the invoice to refund
      * @param amountInCents The open amount to refund
      * @param method If credit line items exist on the invoice, this parameter specifies which refund method to use first
      * @return the refunded invoice
      */
+    @Deprecated
     public Invoice refundInvoice(final String invoiceId, final Integer amountInCents, final RefundMethod method) {
         final InvoiceRefund invoiceRefund = new InvoiceRefund();
         invoiceRefund.setRefundMethod(method);
         invoiceRefund.setAmountInCents(amountInCents);
 
-        return doPOST(Invoices.INVOICES_RESOURCE + "/" + invoiceId + "/refund", invoiceRefund, Invoice.class);
+        return refundInvoice(invoiceId, invoiceRefund);
     }
 
     /**
@@ -1047,17 +1048,33 @@ public class RecurlyClient {
      * <p/>
      * Returns the refunded invoice
      *
+     * @deprecated Please use refundInvoice(String, InvoiceRefund)
+     *
      * @param invoiceId The id of the invoice to refund
      * @param lineItems The list of adjustment refund objects
      * @param method If credit line items exist on the invoice, this parameter specifies which refund method to use first
      * @return the refunded invoice
      */
+    @Deprecated
     public Invoice refundInvoice(final String invoiceId, List<AdjustmentRefund> lineItems, final RefundMethod method) {
         final InvoiceRefund invoiceRefund = new InvoiceRefund();
         invoiceRefund.setRefundMethod(method);
         invoiceRefund.setLineItems(lineItems);
 
-        return doPOST(Invoices.INVOICES_RESOURCE + "/" + invoiceId + "/refund", invoiceRefund, Invoice.class);
+        return refundInvoice(invoiceId, invoiceRefund);
+    }
+
+    /**
+     * Refund an invoice given some options
+     * <p/>
+     * Returns the refunded invoice
+     *
+     * @param invoiceId The id of the invoice to refund
+     * @param refundOptions The options for the refund
+     * @return the refunded invoice
+     */
+    public Invoice refundInvoice(final String invoiceId, final InvoiceRefund refundOptions) {
+        return doPOST(Invoices.INVOICES_RESOURCE + "/" + invoiceId + "/refund", refundOptions, Invoice.class);
     }
 
     /**

--- a/src/main/java/com/ning/billing/recurly/model/Adjustment.java
+++ b/src/main/java/com/ning/billing/recurly/model/Adjustment.java
@@ -20,10 +20,9 @@ package com.ning.billing.recurly.model;
 import com.google.common.base.Objects;
 import org.joda.time.DateTime;
 
-import java.math.BigDecimal;
-
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.math.BigDecimal;
 
 @XmlRootElement(name = "adjustment")
 public class Adjustment extends RecurlyObject {

--- a/src/main/java/com/ning/billing/recurly/model/InvoiceRefund.java
+++ b/src/main/java/com/ning/billing/recurly/model/InvoiceRefund.java
@@ -18,6 +18,7 @@
 package com.ning.billing.recurly.model;
 
 import com.google.common.base.Objects;
+import org.joda.time.DateTime;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
@@ -35,6 +36,21 @@ public class InvoiceRefund extends RecurlyObject {
     @XmlElementWrapper(name = "line_items")
     @XmlElement(name = "adjustment")
     private List<AdjustmentRefund> lineItems;
+
+    @XmlElement(name = "external_refund")
+    private Boolean externalRefund;
+
+    @XmlElement(name = "credit_customer_notes")
+    private String creditCustomerNotes;
+
+    @XmlElement(name = "payment_method")
+    private String paymentMethod;
+
+    @XmlElement(name = "description")
+    private String description;
+
+    @XmlElement(name = "refunded_at")
+    private DateTime refundedAt;
 
     public void setRefundMethod(final RefundMethod refundMethod) {
         this.refundMethod = refundMethod;
@@ -60,6 +76,46 @@ public class InvoiceRefund extends RecurlyObject {
         return this.lineItems;
     }
 
+    public String getCreditCustomerNotes() {
+        return creditCustomerNotes;
+    }
+
+    public void setCreditCustomerNotes(final Object creditCustomerNotes) {
+        this.creditCustomerNotes = stringOrNull(creditCustomerNotes);
+    }
+
+    public void setExternalRefund(final Object externalRefund) {
+        this.externalRefund = booleanOrNull(externalRefund);
+    }
+
+    public Boolean getExternalRefund() {
+        return this.externalRefund;
+    }
+
+    public void setPaymentMethod(final Object paymentMethod) {
+        this.paymentMethod = stringOrNull(paymentMethod);
+    }
+
+    public String getPaymentMethod() {
+        return this.paymentMethod;
+    }
+
+    public void setDescription(final Object description) {
+        this.description = stringOrNull(description);
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public void setRefundedAt(final Object refundedAt) {
+        this.refundedAt = dateTimeOrNull(refundedAt);
+    }
+
+    public DateTime getRefundedAt() {
+        return this.refundedAt;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hashCode(refundMethod, amountInCents);
@@ -75,7 +131,22 @@ public class InvoiceRefund extends RecurlyObject {
         if (amountInCents != null ? !amountInCents.equals(refund.amountInCents) : refund.amountInCents != null) {
             return false;
         }
+        if (externalRefund != null ? !externalRefund.equals(refund.externalRefund) : refund.externalRefund != null) {
+            return false;
+        }
         if (refundMethod != null ? !refundMethod.equals(refund.refundMethod) : refund.refundMethod != null) {
+            return false;
+        }
+        if (creditCustomerNotes != null ? !creditCustomerNotes.equals(refund.creditCustomerNotes) : refund.creditCustomerNotes != null) {
+            return false;
+        }
+        if (description != null ? !description.equals(refund.description) : refund.description != null) {
+            return false;
+        }
+        if (paymentMethod != null ? !paymentMethod.equals(refund.paymentMethod) : refund.paymentMethod != null) {
+            return false;
+        }
+        if (refundedAt != null ? refundedAt.compareTo(refund.refundedAt) != 0: refund.refundedAt != null) {
             return false;
         }
         return true;
@@ -86,6 +157,11 @@ public class InvoiceRefund extends RecurlyObject {
         final StringBuilder sb = new StringBuilder("InvoiceRefund{");
         sb.append("amountInCents=").append(amountInCents);
         sb.append(", refundMethod='").append(refundMethod).append('\'');
+        sb.append(", externalRefund='").append(externalRefund).append('\'');
+        sb.append(", creditCustomerNotes='").append(creditCustomerNotes).append('\'');
+        sb.append(", description='").append(description).append('\'');
+        sb.append(", paymentMethod='").append(paymentMethod).append('\'');
+        sb.append(", refundedAt='").append(refundedAt).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/src/main/java/com/ning/billing/recurly/model/RefundMethod.java
+++ b/src/main/java/com/ning/billing/recurly/model/RefundMethod.java
@@ -21,5 +21,5 @@ package com.ning.billing.recurly.model;
  * The order in which to apply an invoice refund
  */
 public enum RefundMethod {
-    transaction_first, credit_first
+    transaction_first, credit_first, all_transaction, all_credit
 }

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -36,6 +36,7 @@ import com.ning.billing.recurly.model.CustomFields;
 import com.ning.billing.recurly.model.GiftCard;
 import com.ning.billing.recurly.model.Invoice;
 import com.ning.billing.recurly.model.InvoiceCollection;
+import com.ning.billing.recurly.model.InvoiceRefund;
 import com.ning.billing.recurly.model.Invoices;
 import com.ning.billing.recurly.model.Plan;
 import com.ning.billing.recurly.model.Purchase;
@@ -1603,7 +1604,13 @@ public class TestRecurlyClient {
             recurlyClient.updateInvoice(invoice.getId(), updatedInvoice);
 
             // Now refund the invoice
-            final Invoice refundInvoice = recurlyClient.refundInvoice(invoice.getId(), 100, RefundMethod.transaction_first);
+            final InvoiceRefund refundOptions = new InvoiceRefund();
+            refundOptions.setRefundMethod(RefundMethod.transaction_first);
+            refundOptions.setAmountInCents(100);
+            refundOptions.setCreditCustomerNotes("Credit Customer Notes");
+            refundOptions.setExternalRefund(true);
+            refundOptions.setPaymentMethod("credit_card");
+            final Invoice refundInvoice = recurlyClient.refundInvoice(invoice.getId(), refundOptions);
 
             Assert.assertEquals(refundInvoice.getTotalInCents(), new Integer(-100));
             Assert.assertEquals(refundInvoice.getSubtotalInCents(), new Integer(-100));
@@ -1671,7 +1678,10 @@ public class TestRecurlyClient {
             // adjustmentRefund.setQuantity(1);
             lineItems.add(adjustmentRefund);
 
-            final Invoice refundInvoice = recurlyClient.refundInvoice(invoice.getId(), lineItems, RefundMethod.transaction_first);
+            final InvoiceRefund refundOptions = new InvoiceRefund();
+            refundOptions.setRefundMethod(RefundMethod.transaction_first);
+            refundOptions.setLineItems(lineItems);
+            final Invoice refundInvoice = recurlyClient.refundInvoice(invoice.getId(), refundOptions);
 
             Assert.assertEquals(refundInvoice.getTotalInCents(), new Integer(-100));
             Assert.assertEquals(refundInvoice.getSubtotalInCents(), new Integer(-100));


### PR DESCRIPTION
Deprecating current way of doing refunds for a single refund method
which now supports all possible options.

This is not a breaking change but does deprecate the current methods for doing refunds on Invoices.

In order to do refunds now, the programmer should use the `InvoiceRefund` object:

```java
final InvoiceRefund refundOptions = new InvoiceRefund();
refundOptions.setRefundMethod(RefundMethod.transaction_first);
refundOptions.setAmountInCents(100);
refundOptions.setCreditCustomerNotes("Credit Customer Notes");
refundOptions.setExternalRefund(true);
refundOptions.setPaymentMethod("credit_card");
final Invoice refundInvoice = recurlyClient.refundInvoice(invoice.getId(), refundOptions);
```