### PR TITLE
Fix stackoverflow exception

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -747,9 +747,34 @@ public class RecurlyClient {
      * Please note: this API end-point may be used to import billing information without security codes (CVV).
      * Recurly recommends requiring CVV from your customers when collecting new or updated billing information.
      *
+     * @param accountCode recurly account id
      * @param billingInfo billing info object to create or update
      * @return the newly created or update billing info object on success, null otherwise
      */
+    public BillingInfo createOrUpdateBillingInfo(final String accountCode, final BillingInfo billingInfo) {
+        return doPUT(Account.ACCOUNT_RESOURCE + "/" + accountCode + BillingInfo.BILLING_INFO_RESOURCE,
+                     billingInfo, BillingInfo.class);
+    }
+
+    /**
+     * Update an account's billing info
+     * <p>
+     * When new or updated credit card information is updated, the billing information is only saved if the credit card
+     * is valid. If the account has a past due invoice, the outstanding balance will be collected to validate the
+     * billing information.
+     * <p>
+     * If the account does not exist before the API request, the account will be created if the billing information
+     * is valid.
+     * <p>
+     * Please note: this API end-point may be used to import billing information without security codes (CVV).
+     * Recurly recommends requiring CVV from your customers when collecting new or updated billing information.
+     *
+     * @deprecated Replaced by {@link #createOrUpdateBillingInfo(String, BillingInfo)} Please pass in the account code rather than setting the account on the BillingInfo object
+     *
+     * @param billingInfo billing info object to create or update
+     * @return the newly created or update billing info object on success, null otherwise
+     */
+    @Deprecated
     public BillingInfo createOrUpdateBillingInfo(final BillingInfo billingInfo) {
         final String accountCode = billingInfo.getAccount().getAccountCode();
         // Unset it to avoid confusing Recurly

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -146,6 +146,11 @@ public class BillingInfo extends RecurlyObject {
         return account;
     }
 
+    /**
+     * @deprecated Please do not attach an account to a BillingInfo object. Pass the account code into {@link com.ning.billing.recurly.RecurlyClient#createOrUpdateBillingInfo(String, BillingInfo)}
+     * @param account
+     */
+    @Deprecated
     public void setAccount(final Account account) {
         this.account = account;
     }
@@ -386,7 +391,16 @@ public class BillingInfo extends RecurlyObject {
     public String toString() {
         final StringBuilder sb = new StringBuilder();
         sb.append("BillingInfo");
-        sb.append("{account='").append(account).append('\'');
+
+        // Prevent infinite loop when printing account.
+        // See https://github.com/killbilling/recurly-java-library/issues/326
+        if (account != null && account.getBillingInfo().equals(this)) {
+            sb.append("{account='").append(account.getAccountCode()).append('\'');
+        }
+        else {
+            sb.append("{account='").append(account).append('\'');
+        }
+
         sb.append(", type='").append(type).append('\'');
         sb.append(", firstName='").append(firstName).append('\'');
         sb.append(", lastName='").append(lastName).append('\'');


### PR DESCRIPTION
Fixes #326 

Print just the account code if the account's billing info is set to the same object as the billing info to prevent an infinite when there's a circular reference.

Script:
```java
            final Account account = new Account();
            account.setAccountCode("b");

            final BillingInfo info = new BillingInfo();

            // create a circular reference
            account.setBillingInfo(info);
            info.setAccount(account);
            
            System.out.println(account); // now this does not throw an exception
```