### PR TITLE
Add gatewayCode to subscription notes and invoice

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -111,6 +111,9 @@ public class Invoice extends RecurlyObject {
     @XmlElement(name = "vat_reverse_charge_notes")
     private String vatReverseChargeNotes;
 
+    @XmlElement(name = "gateway_code")
+    private String gatewayCode;
+
     @XmlElement(name = "subtotal_before_discount_in_cents")
     private Integer subtotalBeforeDiscountInCents;
 
@@ -377,6 +380,14 @@ public class Invoice extends RecurlyObject {
         this.vatReverseChargeNotes = stringOrNull(vatReverseChargeNotes);
     }
 
+    public String getGatewayCode() {
+        return gatewayCode;
+    }
+
+    public void setGatewayCode(final Object gatewayCode) {
+        this.gatewayCode = stringOrNull(gatewayCode);
+    }
+
     public Integer getSubtotalBeforeDiscountInCents() {
         return subtotalBeforeDiscountInCents;
     }
@@ -480,6 +491,7 @@ public class Invoice extends RecurlyObject {
         sb.append(", customerNotes='").append(customerNotes).append('\'');
         sb.append(", termsAndConditions='").append(termsAndConditions).append('\'');
         sb.append(", vatReverseChargeNotes='").append(vatReverseChargeNotes).append('\'');
+        sb.append(", gatewayCode='").append(gatewayCode).append('\'');
         sb.append(", subtotalBeforeDiscountInCents=").append(subtotalBeforeDiscountInCents);
         sb.append(", discountInCents=").append(discountInCents);
         sb.append(", balanceInCents=").append(balanceInCents);
@@ -605,6 +617,9 @@ public class Invoice extends RecurlyObject {
         if (vatReverseChargeNotes != null ? !vatReverseChargeNotes.equals(invoice.vatReverseChargeNotes) : invoice.vatReverseChargeNotes != null) {
             return false;
         }
+        if (gatewayCode != null ? !gatewayCode.equals(invoice.gatewayCode) : invoice.gatewayCode != null) {
+            return false;
+        }
 
         return true;
     }
@@ -639,6 +654,7 @@ public class Invoice extends RecurlyObject {
                 customerNotes,
                 termsAndConditions,
                 vatReverseChargeNotes,
+                gatewayCode,
                 subtotalBeforeDiscountInCents,
                 discountInCents,
                 balanceInCents,

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionNotes.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionNotes.java
@@ -33,6 +33,9 @@ public class SubscriptionNotes extends AbstractSubscription {
     @XmlElement(name = "vat_reverse_charge_notes")
     private String vatReverseChargeNotes;
 
+    @XmlElement(name = "gateway_code")
+    private String gatewayCode;
+
     @XmlElementWrapper(name = "custom_fields")
     @XmlElement(name = "custom_field")
     private CustomFields customFields;
@@ -60,6 +63,14 @@ public class SubscriptionNotes extends AbstractSubscription {
     public void setVatReverseChargeNotes(final Object getVatReverseChargeNotes) {
         this.vatReverseChargeNotes = stringOrNull(vatReverseChargeNotes);
     }
+    
+    public String getGatewayCode() {
+        return gatewayCode;
+    }
+
+    public void setGatewayCode(final Object gatewayCode) {
+        this.gatewayCode = stringOrNull(gatewayCode);
+    }
 
     public CustomFields getCustomFields() {
         return customFields;
@@ -75,6 +86,7 @@ public class SubscriptionNotes extends AbstractSubscription {
         sb.append("termsAndConditions=").append(termsAndConditions).append('\'');
         sb.append(", customerNotes=").append(customerNotes).append('\'');
         sb.append(", vatReverseChargeNotes=").append(vatReverseChargeNotes).append('\'');
+        sb.append(", gatewayCode=").append(gatewayCode).append('\'');
         sb.append(", customFields=").append(customFields);
         sb.append('}');
         return sb.toString();
@@ -99,6 +111,9 @@ public class SubscriptionNotes extends AbstractSubscription {
         if (vatReverseChargeNotes != null ? !vatReverseChargeNotes.equals(that.vatReverseChargeNotes) : that.vatReverseChargeNotes != null) {
             return false;
         }
+        if (gatewayCode != null ? !gatewayCode.equals(that.gatewayCode) : that.gatewayCode != null) {
+            return false;
+        }
 
         return true;
     }
@@ -109,7 +124,8 @@ public class SubscriptionNotes extends AbstractSubscription {
                 termsAndConditions,
                 customerNotes,
                 vatReverseChargeNotes,
-                customFields
+                customFields,
+                gatewayCode
         );
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
@@ -48,6 +48,7 @@ public class TestInvoice extends TestModelBase {
                                    + "  <vat_reverse_charge_notes>Some reverse charge notes</vat_reverse_charge_notes>\n"
                                    + "  <customer_notes>Some notes</customer_notes>\n"
                                    + "  <terms_and_conditions>t and c</terms_and_conditions>\n"
+                                   + "  <gateway_code>Some Gateway Code</gateway_code>\n"
                                    + "  <net_terms type=\"integer\">0</net_terms>\n"
                                    + "  <currency>USD</currency>\n"
                                    + "  <tax_type>usst</tax_type>\n"
@@ -115,6 +116,7 @@ public class TestInvoice extends TestModelBase {
         Assert.assertEquals(invoice.getTermsAndConditions(), "t and c");
         Assert.assertEquals((int) invoice.getNetTerms(), 0);
         Assert.assertNull(invoice.getVatNumber());
+        Assert.assertEquals(invoice.getGatewayCode(), "Some Gateway Code");
         Assert.assertEquals((int) invoice.getSubtotalInCents(), 9900);
         Assert.assertEquals((int) invoice.getTaxInCents(), 0);
         Assert.assertEquals((int) invoice.getTotalInCents(), 9900);


### PR DESCRIPTION
This allows you to change the gateway code via the subscription `/notes` endpoint as well as the `PUT invoice` endpoint.

Script:
```java
try {
    client.open();

    // Subscription Notes
    final SubscriptionNotes subscriptionNotesData = new SubscriptionNotes();
    subscriptionNotesData.setGatewayCode("jqgayw0mjh5w");
    Subscription sub = client.updateSubscriptionNotes("4810fde9f3f29b244474e445d795cc78", subscriptionNotesData);

    // Invoice
    Invoice updatedInvoice = new Invoice();
    updatedInvoice.setGatewayCode("jvm7v7as5ugm");
    client.updateInvoice("1001", updatedInvoice);
} catch (Exception e) {
    e.printStackTrace();
} finally {
    client.close();
}
```