### PR TITLE
Add hasOriginalInvoices() method to Invoice class

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -34,6 +34,9 @@ public class Invoice extends RecurlyObject {
     @XmlElement(name = "original_invoice")
     private Invoice originalInvoice;
 
+    @XmlElement(name = "original_invoices")
+    private Invoice originalInvoices;
+
     @XmlElement(name = "uuid")
     private String uuid;
 
@@ -165,6 +168,16 @@ public class Invoice extends RecurlyObject {
             originalInvoice = fetch(originalInvoice, Invoice.class);
         }
         return originalInvoice;
+    }
+
+    /**
+     * For use with RecurlyClient.getOriginalInvoices(). Check if an invoice had an <original_invoices> link
+     * in the XML from the API.
+     *
+     * @return true if there are original invoices associated with this invoice
+     */
+    public Boolean hasOriginalInvoices() {
+        return originalInvoices != null && originalInvoices.getHref() != null && !originalInvoices.getHref().isEmpty();
     }
 
     public String getId() {
@@ -455,6 +468,7 @@ public class Invoice extends RecurlyObject {
         final StringBuilder sb = new StringBuilder("Invoice{");
         sb.append("account=").append(account);
         sb.append(", originalInvoice='").append(originalInvoice).append('\'');
+        sb.append(", originalInvoices='").append(originalInvoices).append('\'');
         sb.append(", uuid='").append(uuid).append('\'');
         sb.append(", state='").append(state).append('\'');
         sb.append(", invoiceNumber=").append(invoiceNumber);
@@ -545,6 +559,9 @@ public class Invoice extends RecurlyObject {
         if (originalInvoice != null ? !originalInvoice.equals(invoice.originalInvoice) : invoice.originalInvoice != null) {
             return false;
         }
+        if (originalInvoices != null ? !originalInvoices.equals(invoice.originalInvoices) : invoice.originalInvoices != null) {
+            return false;
+        }
         if (origin != null ? !origin.equals(invoice.origin) : invoice.origin != null) {
             return false;
         }
@@ -614,6 +631,7 @@ public class Invoice extends RecurlyObject {
         return Objects.hashCode(
                 account,
                 originalInvoice,
+                originalInvoices,
                 uuid,
                 state,
                 invoiceNumber,

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
@@ -35,7 +35,7 @@ public class TestInvoice extends TestModelBase {
         final String invoiceData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                                    + "<invoice href=\"https://api.recurly.com/v2/invoices/e3f0a9e084a2468480d00ee61b090d4d\">\n"
                                    + "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n"
-                                   + "  <original_invoice href=\"https://api.recurly.com/v2/invoices/1192\"/>"
+                                   + "  <original_invoices href=\"https://api.recurly.com/v2/invoices/1192/original_invoices\"/>\n"
                                    + "  <uuid>421f7b7d414e4c6792938e7c49d552e9</uuid>\n"
                                    + "  <state>open</state>\n"
                                    + "  <invoice_number type=\"integer\">1402</invoice_number>\n"
@@ -105,7 +105,7 @@ public class TestInvoice extends TestModelBase {
         final Invoice invoice = xmlMapper.readValue(invoiceData, Invoice.class);
 
         Assert.assertEquals(invoice.getAccount().getHref(), "https://api.recurly.com/v2/accounts/1");
-        Assert.assertEquals(invoice.getOriginalInvoice().getHref(), "https://api.recurly.com/v2/invoices/1192");
+        Assert.assertTrue(invoice.hasOriginalInvoices());
         Assert.assertEquals(invoice.getUuid(), "421f7b7d414e4c6792938e7c49d552e9");
         Assert.assertEquals(invoice.getState(), "open");
         Assert.assertEquals((int) invoice.getInvoiceNumber(), 1402);


### PR DESCRIPTION
Fixes #295 

Adds a method to check if there are any original invoices on an invoice received from the API or a webhook, so that an extra API call need not be made if there is no original invoice.

Example usage:
```java
if (invoice.hasOriginalInvoices()) {
    final Invoices originalInvoices = recurlyClient.getOriginalInvoices(invoice.getId());
}
```

