### PR TITLE
Adds request identifiers to errors

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/RecurlyAPIError.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyAPIError.java
@@ -19,10 +19,19 @@ package com.ning.billing.recurly.model;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.base.Objects;
+import com.ning.http.client.Response;
+
+import java.io.IOException;
 
 @XmlRootElement(name = "error")
 public class RecurlyAPIError extends RecurlyObject {
+
+    @XmlTransient
+    private ResponseMetadata responseMetadata;
 
     @XmlElement(name = "description")
     private String description;
@@ -34,6 +43,18 @@ public class RecurlyAPIError extends RecurlyObject {
     private String details;
 
     private int httpStatusCode;
+
+    public static RecurlyAPIError buildFromResponse(final Response response) {
+        final RecurlyAPIError recurlyAPIError = new RecurlyAPIError();
+        recurlyAPIError.setResponse(response);
+        return recurlyAPIError;
+    }
+
+    public static RecurlyAPIError buildFromXml(final XmlMapper xmlMapper, final String payload, final Response response) throws IOException {
+        final RecurlyAPIError recurlyAPIError = xmlMapper.readValue(payload, RecurlyAPIError.class);
+        recurlyAPIError.setResponse(response);
+        return recurlyAPIError;
+    }
 
     public String getDescription() {
         return description;
@@ -65,6 +86,19 @@ public class RecurlyAPIError extends RecurlyObject {
 
     public int getHttpStatusCode() { return this.httpStatusCode; }
 
+    public void setResponseMetadata(final ResponseMetadata meta) {
+        this.responseMetadata = meta;
+    }
+
+    public ResponseMetadata getResponseMetadata() {
+        return this.responseMetadata;
+    }
+
+    protected void setResponse(final Response response) {
+        this.setHttpStatusCode(response.getStatusCode());
+        this.setResponseMetadata(new ResponseMetadata(response));
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("RecurlyAPIError{");
@@ -72,6 +106,7 @@ public class RecurlyAPIError extends RecurlyObject {
         sb.append(", symbol='").append(symbol).append('\'');
         sb.append(", details='").append(details).append('\'');
         sb.append(", httpStatusCode='").append(httpStatusCode).append('\'');
+        sb.append(", responseMetadata='").append(responseMetadata).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -90,6 +125,10 @@ public class RecurlyAPIError extends RecurlyObject {
             return false;
         }
         if (symbol != null ? !symbol.equals(that.symbol) : that.symbol != null) {
+
+            return false;
+        }
+        if (responseMetadata != null ? !responseMetadata.equals(that.responseMetadata) : that.responseMetadata != null) {
             return false;
         }
 
@@ -102,7 +141,8 @@ public class RecurlyAPIError extends RecurlyObject {
                 description,
                 symbol,
                 details,
-                httpStatusCode
+                httpStatusCode,
+                responseMetadata
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/ResponseMetadata.java
+++ b/src/main/java/com/ning/billing/recurly/model/ResponseMetadata.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import com.ning.http.client.Response;
+
+public class ResponseMetadata {
+    /**
+     * Represents the unique id given to this
+     * request by Recurly. Comes from the X-Request-Id
+     * header in the response.
+     */
+    private String requestId;
+
+    /**
+     * Represents the unique id given to this
+     * request by Cloudflare (if request is proxied through
+     * Cloudflare). Comes from the CF-RAY header in the response.
+     */
+    private String cfRay;
+
+    /**
+     * The HTTP Status Code of the response.
+     */
+    private int statusCode;
+
+    public ResponseMetadata(Response response) {
+        this.requestId = response.getHeader("X-Request-Id");
+        this.cfRay = response.getHeader("CF-RAY");
+        this.statusCode = response.getStatusCode();
+    }
+
+    public String getRequestId() {
+        return this.requestId;
+    }
+
+    public String getCfRay() {
+        return this.cfRay;
+    }
+
+    public int getStatusCode() {
+        return this.getStatusCode();
+    }
+
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ResponseMetadata{");
+        sb.append("requestId=").append(requestId);
+        sb.append(", cfRay=").append(cfRay);
+        sb.append(", statusCode=").append(statusCode);
+        sb.append('}');
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
If a user gets exceptions, they will now see the Recurly request id and/or the cloudflare request id. This is useful for debugging esp at the cloudflare layer. This can be expanded on in the future, for now I'm keeping it to solving the particular problem he had.

### Testing

To test, create an error (such as a 404) and check that the log contains the request id and the cf_ray id. 