### PR TITLE
Support paused subscription state

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionState.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionState.java
@@ -20,6 +20,7 @@ package com.ning.billing.recurly.model;
 public enum SubscriptionState {
     ACTIVE("active"),
     CANCELED("canceled"),
+    PAUSED("paused"),
     EXPIRED("expired"),
     FUTURE("future"),
     IN_TRIAL("in_trial"),


### PR DESCRIPTION
Hey again!

Stumbled upon the subscription state is missing `paused`, as I need to use this state in our code base.

Available states is pulled from docs https://dev.recurly.com/docs/list-subscriptions

Thanks again!