### PR TITLE
Add support for account hierarchy

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -327,6 +327,18 @@ public class RecurlyClient {
         doDELETE(Account.ACCOUNT_RESOURCE + "/" + accountCode);
     }
 
+    /**
+     * Get Child Accounts
+     * <p>
+     * Returns information about a the child accounts of an account.
+     *
+     * @param accountCode recurly account id
+     * @return Accounts on success, null otherwise
+     */
+    public Accounts getChildAccounts(final String accountCode) {
+        return doGET(Account.ACCOUNT_RESOURCE + "/" + accountCode + "/child_accounts", Accounts.class, new QueryParams());
+    }
+
     ////////////////////////////////////////////////////////////////////////////////////////
     // Account adjustments
 

--- a/src/main/java/com/ning/billing/recurly/model/Account.java
+++ b/src/main/java/com/ning/billing/recurly/model/Account.java
@@ -39,6 +39,9 @@ public class Account extends RecurlyObject {
     @XmlElement(name = "address")
     private Address address;
 
+    @XmlElement(name = "parent_account_code")
+    private String parentAccountCode;
+
     @XmlElementWrapper(name = "adjustments")
     @XmlElement(name = "adjustment")
     private Adjustments adjustments;
@@ -201,6 +204,14 @@ public class Account extends RecurlyObject {
 
     public void setAccountCode(final Object accountCode) {
         this.accountCode = stringOrNull(accountCode);
+    }
+
+    public String getParentAccountCode() {
+        return this.parentAccountCode;
+    }
+
+    public void setParentAccountCode(final Object parentAccountCode) {
+        this.parentAccountCode = stringOrNull(parentAccountCode);
     }
 
     public String getState() {
@@ -417,6 +428,7 @@ public class Account extends RecurlyObject {
         sb.append(", subscriptions=").append(subscriptions);
         sb.append(", transactions=").append(transactions);
         sb.append(", accountCode='").append(accountCode).append('\'');
+        sb.append(", parent_account_code=''").append(parentAccountCode).append('\'');
         sb.append(", state='").append(state).append('\'');
         sb.append(", username='").append(username).append('\'');
         sb.append(", email='").append(email).append('\'');
@@ -460,6 +472,9 @@ public class Account extends RecurlyObject {
             return false;
         }
         if (accountCode != null ? !accountCode.equals(account.accountCode) : account.accountCode != null) {
+            return false;
+        }
+        if (parentAccountCode != null ? !parentAccountCode.equals(account.parentAccountCode) : account.parentAccountCode != null) {
             return false;
         }
         if (address != null ? !address.equals(account.address) : account.address != null) {
@@ -554,6 +569,7 @@ public class Account extends RecurlyObject {
     public int hashCode() {
         return Objects.hashCode(
                 address,
+                parentAccountCode,
                 href,
                 adjustments,
                 invoices,

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -261,6 +261,7 @@ public class TestUtils {
         account.setAcceptLanguage("en-US");
         account.setPreferredLocale("en-US");
         account.setAccountCode(randomAlphaNumericString(10, seed));
+        account.setParentAccountCode(randomAlphaNumericString(9, seed));
         account.setCompanyName(randomAlphaNumericString(10, seed));
         account.setEmail(randomAlphaNumericString(4, seed) + "@test.com");
         account.setFirstName(randomAlphaNumericString(5, seed));

--- a/src/test/java/com/ning/billing/recurly/model/TestAccount.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccount.java
@@ -31,6 +31,8 @@ public class TestAccount extends TestModelBase {
     public void testSerialization() throws Exception {
         // See https://dev.recurly.com/docs/list-accounts
         final String accountData = "<account href=\"https://api.recurly.com/v2/accounts/1\">\n" +
+                                   "  <parent_account href=\"https://api.recurly.com/v2/accounts/2\"/>\n" +
+                                   "  <child_accounts href=\"https://api.recurly.com/v2/accounts/1/child_accounts\"/>\n" +
                                    "  <adjustments href=\"https://api.recurly.com/v2/accounts/1/adjustments\"/>\n" +
                                    "  <billing_info href=\"https://api.recurly.com/v2/accounts/1/billing_info\"/>\n" +
                                    "  <invoices href=\"https://api.recurly.com/v2/accounts/1/invoices\"/>\n" +
@@ -38,6 +40,7 @@ public class TestAccount extends TestModelBase {
                                    "  <subscriptions href=\"https://api.recurly.com/v2/accounts/1/subscriptions\"/>\n" +
                                    "  <transactions href=\"https://api.recurly.com/v2/accounts/1/transactions\"/>\n" +
                                    "  <account_code>1</account_code>\n" +
+                                   "  <parent_account_code>2</parent_account_code>\n" +
                                    "  <state>active</state>\n" +
                                    "  <username nil=\"nil\"></username>\n" +
                                    "  <email>verena@example.com</email>\n" +
@@ -121,6 +124,7 @@ public class TestAccount extends TestModelBase {
         Assert.assertFalse(account.getHasCanceledSubscription());
         Assert.assertFalse(account.getHasPastDueInvoice());
         Assert.assertEquals(account.getVatNumber(), "U12345678");
+        Assert.assertEquals(account.getParentAccountCode(), "2");
     }
 
     private CustomFields getTestFields() {


### PR DESCRIPTION
This adds support for the Account Hierarchy feature. The integration test is not included because the API version has not been released yet. Unit tests are updated. Please see below for example usage.

Create an account with a parent account:

```java
// Assumes account "example-124" exists
try {
    client.open();
    final Account account = new Account();
    account.setAccountCode("example-123");
    account.setParentAccountCode("example-124");
    
    client.createAccount(account);
} catch (Exception e) {
    System.out.println(e.getStackTrace());
} finally {
    client.close();
}
```

Update an account to add a parent account:

```java
// Assumes "example-123" and "example-124" exist
// Assumes that "example-124" is not already the parent of "example-123"
try {
    client.open();
    final Account account = new Account();
    account.setParentAccountCode("example-124");
    client.updateAccount("example-123", account);
} catch (Exception e) {
    e.printStackTrace();
} finally {
    client.close();
}
```

Update an account to remove a parent account:

```java
try {
    client.open();
    final Account account = new Account();
    account.setParentAccountCode("");
    client.updateAccount("example-123", account);
} catch (Exception e) {
    e.printStackTrace();
} finally {
    client.close();
}
```

Get the parent account for a child:

```java
try {
    client.open();
    Account child = client.getAccount("example-123");
    Account parent = client.getAccount(child.getParentAccountCode());
    System.out.println(parent);
} catch (Exception e) {
    e.printStackTrace();
} finally {
    client.close();
}
```

Get the child accounts:

```java
// Assumes account "example-124" exists and has at least one child account
try {
    client.open();
    Accounts children = client.getChildAccounts("example-124");
    System.out.println(children.get(0));
} catch (Exception e) {
    e.printStackTrace();
} finally {
    client.close();
}
```

Associate a parent with a child account by creating a new subscription:

```java
// Assumes plan "gold" exists
// Assumes account "example-123" does not have a subscription for plan "gold"
// Assumes account "example-124" exists
try {
    client.open();

    Account acct = new Account();
    acct.setAccountCode("example-123");
    acct.setParentAccountCode("example-124");

    Subscription sub = new Subscription();
    sub.setAccount(acct);
    sub.setPlanCode("gold");
    sub.setCurrency("USD");

    client.createSubscription(sub);
} catch (Exception e) {
    e.printStackTrace();
} finally {
    client.close();
}
```

Associate a parent with a child by creating a new purchase:

```java
// Assumes account "example-124" exists
// Assumes plan code "silver" exists
try {
    client.open();

    Account acct = new Account();
    acct.setAccountCode("example-123");
    acct.setParentAccountCode("example-124");

    Subscription sub = new Subscription();
    sub.setPlanCode("silver");
    final Subscriptions subscriptions = new Subscriptions();
    subscriptions.add(sub);

    final Purchase purchaseData = new Purchase();
    purchaseData.setAccount(acct);
    purchaseData.setCollectionMethod("automatic");
    purchaseData.setCurrency("USD");
    purchaseData.setSubscriptions(subscriptions);

    final InvoiceCollection collection = client.purchase(purchaseData);
} catch (Exception e) {
    e.printStackTrace();
} finally {
    client.close();
}
```
The subscription and purchase endpoints can also be used to remove a parent account if the ParentAccountCode is set to empty string "".

