### PR TITLE
Add method to list coupon redemptions by subscription

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -1608,6 +1608,18 @@ public class RecurlyClient {
     }
 
     /**
+     * Lookup all coupon redemptions on a subscription given query params.
+     *
+     * @param subscriptionUuid String subscription uuid
+     * @param params {@link QueryParams}
+     * @return the coupon redemptions for this subscription on success, null otherwise
+     */
+    public Redemptions getCouponRedemptionsBySubscription(final String subscriptionUuid, final QueryParams params) {
+        return doGET(Subscription.SUBSCRIPTION_RESOURCE + "/" + subscriptionUuid + Redemptions.REDEMPTIONS_RESOURCE,
+                Redemptions.class, params);
+    }
+
+    /**
      * Deletes a coupon redemption from an account.
      *
      * @param accountCode recurly account id


### PR DESCRIPTION
This PR adds a method for this API endpoint: https://dev.recurly.com/docs/lookup-a-coupon-redemption-on-a-subscription

Script:
```java
// Assumes sub uuid "466150990318962b8cfabb4513896cd5" exists on account
// and has a coupon redemption associated with it
package com.recurly.testrig;

import com.ning.billing.recurly.QueryParams;
import com.ning.billing.recurly.RecurlyClient;
import com.ning.billing.recurly.model.Redemptions;

public class ListCouponRedemptions {
    public static void run(final RecurlyClient client) {
        try {
            client.open();
            final String subUuid = "466150990318962b8cfabb4513896cd5";

            Redemptions red = client.getCouponRedemptionsBySubscription(subUuid, new QueryParams());
            System.out.println(red);
        } catch (Exception e) {
            e.printStackTrace();
        } finally {
          client.close();
        }
    }
}
```