### PR TITLE
coupon: fix plan_codes parsing

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Coupon.java
+++ b/src/main/java/com/ning/billing/recurly/model/Coupon.java
@@ -488,6 +488,9 @@ public class Coupon extends RecurlyObject {
         if (couponCode != null ? !couponCode.equals(coupon.couponCode) : coupon.couponCode != null) {
             return false;
         }
+        if (planCodes != null ? !planCodes.equals(coupon.planCodes) : coupon.planCodes != null) {
+            return false;
+        }
         if (createdAt != null ? createdAt.compareTo(coupon.createdAt) != 0 : coupon.createdAt != null) {
             return false;
         }
@@ -560,6 +563,7 @@ public class Coupon extends RecurlyObject {
                 appliesToNonPlanCharges,
                 name,
                 couponCode,
+                planCodes,
                 description,
                 discountType,
                 discountPercent,

--- a/src/main/java/com/ning/billing/recurly/model/Coupon.java
+++ b/src/main/java/com/ning/billing/recurly/model/Coupon.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2015 The Billing Project, LLC
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -24,8 +24,6 @@ import javax.xml.bind.annotation.XmlTransient;
 
 import org.joda.time.DateTime;
 import com.google.common.base.Objects;
-
-import java.util.List;
 
 /**
  * Class that represents the Concept of a Coupon within the Recurly API.
@@ -139,17 +137,17 @@ public class Coupon extends RecurlyObject {
     @XmlElement(name = "updated_at")
     private DateTime updatedAt;
 
-    public List<String> getPlanCodes() {
+    public PlanCodes getPlanCodes() {
         return planCodes;
     }
 
-    public void setPlanCodes(List<String> planCodes) {
+    public void setPlanCodes(final PlanCodes planCodes) {
         this.planCodes = planCodes;
     }
 
-    @XmlElement( name="plan_code" )
-    @XmlElementWrapper( name="plan_codes" )
-    private List<String> planCodes;
+    @XmlElement(name = "plan_code")
+    @XmlElementWrapper(name = "plan_codes")
+    private PlanCodes planCodes;
 
     /**
      * forever, single_use, or temporal. If single_use, the coupon applies to

--- a/src/main/java/com/ning/billing/recurly/model/PlanCode.java
+++ b/src/main/java/com/ning/billing/recurly/model/PlanCode.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.google.common.base.Objects;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "plan_code")
+public class PlanCode extends RecurlyObject {
+
+    private String name;
+
+    public PlanCode(final String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final Object name) {
+        this.name = stringOrNull(name);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("PlanCode{");
+        sb.append("name=").append(name);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final PlanCode field = (PlanCode) o;
+
+        if (name != null ? !name.equals(field.name) : field.name != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name);
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/PlanCode.java
+++ b/src/main/java/com/ning/billing/recurly/model/PlanCode.java
@@ -16,14 +16,18 @@
 
 package com.ning.billing.recurly.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Objects;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
+@JsonSerialize(using = PlanCodeSerializer.class)
 @XmlRootElement(name = "plan_code")
 public class PlanCode extends RecurlyObject {
 
     private String name;
+
+    public PlanCode() { /* Required for Jackson */ }
 
     public PlanCode(final String name) {
         this.name = name;

--- a/src/main/java/com/ning/billing/recurly/model/PlanCodeSerializer.java
+++ b/src/main/java/com/ning/billing/recurly/model/PlanCodeSerializer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class PlanCodeSerializer extends StdSerializer<PlanCode> {
+
+    public PlanCodeSerializer() {
+        this(null);
+    }
+
+    public PlanCodeSerializer(final Class<PlanCode> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(final PlanCode value, final JsonGenerator jgen, final SerializerProvider provider) throws IOException, JsonGenerationException {
+        jgen.writeObject(value.getName());
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/PlanCodes.java
+++ b/src/main/java/com/ning/billing/recurly/model/PlanCodes.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+@XmlRootElement(name = "plan_codes")
+public class PlanCodes extends RecurlyObjects<PlanCode> {
+
+    @XmlTransient
+    private static final String PROPERTY_NAME = "plan_code";
+
+    @JsonSetter(value = PROPERTY_NAME)
+    @Override
+    public void setRecurlyObject(final PlanCode value) {
+        super.setRecurlyObject(value);
+    }
+
+    @JsonIgnore
+    @Override
+    public PlanCodes getStart() {
+        return getStart(PlanCodes.class);
+    }
+
+    @JsonIgnore
+    @Override
+    public PlanCodes getNext() {
+        return getNext(PlanCodes.class);
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/PlanCodes.java
+++ b/src/main/java/com/ning/billing/recurly/model/PlanCodes.java
@@ -18,10 +18,12 @@ package com.ning.billing.recurly.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
+@JsonSerialize(using = PlanCodesSerializer.class)
 @XmlRootElement(name = "plan_codes")
 public class PlanCodes extends RecurlyObjects<PlanCode> {
 

--- a/src/main/java/com/ning/billing/recurly/model/PlanCodesSerializer.java
+++ b/src/main/java/com/ning/billing/recurly/model/PlanCodesSerializer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class PlanCodesSerializer extends StdSerializer<PlanCodes> {
+
+    public PlanCodesSerializer() {
+        this(null);
+    }
+
+    public PlanCodesSerializer(final Class<PlanCodes> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(final PlanCodes value, final JsonGenerator jgen, final SerializerProvider provider) throws IOException, JsonGenerationException {
+        for (final PlanCode planCode : value) {
+            jgen.writeObject(planCode);
+        }
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2015 The Billing Project, LLC
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -39,6 +39,8 @@ import com.ning.billing.recurly.model.InvoiceCollection;
 import com.ning.billing.recurly.model.InvoiceRefund;
 import com.ning.billing.recurly.model.Invoices;
 import com.ning.billing.recurly.model.Plan;
+import com.ning.billing.recurly.model.PlanCode;
+import com.ning.billing.recurly.model.PlanCodes;
 import com.ning.billing.recurly.model.Purchase;
 import com.ning.billing.recurly.model.RecurlyAPIError;
 import com.ning.billing.recurly.model.Redemption;
@@ -652,7 +654,9 @@ public class TestRecurlyClient {
 
             // Create a coupon for the plan
             couponDataForPlan.setAppliesToAllPlans(false);
-            couponDataForPlan.setPlanCodes(Arrays.asList(plan.getPlanCode()));
+            final PlanCodes planCodes = new PlanCodes();
+            planCodes.add(new PlanCode(plan.getPlanCode()));
+            couponDataForPlan.setPlanCodes(planCodes);
             Coupon couponForPlan = recurlyClient.createCoupon(couponDataForPlan);
 
             // Set up a subscription

--- a/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
@@ -33,7 +33,6 @@ import static org.testng.Assert.assertNotEquals;
 
 public class TestCoupon extends TestModelBase {
 
-
     @Test(groups = "fast")
     public void testDeserializationPercent() throws Exception {
         final String couponData = 
@@ -216,7 +215,6 @@ public class TestCoupon extends TestModelBase {
         assertEquals(coupon.getType(), Type.single_code);
     }
 
-
     @Test(groups = "fast")
     public void testPlanCodes() throws Exception {
         // See https://dev.recurly.com/docs/list-active-coupons
@@ -278,6 +276,11 @@ public class TestCoupon extends TestModelBase {
         assertEquals(coupon.getPlanCodes().size(), 2);
         assertTrue(coupon.getPlanCodes().contains(new PlanCode("platinum")));
         assertTrue(coupon.getPlanCodes().contains(new PlanCode("gold")));
+
+        // Verify serialization
+        final String couponSerialized = xmlMapper.writeValueAsString(coupon);
+        final Coupon coupon2 = xmlMapper.readValue(couponSerialized, Coupon.class);
+        assertEquals(coupon2, coupon);
     }
 
     @Test(groups = "fast")

--- a/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2015 The Billing Project, LLC
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -276,8 +276,8 @@ public class TestCoupon extends TestModelBase {
         assertEquals(coupon.getMaxRedemptionsPerAccount().intValue(), 1);
         assertEquals(coupon.getType(), Type.single_code);
         assertEquals(coupon.getPlanCodes().size(), 2);
-        assertTrue(coupon.getPlanCodes().contains("platinum"));
-        assertTrue(coupon.getPlanCodes().contains("gold"));
+        assertTrue(coupon.getPlanCodes().contains(new PlanCode("platinum")));
+        assertTrue(coupon.getPlanCodes().contains(new PlanCode("gold")));
     }
 
     @Test(groups = "fast")

--- a/src/test/java/com/ning/billing/recurly/model/TestCoupons.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCoupons.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2015 The Billing Project, LLC
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -96,6 +96,7 @@ public class TestCoupons extends TestModelBase {
                                     "    <applies_to_all_plans type=\"boolean\">true</applies_to_all_plans>\n" +
                                     "    <created_at type=\"dateTime\">2013-05-08T11:25:02Z</created_at>\n" +
                                     "    <plan_codes type=\"array\">\n" +
+                                    "      <plan_code>gold</plan_code>\n" +
                                     "    </plan_codes>\n" +
                                     "    <a name=\"redeem\" href=\"https://api.recurly.com/v2/coupons/9442c/redeem\" method=\"post\"/>\n" +
                                     "  </coupon>\n" +
@@ -114,6 +115,8 @@ public class TestCoupons extends TestModelBase {
                                     "    <applies_to_all_plans type=\"boolean\">true</applies_to_all_plans>\n" +
                                     "    <created_at type=\"dateTime\">2013-05-08T11:24:31Z</created_at>\n" +
                                     "    <plan_codes type=\"array\">\n" +
+                                    "      <plan_code>gold</plan_code>\n" +
+                                    "      <plan_code>silver</plan_code>" +
                                     "    </plan_codes>\n" +
                                     "    <a name=\"redeem\" href=\"https://api.recurly.com/v2/coupons/f15a9/redeem\" method=\"post\"/>\n" +
                                     "  </coupon>\n" +
@@ -121,5 +124,13 @@ public class TestCoupons extends TestModelBase {
 
         final Coupons coupons = xmlMapper.readValue(couponData, Coupons.class);
         Assert.assertEquals(coupons.size(), 5);
+        Assert.assertEquals(coupons.get(0).getPlanCodes().size(), 0);
+        Assert.assertEquals(coupons.get(1).getPlanCodes().size(), 0);
+        Assert.assertEquals(coupons.get(2).getPlanCodes().size(), 0);
+        Assert.assertEquals(coupons.get(3).getPlanCodes().size(), 1);
+        Assert.assertEquals(coupons.get(3).getPlanCodes().get(0).getName(), "gold");
+        Assert.assertEquals(coupons.get(4).getPlanCodes().size(), 2);
+        Assert.assertEquals(coupons.get(4).getPlanCodes().get(0).getName(), "gold");
+        Assert.assertEquals(coupons.get(4).getPlanCodes().get(1).getName(), "silver");
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscriptions.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscriptions.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2014-2015 The Billing Project, LLC
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -77,6 +77,8 @@ public class TestSubscriptions extends TestModelBase {
         final Subscription subscription = subscriptions.get(0);
         Assert.assertEquals(subscription.getUuid(), "44f83d7cba354d5b84812419f923ea96");
         Assert.assertEquals(subscription.getCurrency(), "EUR");
+        Assert.assertNull(subscription.getPlanCode());
+        Assert.assertEquals(subscription.getPlan().getPlanCode(), "gold");
 
         List<String> coupons = new ArrayList<String>(Arrays.asList("abc", "123"));
         Assert.assertEquals(subscription.getCouponCodes(), coupons);


### PR DESCRIPTION
This fixes https://github.com/killbilling/recurly-java-library/issues/244.

Any idea for the `must_apply_to_plans_or_non_plan_charges` error on Travis?
