### PR TITLE
Add setAcceptLanguage method

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -136,6 +136,9 @@ public class RecurlyClient {
     private final String baseUrl;
     private AsyncHttpClient client;
 
+    // Allows error messages to be returned in a specified language
+    private String acceptLanguage = "en-US";
+
     // Stores the number of requests remaining before rate limiting takes effect
     private int rateLimitRemaining;
 
@@ -173,6 +176,18 @@ public class RecurlyClient {
         if (client != null) {
             client.close();
         }
+    }
+
+    /**
+     * Set the Accept-Language header
+     * <p>
+     * Sets the Accept-Language header for all requests made by this client. Note: this is not thread-safe!
+     * See https://github.com/killbilling/recurly-java-library/pull/298 for more details about thread safety.
+     *
+     * @param language The language to set in the header. E.g., "en-US"
+     */
+    public void setAcceptLanguage(String language) {
+        this.acceptLanguage = language;
     }
 
     /**
@@ -2163,6 +2178,7 @@ public class RecurlyClient {
         return requestBuilder.addHeader("Authorization", "Basic " + key)
                 .addHeader("X-Api-Version", RECURLY_API_VERSION)
                 .addHeader(HttpHeaders.USER_AGENT, userAgent)
+                .addHeader("Accept-Language", acceptLanguage)
                 .setBodyEncoding("UTF-8");
     }
 


### PR DESCRIPTION
Fixes #297 

NOTE: This is not thread safe. Consider the following situation:

```java
// in user 1's thread
client.setAcceptLanguage('de')
client.createSubscription()
```

```java
// in user 2's thread
client.setAcceptLanguage('en-US')
client.createSubscription()
```
These operations could interleave, such that `setAcceptLanguage()` gets called twice before the calls to `createSubscription()` are ever called. Meaning that if something went wrong with one of the requests, it would not be possible to guarantee that their error message would be in the correct language.

If your implementation takes advantage of threading (as most modern Java implementations do), you may experience problems by using this method in the above fashion. Please take all necessary caution to ensure that the client sets the correct language per request if you choose to use this method.


Example usage:
```java
package com.recurly.testrig;

import com.ning.billing.recurly.RecurlyClient;
import com.ning.billing.recurly.model.Account;
import com.ning.billing.recurly.TransactionErrorException;

public class CreateAccount {
    public static void run(final RecurlyClient client) {
        try {
            client.open();
            client.setAcceptLanguage("de");
            final Account account = new Account();
            account.setAccountCode(".invalid");
            
            client.createAccount(account);
        } catch (TransactionErrorException e) {
            System.out.println(e.getErrors().getRecurlyErrors().get(0).getMessage()); // ist nicht gültig
        } catch (Exception e) {
            System.out.println(e.getStackTrace());
        } finally {
          client.close();
        }
    }
}
```