### PR TITLE
Add more invoice states in accordance with the docs

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/InvoiceState.java
+++ b/src/main/java/com/ning/billing/recurly/model/InvoiceState.java
@@ -21,7 +21,13 @@ public enum InvoiceState {
     OPEN("open"),
     FAILED("failed"),
     COLLECTED("collected"),
-    PAST_DUE("past_due");
+    PAST_DUE("past_due"),
+    PENDING("pending"),
+    PAID("paid"),
+    CLOSED("closed"),
+    VOIDED("voided"),
+    PROCESSING("processing");
+
 
     private final String type;
 


### PR DESCRIPTION
The docs [here](https://dev.recurly.com/docs/list-invoices) show that there are more available invoice states than what was currently in the library. This updates the InvoiceState enum to allow for the more recent states.

Script:
```java
package com.recurly.testrig;

import com.ning.billing.recurly.QueryParams;
import com.ning.billing.recurly.RecurlyClient;
import com.ning.billing.recurly.model.Invoices;
import com.ning.billing.recurly.model.InvoiceState;

public class GetAccountInvoices {
    public static void run(final RecurlyClient client) {
        try {
            client.open();
            String accountCode = "x";
            InvoiceState state = InvoiceState.PAID;
            QueryParams params = new QueryParams();
            Invoices accountInvoices = client.getAccountInvoices(accountCode, state, params);
            System.out.println(accountInvoices);
        } catch (Exception e) {
            e.printStackTrace();
        } finally {
          client.close();
        }
    }
}
```