### PR TITLE
Add support for Amazon Pay to Billing Info

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -118,6 +118,12 @@ public class BillingInfo extends RecurlyObject {
     @XmlElement(name = "gateway_code")
     private String gatewayCode;
 
+    @XmlElement(name = "amazon_billing_agreement_id")
+    private String amazonBillingAgreementId;
+
+    @XmlElement(name = "amazon_region")
+    private String amazonRegion;
+
     public String getType() {
         return type;
     }
@@ -360,6 +366,22 @@ public class BillingInfo extends RecurlyObject {
         this.gatewayCode = stringOrNull(gatewayCode);
     }
 
+    public String getAmazonBillingAgreementId() {
+        return amazonBillingAgreementId;
+    }
+
+    public void setAmazonBillingAgreementId(final Object amazonBillingAgreementId) {
+        this.amazonBillingAgreementId = stringOrNull(amazonBillingAgreementId);
+    }
+
+    public String getAmazonRegion() {
+        return amazonRegion;
+    }
+
+    public void setAmazonRegion(final Object amazonRegion) {
+        this.amazonRegion = stringOrNull(amazonRegion);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -389,6 +411,8 @@ public class BillingInfo extends RecurlyObject {
         sb.append(", externalHppType='").append(externalHppType).append('\'');
         sb.append(", gatewayToken='").append(gatewayToken).append('\'');
         sb.append(", gatewayCode='").append(gatewayCode).append('\'');
+        sb.append(", amazonBillingAgreementId='").append(amazonBillingAgreementId).append('\'');
+        sb.append(", amazonRegion='").append(amazonRegion).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -475,6 +499,12 @@ public class BillingInfo extends RecurlyObject {
         if (externalHppType != null ? !externalHppType.equals(that.externalHppType) : that.externalHppType != null) {
             return false;
         }
+        if (amazonBillingAgreementId != null ? !amazonBillingAgreementId.equals(that.amazonBillingAgreementId) : that.amazonBillingAgreementId != null) {
+            return false;
+        }
+        if (amazonRegion != null ? !amazonRegion.equals(that.amazonRegion) : that.amazonRegion != null) {
+            return false;
+        }
 
         return true;
     }
@@ -506,7 +536,9 @@ public class BillingInfo extends RecurlyObject {
                 type,
                 externalHppType,
                 gatewayToken,
-                gatewayCode
+                gatewayCode,
+                amazonBillingAgreementId,
+                amazonRegion
         );
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestBillingInfo.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestBillingInfo.java
@@ -53,6 +53,8 @@ public class TestBillingInfo extends TestModelBase {
         billingInfo.setGeoCode(randomString());
         billingInfo.setGatewayToken(randomString());
         billingInfo.setGatewayCode(randomString());
+        billingInfo.setAmazonBillingAgreementId(randomString());
+        billingInfo.setAmazonRegion(randomString());
 
         final String xml = xmlMapper.writeValueAsString(billingInfo);
         Assert.assertEquals(xmlMapper.readValue(xml, BillingInfo.class), billingInfo);


### PR DESCRIPTION
This adds support for Amazon Pay.

```java
package com.recurly.testrig;

import com.ning.billing.recurly.RecurlyClient;
import com.ning.billing.recurly.model.BillingInfo;

public class CreateBillingInfo {
    public static void run(final RecurlyClient client) {
        try {
            client.open();

            final BillingInfo billingInfo = new BillingInfo();

            billingInfo.setFirstName("John");
            billingInfo.setLastName("Smith");
            billingInfo.setAddress1("125 Paper Street");
            billingInfo.setCity("Los Angeles");
            billingInfo.setState("CA");
            billingInfo.setZip("95312");
            billingInfo.setCountry("US");
            billingInfo.setPhone("213-555-5555");
            billingInfo.setAmazonBillingAgreementId("C02-2000965-4255444");
            billingInfo.setAmazonRegion("us");

            client.createOrUpdateBillingInfo(billingInfo);
        } catch (Exception e) {
            System.out.println(e.getStackTrace());
        } finally {
          client.close();
        }
    }
}
```