### PR TITLE
Add exemption certificate to Account

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Account.java
+++ b/src/main/java/com/ning/billing/recurly/model/Account.java
@@ -103,6 +103,9 @@ public class Account extends RecurlyObject {
     @XmlElement(name = "tax_exempt")
     private Boolean taxExempt;
 
+    @XmlElement(name = "exemption_certificate")
+    private String exemptionCertificate;
+
     @XmlElementWrapper(name = "shipping_addresses")
     @XmlElement(name = "shipping_address")
     private ShippingAddresses shippingAddresses;
@@ -308,6 +311,14 @@ public class Account extends RecurlyObject {
         this.taxExempt = booleanOrNull(taxExempt);
     }
 
+    public String getExemptionCertificate() {
+        return exemptionCertificate;
+    }
+
+    public void setExemptionCertificate(final Object exemptionCertificate) {
+        this.exemptionCertificate = stringOrNull(exemptionCertificate);
+    }
+
     public Boolean getHasLiveSubscription() {
         return hasLiveSubscription;
     }
@@ -419,6 +430,7 @@ public class Account extends RecurlyObject {
         sb.append(", updatedAt=").append(updatedAt);
         sb.append(", billingInfo=").append(billingInfo);
         sb.append(", taxExempt=").append(taxExempt);
+        sb.append(", exemptionCertificate='").append(exemptionCertificate).append('\'');
         sb.append(", shippingAddresses=").append(shippingAddresses);
         sb.append(", customFields=").append(customFields);
         sb.append(", hasLiveSubscription=").append(hasLiveSubscription);
@@ -522,6 +534,9 @@ public class Account extends RecurlyObject {
         if (taxExempt != null ? !taxExempt.equals(account.taxExempt) : account.taxExempt != null) {
             return false;
         }
+        if (exemptionCertificate != null ? !exemptionCertificate.equals(account.exemptionCertificate) : account.exemptionCertificate != null) {
+            return false;
+        }
         if (shippingAddresses != null ? !shippingAddresses.equals(account.shippingAddresses) : account.shippingAddresses != null) {
             return false;
         }
@@ -564,6 +579,7 @@ public class Account extends RecurlyObject {
                 billingInfo,
                 updatedAt,
                 taxExempt,
+                exemptionCertificate,
                 shippingAddresses,
                 customFields,
                 vatNumber,

--- a/src/test/java/com/ning/billing/recurly/model/TestAccount.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccount.java
@@ -44,6 +44,7 @@ public class TestAccount extends TestModelBase {
                                    "  <first_name>Verena</first_name>\n" +
                                    "  <last_name>Example</last_name>\n" +
                                    "  <tax_exempt type=\"boolean\">false</tax_exempt>\n\n" +
+                                   "  <exemption_certificate>Some Certificate</exemption_certificate>\n" +
                                    "  <accept_language nil=\"nil\"></accept_language>\n" +
                                    "  <hosted_login_token>a92468579e9c4231a6c0031c4716c01d</hosted_login_token>\n" +
                                    "  <created_at type=\"dateTime\">2011-10-25T12:00:00</created_at>\n" +
@@ -111,6 +112,7 @@ public class TestAccount extends TestModelBase {
         Assert.assertEquals(account.getAddress().getZip(), "94105-1804");
         Assert.assertEquals(account.getAddress().getCountry(), "US");
         Assert.assertFalse(account.getTaxExempt());
+        Assert.assertEquals(account.getExemptionCertificate(), "Some Certificate");
         Assert.assertNull(account.getAddress().getPhone());
         Assert.assertEquals(account.getCustomFields(), getTestFields());
         Assert.assertTrue(account.getHasLiveSubscription());


### PR DESCRIPTION
Adds exemption_certificate attribute to the account object.

Script:
```java
try {
    client.open();

    final Account account = new Account();
    account.setAccountCode("new-account");
    account.setTaxExempt(true);
    account.setExemptionCertificate("Some Certificate");
    
    client.createAccount(account);
} catch (Exception e) {
    System.out.println(e.getStackTrace());
} finally {
    client.close();
}
```