### PR TITLE
Add getSubscriptionId() to Adjustment for Purchases endpoint

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Adjustment.java
+++ b/src/main/java/com/ning/billing/recurly/model/Adjustment.java
@@ -30,6 +30,9 @@ public class Adjustment extends RecurlyObject {
     @XmlElement(name = "account")
     private Account account;
 
+    @XmlElement(name = "subscription")
+    private Subscription subscription;
+
     @XmlElement(name = "uuid")
     private String uuid;
 
@@ -114,6 +117,18 @@ public class Adjustment extends RecurlyObject {
 
     public void setAccount(final Account account) {
         this.account = account;
+    }
+
+    public String getSubscriptionId() {
+        if (subscription != null && subscription.getHref() != null) {
+            String[] parts = subscription.getHref().split("/");
+            return parts[parts.length - 1];
+        }
+        return null;
+    }
+
+    public void setSubscription(final Subscription subscription) {
+        this.subscription = subscription;
     }
 
     public String getUuid() {

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -1763,6 +1763,11 @@ public class TestRecurlyClient {
 
             final Invoice invoice = recurlyClient.purchase(purchaseData).getChargeInvoice();
             Assert.assertNotNull(invoice.getInvoiceNumber());
+
+            // Ensure Adjustment's subscription id is valid
+            String subscriptionId = invoice.getLineItems().get(0).getSubscriptionId();
+            Subscription sub = recurlyClient.getSubscription(subscriptionId);
+            Assert.assertEquals(sub.getUuid(), subscriptionId);
         } finally {
             recurlyClient.closeAccount(accountData.getAccountCode());
             recurlyClient.deletePlan(planData.getPlanCode());

--- a/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
@@ -53,6 +53,7 @@ public class TestPurchase extends TestModelBase {
                 "  </account>" +
                 "  <adjustments>" +
                 "    <adjustment>" +
+                "      <subscription href=\"https://subdomain.recurly.com/v2/subscriptions/48e99881b3726425bf49e64b45af7fe4\"/>" +
                 "      <unit_amount_in_cents type=\"integer\">1000</unit_amount_in_cents>" +
                 "      <quantity type=\"integer\">1</quantity>" +
                 "      <currency>USD</currency>" +
@@ -114,6 +115,7 @@ public class TestPurchase extends TestModelBase {
         assertEquals(adjustment.getProductCode(), "product-code");
         assertEquals(adjustment.getQuantity(), new Integer(1));
         assertEquals(adjustment.getUnitAmountInCents(), new Integer(1000));
+        assertEquals(adjustment.getSubscriptionId(), "48e99881b3726425bf49e64b45af7fe4");
 
 
         final Subscription sub1 = purchase.getSubscriptions().get(0);


### PR DESCRIPTION
Fixes #301 

This adds a method called `getSubscriptionId` to the Adjustment. Not all adjustments have a `subscription` tag, so it returns null if irrelevant.

Script:
```java
try {
    client.open();

    final Account accountData = new Account();
    accountData.setAccountCode("bklalskjalg");

    final BillingInfo billingInfoData = new BillingInfo();
    billingInfoData.setFirstName("Benjamin");
    billingInfoData.setLastName("Du monde");
    billingInfoData.setAddress1("124 main st");
    billingInfoData.setCity("New York");
    billingInfoData.setState("CA");
    billingInfoData.setZip("94110");
    billingInfoData.setCountry("US");
    billingInfoData.setYear(2020);
    billingInfoData.setMonth(12);
    billingInfoData.setNumber("4111 1111 1111 1111");
    billingInfoData.setVerificationValue(123);

    accountData.setBillingInfo(billingInfoData);
    final Subscription subscriptionData = new Subscription();
    subscriptionData.setPlanCode("gold");
    final Subscriptions subscriptions = new Subscriptions();
    subscriptions.add(subscriptionData);

    final Purchase purchaseData = new Purchase();
    purchaseData.setAccount(accountData);
    purchaseData.setCollectionMethod("automatic");
    purchaseData.setCurrency("USD");
    purchaseData.setPoNumber("2345");
    purchaseData.setSubscriptions(subscriptions);

    final InvoiceCollection collection = client.purchase(purchaseData);

    // Get the subscription id and print it out
    Adjustment adj = collection.getChargeInvoice().getLineItems().get(0);
    System.out.println(adj.getSubscriptionId());
} catch (Exception e) {
    e.printStackTrace();
} finally {
    client.close();
}
```