### PR TITLE
Add tax_exempt and tax_code to Plan

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Plan.java
+++ b/src/main/java/com/ning/billing/recurly/model/Plan.java
@@ -110,6 +110,12 @@ public class Plan extends RecurlyObject {
     @XmlElement(name = "auto_renew")
     private Boolean autoRenew;
 
+    @XmlElement(name = "tax_exempt")
+    private Boolean taxExempt;
+
+    @XmlElement(name = "tax_code")
+    private String taxCode;
+
     public String getPlanCode() {
         return planCode;
     }
@@ -318,6 +324,22 @@ public class Plan extends RecurlyObject {
         this.autoRenew = booleanOrNull(autoRenew);
     }
 
+    public Boolean getTaxExempt() {
+        return this.taxExempt;
+    }
+
+    public void setTaxExempt(final Object taxExempt) {
+        this.taxExempt = booleanOrNull(taxExempt);
+    }
+
+    public String getTaxCode() {
+        return this.taxCode;
+    }
+
+    public void setTaxCode(final Object taxCode) {
+        this.taxCode = stringOrNull(taxCode);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -348,6 +370,8 @@ public class Plan extends RecurlyObject {
         sb.append(", revenueScheduleType=").append(revenueScheduleType);
         sb.append(", setupFeeRevenueScheduleType=").append(setupFeeRevenueScheduleType);
         sb.append(", autoRenew=").append(autoRenew);
+        sb.append(", taxExempt=").append(taxExempt);
+        sb.append(", taxCode=").append(taxCode);
         sb.append('}');
         return sb.toString();
     }
@@ -437,6 +461,12 @@ public class Plan extends RecurlyObject {
         if (setupFeeAccountingCode != null ? setupFeeAccountingCode.compareTo(plan.setupFeeAccountingCode) != 0: plan.setupFeeAccountingCode != null) {
             return false;
         }
+        if (taxExempt != null ? taxExempt.compareTo(plan.taxExempt) != 0: plan.taxExempt != null) {
+            return false;
+        }
+        if (taxCode != null ? taxCode.compareTo(plan.taxCode) != 0: plan.taxCode != null) {
+            return false;
+        }
 
         return true;
     }
@@ -469,7 +499,9 @@ public class Plan extends RecurlyObject {
                 revenueScheduleType,
                 setupFeeRevenueScheduleType,
                 trialRequiresBillingInfo,
-                autoRenew
+                autoRenew,
+                taxExempt,
+                taxCode
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Plan.java
+++ b/src/main/java/com/ning/billing/recurly/model/Plan.java
@@ -320,7 +320,7 @@ public class Plan extends RecurlyObject {
         return this.autoRenew;
     }
 
-    public void setAutoRenew(final Object trialRequiresBillingInfo) {
+    public void setAutoRenew(final Object autoRenew) {
         this.autoRenew = booleanOrNull(autoRenew);
     }
 

--- a/src/test/java/com/ning/billing/recurly/model/TestPlan.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPlan.java
@@ -53,6 +53,9 @@ public class TestPlan extends TestModelBase {
                                 "  <setup_fee_accounting_code nil=\"nil\"></setup_fee_accounting_code>\n" +
                                 "  <created_at type=\"dateTime\">2011-04-19T07:00:00Z</created_at>\n" +
                                 "  <updated_at type=\"dateTime\">2011-04-19T07:00:00Z</updated_at>\n" +
+                                "  <tax_exempt>false</tax_exempt>\n" +
+                                "  <tax_code>digital</tax_code>\n" +
+                                "  <accounting_code nil=\"nil\"></accounting_code>\n" +
                                 "  <unit_amount_in_cents>\n" +
                                 "    <USD type=\"integer\">1000</USD>\n" +
                                 "    <EUR type=\"integer\">800</EUR>\n" +
@@ -78,6 +81,8 @@ public class TestPlan extends TestModelBase {
         Assert.assertEquals(plan.getUnitAmountInCents().getUnitAmountEUR(), new Integer(800));
         Assert.assertEquals(plan.getSetupFeeInCents().getUnitAmountUSD(), new Integer(6000));
         Assert.assertEquals(plan.getSetupFeeInCents().getUnitAmountEUR(), new Integer(4500));
+        Assert.assertEquals(plan.getTaxExempt(), new Boolean(false));
+        Assert.assertEquals(plan.getTaxCode(), "digital");
         Assert.assertNull(plan.getDescription());
         Assert.assertNull(plan.getSuccessLink());
         Assert.assertNull(plan.getCancelLink());
@@ -114,6 +119,8 @@ public class TestPlan extends TestModelBase {
                                 "  <setup_fee_revenue_schedule_type>evenly</setup_fee_revenue_schedule_type>>\n" +
                                 "  <created_at type=\"dateTime\">2011-04-19T07:00:00Z</created_at>\n" +
                                 "  <updated_at type=\"dateTime\">2011-04-19T07:00:00Z</updated_at>\n" +
+                                "  <tax_exempt>false</tax_exempt>\n" +
+                                "  <tax_code>digital</tax_code>\n" +
                                 "  <unit_amount_in_cents>\n" +
                                 "  </unit_amount_in_cents>\n" +
                                 "  <setup_fee_in_cents>\n" +
@@ -141,6 +148,8 @@ public class TestPlan extends TestModelBase {
         Assert.assertNull(plan.getSetupFeeAccountingCode());
         Assert.assertEquals(plan.getRevenueScheduleType(), RevenueScheduleType.EVENLY);
         Assert.assertEquals(plan.getSetupFeeRevenueScheduleType(), RevenueScheduleType.EVENLY);
+        Assert.assertEquals(plan.getTaxExempt(), new Boolean(false));
+        Assert.assertEquals(plan.getTaxCode(), "digital");
     }
 
     @Test(groups = "fast")


### PR DESCRIPTION
Fixes #333 and #334 

Example with tax code and tax exempt:
```java
client.open();
final Plan plan = new Plan();
plan.setPlanCode("new-plan");
plan.setName("New Plan");

final RecurlyUnitCurrency price = new RecurlyUnitCurrency();
price.setUnitAmountUSD(10);

plan.setUnitAmountInCents(price);
plan.setTaxCode("unknown");
plan.setTaxExempt(true);

client.createPlan(plan);
```

The parameter name for `setAutoRenew` is also fixed, but the interface is the same so it's not in the example.