### PR TITLE
Update README based on current technologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,29 +34,12 @@ Java properties
 * Set `-Drecurly.debug=true` to output debug information in the info log file
 * Set `-Drecurly.page.size=20` to configure the page size for Recurly API calls
 * To run the tests, one can use `-Dkillbill.payment.recurly.currency=EUR` to override the default USD currency used
-* You may optionally pass the TLS protocol used with the setting `-Dkillbill.payment.recurly.tlsProtocol`. Keep in mind that Recurly only supports `TLSv1.1` and above. This setting defaults to `TLSv1.2`.
+* You may optionally pass the TLS protocol used with the setting `-Dkillbill.payment.recurly.tlsProtocol`. Keep in mind that Recurly only supports `TLSv1.2` and above. This setting defaults to `TLSv1.2`.
 
 Push notifications
 ------------------
 
 See https://gist.github.com/dbathily/4433939 for an example on how to set it up.
-
-Signature Generation for Recurly.js
--------------------------------------
-
-A special signature string is needed for the BuildSubscriptionForm helper method in the recurly.js library. To obtain a signature on the server to pass to the page, simply use:
-
-	String signature = RecurlyJs.getRecurlySignature(String jsPrivateKey);
-
-If you wish to specify extra parameters (such as account id and subscription code), build an ArrayList<String> with url-encoded key=value string pairs. For example:
-
-    List<String> extraParams = new ArrayList<String>();
-    extraParams.add(String.format("%s=%s", "subscription%5Bplan_code%5D", "testplan1"));
-    extraParams.add(String.format("%s=%s", "account%5Baccount_code%5D", "123abc"));
-	String signature = RecurlyJs.getRecurlySignature(String jsPrivateKey, extraParams);
-
-Refer to the [Recurly.js Signature Generation documentation](https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures) for more information on the format for building parameters.
-
 
 Build
 -----


### PR DESCRIPTION
Recurly has not supported TLS 1.1 since July 2018. See https://dev.recurly.com/page/tls-v10-deprecation

Recurly.js v4 does not require signatures using the private key. See https://dev.recurly.com/docs/recurlyjs