### PR TITLE
Add a warning about logging PII in production

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -129,6 +129,17 @@ public class RecurlyClient {
         return Boolean.getBoolean(RECURLY_DEBUG_KEY);
     }
 
+    /**
+     * Warns the user about logging PII in production environments
+     */
+    private static void loggerWarning() {
+        if (debug())
+        {
+            log.warn("[WARNING] Logger enabled. The logger has the potential to leak " +
+            "PII and should never be used in production environments.");
+        }
+    }
+
     // TODO: should we make it static?
     private final XmlMapper xmlMapper;
     private final String userAgent;
@@ -145,14 +156,17 @@ public class RecurlyClient {
 
     public RecurlyClient(final String apiKey) {
         this(apiKey, "api");
+        loggerWarning();
     }
 
     public RecurlyClient(final String apiKey, final String subDomain) {
         this(apiKey, subDomain + ".recurly.com", 443, "v2");
+        loggerWarning();
     }
 
     public RecurlyClient(final String apiKey, final String host, final int port, final String version) {
         this(apiKey, "https", host, port, version);
+        loggerWarning();
     }
 
     public RecurlyClient(final String apiKey, final String scheme, final String host, final int port, final String version) {
@@ -161,6 +175,7 @@ public class RecurlyClient {
         this.xmlMapper = RecurlyObject.newXmlMapper();
         this.userAgent = buildUserAgent();
         this.rateLimitRemaining = -1;
+        loggerWarning();
     }
 
     /**

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -1104,7 +1104,8 @@ public class TestRecurlyClient {
             // 2 Invoices are present (the first one is for the transaction, the second for the subscription)
             Assert.assertEquals(invoices.size(), 2, "Number of Invoices incorrect");
             Assert.assertEquals(invoices.get(0).getTotalInCents(), t.getAmountInCents(), "Amount in cents is not the same");
-            Assert.assertEquals(invoices.get(1).getTotalInCents(), subscriptionData.getUnitAmountInCents(), "Amount in cents is not the same");
+            final Integer total = subscriptionData.getUnitAmountInCents() + planData.getSetupFeeInCents().getUnitAmountUSD();
+            Assert.assertEquals(invoices.get(1).getTotalInCents(), total, "Amount in cents is not the same");
         } finally {
             // Close the account
             recurlyClient.closeAccount(accountData.getAccountCode());

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -486,7 +486,7 @@ public class TestUtils {
         price.setUnitAmountUSD(LifecycleTest.randomInteger(10));
         price.setUnitAmountSEK(LifecycleTest.randomInteger(10));
         */
-        price.setUnitAmountEUR(10);
+        price.setUnitAmountUSD(10);
 
         return price;
     }


### PR DESCRIPTION
Theoretically, no merchants should have logging enabled in production. However, in the other client libraries, we go ahead and give a warning when the logger is enabled. This will log a similar warning so that if anyone has debug mode on in production, they are aware of the PII consequences (and are hopefully inspired to turn off debugging of production data).