### PR TITLE
Validate all API calls are being made to recurly.com

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -90,6 +90,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.ConnectException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.security.KeyManagementException;
@@ -101,6 +102,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.List;
+import java.util.Arrays;
 
 public class RecurlyClient {
 
@@ -119,6 +121,8 @@ public class RecurlyClient {
     private static final Pattern TAG_FROM_GIT_DESCRIBE_PATTERN = Pattern.compile("recurly-java-library-([0-9]*\\.[0-9]*\\.[0-9]*)(-[0-9]*)?");
 
     public static final String FETCH_RESOURCE = "/recurly_js/result";
+
+    private static final List<String> validHosts = Arrays.asList("recurly.com");
 
     /**
      * Checks a system property to see if debugging output is
@@ -1997,6 +2001,7 @@ public class RecurlyClient {
         if (debug()) {
             log.info("Msg to Recurly API [GET] :: URL : {}", url);
         }
+        validateHost(url);
         return callRecurlySafeXmlContent(client.prepareGet(url), clazz);
     }
 
@@ -2009,6 +2014,8 @@ public class RecurlyClient {
     }
 
     private InputStream callRecurlySafeGetPdf(String url) {
+        validateHost(url);
+
         final Response response;
         final InputStream pdfInputStream;
         try {
@@ -2051,6 +2058,8 @@ public class RecurlyClient {
             return null;
         }
 
+        validateHost(baseUrl + resource);
+
         return callRecurlySafeXmlContent(client.preparePost(baseUrl + resource).setBody(xmlPayload), clazz);
     }
 
@@ -2072,6 +2081,8 @@ public class RecurlyClient {
             return null;
         }
 
+        validateHost(baseUrl + resource);
+
         return callRecurlySafeXmlContent(client.preparePut(baseUrl + resource).setBody(xmlPayload), clazz);
     }
 
@@ -2084,10 +2095,15 @@ public class RecurlyClient {
         if (debug()) {
             log.info("Msg to Recurly API [HEAD]:: URL : {}", url);
         }
+
+        validateHost(url);
+
         return callRecurlyNoContent(client.prepareHead(url));
     }
 
     private void doDELETE(final String resource) {
+        validateHost(baseUrl + resource);
+
         callRecurlySafeXmlContent(client.prepareDelete(baseUrl + resource), null);
     }
 
@@ -2258,6 +2274,18 @@ public class RecurlyClient {
         builder.setSSLContext(SslUtils.getInstance().getSSLContext());
 
         return new AsyncHttpClient(builder.build());
+    }
+
+    private void validateHost(String url) {
+        String host = URI.create(url).getHost();
+
+        // Remove the subdomain from the host
+        host = host.substring(host.indexOf(".")+1);
+
+        if (!validHosts.contains(host)) {
+            String exc = String.format("Attempted to make call to %s instead of Recurly", host);
+            throw new RuntimeException(exc);
+        }
     }
 
     @VisibleForTesting


### PR DESCRIPTION
The other Recurly clients all validate that the domain requests are being made to is "recurly.com". This adds a check to verify the same is true in this library.

Testing:

Initialize a RecurlyClient with the "subdomain" as `maliciousdomain.com/`. See how the client now blocks requests from being made to that malicious domain.