### PR TITLE
Fix missing values in add ons

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/AbstractAddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/AbstractAddOn.java
@@ -17,6 +17,8 @@
 
 package com.ning.billing.recurly.model;
 
+import java.math.BigDecimal;
+
 import javax.xml.bind.annotation.XmlElement;
 import com.google.common.base.Objects;
 
@@ -30,6 +32,12 @@ public class AbstractAddOn extends RecurlyObject {
 
     @XmlElement(name = "usage_type")
     protected String usageType;
+
+    @XmlElement(name = "usage_percentage")
+    protected BigDecimal usagePercentage;
+
+    @XmlElement(name = "revenue_schedule_type")
+    private RevenueScheduleType revenueScheduleType;
 
     public String getAddOnCode() {
         return addOnCode;
@@ -55,12 +63,30 @@ public class AbstractAddOn extends RecurlyObject {
         this.usageType = stringOrNull(usageType);
     }
 
+    public BigDecimal getUsagePercentage() {
+        return usagePercentage;
+    }
+
+    public void setUsagePercentage(final Object usagePercentage) {
+        this.usagePercentage = bigDecimalOrNull(usagePercentage);
+    }
+
+    public RevenueScheduleType getRevenueScheduleType() {
+        return revenueScheduleType;
+    }
+
+    public void setRevenueScheduleType(final Object revenueScheduleType) {
+        this.revenueScheduleType = enumOrNull(RevenueScheduleType.class, revenueScheduleType, true);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("AbstractAddOn{");
         sb.append("addOnCode='").append(addOnCode).append('\'');
         sb.append("measuredUnitId='").append(measuredUnitId).append('\'');
         sb.append("usageType='").append(usageType).append('\'');
+        sb.append("usagePercentage=").append(usagePercentage);
+        sb.append(", revenueScheduleType='").append(revenueScheduleType).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -84,11 +110,26 @@ public class AbstractAddOn extends RecurlyObject {
             return false;
         }
 
+        if (usagePercentage != null ? !usagePercentage.equals(that.usagePercentage) : that.usagePercentage != null) {
+            return false;
+        }
+
+        if (revenueScheduleType != null ? !revenueScheduleType.equals(that.revenueScheduleType) : that.revenueScheduleType != null) {
+            return false;
+        }
+
         return true;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(addOnCode, measuredUnitId, usageType);
+        return Objects.hashCode(
+            addOnCode,
+            measuredUnitId,
+            usageType,
+            usagePercentage,
+            revenueScheduleType
+        );
+                
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/AddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/AddOn.java
@@ -42,9 +42,6 @@ public class AddOn extends AbstractAddOn {
     @XmlElement(name = "unit_amount_in_cents")
     private RecurlyUnitCurrency unitAmountInCents;
 
-    @XmlElement(name = "revenue_schedule_type")
-    private RevenueScheduleType revenueScheduleType;
-
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
@@ -56,6 +53,15 @@ public class AddOn extends AbstractAddOn {
 
     @XmlElement(name = "add_on_type")
     private String addOnType;
+
+    @XmlElement(name = "tax_code")
+    private String taxCode;
+
+    @XmlElement(name = "accounting_code")
+    private String accountingCode;
+
+    @XmlElement(name = "optional")
+    private Boolean optional;
 
     public String getName() {
         return name;
@@ -79,14 +85,6 @@ public class AddOn extends AbstractAddOn {
 
     public void setDefaultQuantity(final Object defaultQuantity) {
         this.defaultQuantity = integerOrNull(defaultQuantity);
-    }
-
-    public RevenueScheduleType getRevenueScheduleType() {
-        return revenueScheduleType;
-    }
-
-    public void setRevenueScheduleType(final Object revenueScheduleType) {
-        this.revenueScheduleType = enumOrNull(RevenueScheduleType.class, revenueScheduleType, true);
     }
 
     public RecurlyUnitCurrency getUnitAmountInCents() {
@@ -132,6 +130,30 @@ public class AddOn extends AbstractAddOn {
         this.addOnType = stringOrNull(addOnType);
     }
 
+    public String getTaxCode() {
+        return taxCode;
+    }
+
+    public void setTaxCode(final Object taxCode) {
+        this.taxCode = stringOrNull(taxCode);
+    }
+
+    public String getAccountingCode() {
+        return accountingCode;
+    }
+
+    public void setAccountingCode(final Object accountingCode) {
+        this.accountingCode = stringOrNull(accountingCode);
+    }
+
+    public Boolean getOptional() {
+        return optional;
+    }
+
+    public void setOptional(final Object optional) {
+        this.optional = booleanOrNull(optional);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("AddOn{");
@@ -141,9 +163,11 @@ public class AddOn extends AbstractAddOn {
         sb.append(", displayQuantityOnHostedPage=").append(displayQuantityOnHostedPage);
         sb.append(", defaultQuantity=").append(defaultQuantity);
         sb.append(", unitAmountInCents=").append(unitAmountInCents);
-        sb.append(", revenueScheduleType=").append(revenueScheduleType);
         sb.append(", createdAt=").append(createdAt);
         sb.append(", updatedAt=").append(updatedAt);
+        sb.append(", taxCode=").append(taxCode);
+        sb.append(", accountingCode=").append(accountingCode);
+        sb.append(", optional=").append(optional);
         sb.append('}');
         return sb.toString();
     }
@@ -173,13 +197,19 @@ public class AddOn extends AbstractAddOn {
         if (displayQuantityOnHostedPage != null ? !displayQuantityOnHostedPage.equals(addOn.displayQuantityOnHostedPage) : addOn.displayQuantityOnHostedPage != null) {
             return false;
         }
-        if (revenueScheduleType != null ? !revenueScheduleType.equals(addOn.revenueScheduleType) : addOn.revenueScheduleType != null) {
-            return false;
-        }
         if (name != null ? !name.equals(addOn.name) : addOn.name != null) {
             return false;
         }
         if (unitAmountInCents != null ? !unitAmountInCents.equals(addOn.unitAmountInCents) : addOn.unitAmountInCents != null) {
+            return false;
+        }
+        if (taxCode != null ? !taxCode.equals(addOn.taxCode) : addOn.taxCode != null) {
+            return false;
+        }
+        if (accountingCode != null ? !accountingCode.equals(addOn.accountingCode) : addOn.accountingCode != null) {
+            return false;
+        }
+        if (optional != null ? !optional.equals(addOn.optional) : addOn.optional != null) {
             return false;
         }
 
@@ -195,9 +225,11 @@ public class AddOn extends AbstractAddOn {
                 displayQuantityOnHostedPage,
                 defaultQuantity,
                 unitAmountInCents,
-                revenueScheduleType,
                 createdAt,
-                updatedAt
+                updatedAt,
+                taxCode,
+                accountingCode,
+                optional
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Adjustment.java
+++ b/src/main/java/com/ning/billing/recurly/model/Adjustment.java
@@ -22,7 +22,10 @@ import org.joda.time.DateTime;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlList;
 import java.math.BigDecimal;
+import java.util.List;
 
 @XmlRootElement(name = "adjustment")
 public class Adjustment extends RecurlyObject {
@@ -35,6 +38,9 @@ public class Adjustment extends RecurlyObject {
 
     @XmlElement(name = "uuid")
     private String uuid;
+
+    @XmlElement(name = "type")
+    private String type;
 
     @XmlElement(name = "description")
     private String description;
@@ -66,8 +72,24 @@ public class Adjustment extends RecurlyObject {
     @XmlElement(name = "taxable")
     private Boolean taxable;
 
+    @XmlElement(name = "tax_type")
+    private String taxType;
+
+    @XmlElement(name = "tax_region")
+    private String taxRegion;
+
+    @XmlElement(name = "tax_rate")
+    private String taxRate;
+
+    @XmlElement(name = "tax_code")
+    private String taxCode;
+
     @XmlElement(name = "tax_exempt")
     private Boolean taxExempt;
+
+    @XmlList
+    @XmlElementWrapper(name = "tax_details")
+    private List<TaxDetail> taxDetails;
 
     @XmlElement(name = "product_code")
     private String productCode;
@@ -137,6 +159,14 @@ public class Adjustment extends RecurlyObject {
 
     public void setUuid(final Object uuid) {
         this.uuid = stringOrNull(uuid);
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(final Object type) {
+        this.type = stringOrNull(type);
     }
 
     public String getDescription() {
@@ -219,12 +249,52 @@ public class Adjustment extends RecurlyObject {
         this.taxable = booleanOrNull(taxable);
     }
 
+    public String getTaxType() {
+        return taxType;
+    }
+
+    public void setTaxType(final Object taxType) {
+        this.taxType = stringOrNull(taxType);
+    }
+
+    public String getTaxRegion() {
+        return taxRegion;
+    }
+
+    public void setTaxRegion(final Object taxRegion) {
+        this.taxRegion = stringOrNull(taxRegion);
+    }
+
+    public String getTaxRate() {
+        return taxRate;
+    }
+
+    public void setTaxRate(final Object taxRate) {
+        this.taxRate = stringOrNull(taxRate);
+    }
+
+    public String getTaxCode() {
+        return taxCode;
+    }
+
+    public void setTaxCode(final Object taxCode) {
+        this.taxCode = stringOrNull(taxCode);
+    }
+
     public Boolean getTaxExempt() {
         return taxExempt;
     }
 
     public void setTaxExempt(final Object taxExempt) {
         this.taxExempt = booleanOrNull(taxExempt);
+    }
+
+    public List<TaxDetail> getTaxDetails() {
+        return taxDetails;
+    }
+
+    public void setTaxDetails(final List<TaxDetail> taxDetails) {
+        this.taxDetails = taxDetails;
     }
 
     public String getProductCode() { return productCode; }
@@ -341,6 +411,7 @@ public class Adjustment extends RecurlyObject {
         sb.append("Adjustment");
         sb.append("{account=").append(account);
         sb.append(", uuid='").append(uuid).append('\'');
+        sb.append(", type=").append(type);
         sb.append(", description='").append(description).append('\'');
         sb.append(", accountingCode='").append(accountingCode).append('\'');
         sb.append(", origin='").append(origin).append('\'');
@@ -348,7 +419,12 @@ public class Adjustment extends RecurlyObject {
         sb.append(", quantity=").append(quantity);
         sb.append(", discountInCents=").append(discountInCents);
         sb.append(", taxInCents=").append(taxInCents);
+        sb.append(", taxType=").append(taxType);
+        sb.append(", taxRegion=").append(taxRegion);
+        sb.append(", taxRate=").append(taxRate);
+        sb.append(", taxCode=").append(taxCode);
         sb.append(", taxExempt=").append(taxExempt);
+        sb.append(", taxDetails=").append(taxDetails);
         sb.append(", totalInCents=").append(totalInCents);
         sb.append(", currency='").append(currency).append('\'');
         sb.append(", taxable=").append(taxable);
@@ -427,7 +503,25 @@ public class Adjustment extends RecurlyObject {
         if (taxable != null ? !taxable.equals(that.taxable) : that.taxable != null) {
             return false;
         }
+        if (type != null ? !type.equals(that.type) : that.type != null) {
+            return false;
+        }
+        if (taxType != null ? !taxType.equals(that.taxType) : that.taxType != null) {
+            return false;
+        }
+        if (taxRegion != null ? !taxRegion.equals(that.taxRegion) : that.taxRegion != null) {
+            return false;
+        }
+        if (taxRate != null ? !taxRate.equals(that.taxRate) : that.taxRate != null) {
+            return false;
+        }
+        if (taxCode != null ? !taxCode.equals(that.taxCode) : that.taxCode != null) {
+            return false;
+        }
         if (taxExempt != null ? !taxExempt.equals(that.taxExempt) : that.taxExempt != null) {
+            return false;
+        }
+        if (taxDetails != null ? !taxDetails.equals(that.taxDetails) : that.taxDetails != null) {
             return false;
         }
         if (totalInCents != null ? !totalInCents.equals(that.totalInCents) : that.totalInCents != null) {
@@ -462,6 +556,7 @@ public class Adjustment extends RecurlyObject {
         return Objects.hashCode(
                 account,
                 uuid,
+                type,
                 description,
                 accountingCode,
                 origin,
@@ -473,7 +568,12 @@ public class Adjustment extends RecurlyObject {
                 totalInCents,
                 currency,
                 taxable,
+                taxType,
+                taxRegion,
+                taxRate,
+                taxCode,
                 taxExempt,
+                taxDetails,
                 startDate,
                 endDate,
                 createdAt,

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionAddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionAddOn.java
@@ -31,6 +31,9 @@ public class SubscriptionAddOn extends AbstractAddOn {
     @XmlElement(name = "quantity")
     private Integer quantity;
 
+    @XmlElement(name = "gateway_code")
+    private String gatewayCode;
+
     public Integer getUnitAmountInCents() {
         return unitAmountInCents;
     }
@@ -47,11 +50,20 @@ public class SubscriptionAddOn extends AbstractAddOn {
         this.quantity = integerOrNull(quantity);
     }
 
+    public String getGatewayCode() {
+        return gatewayCode;
+    }
+
+    public void setGatewayCode(final Object gatewayCode) {
+        this.gatewayCode = stringOrNull(gatewayCode);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("SubscriptionAddOn{");
         sb.append("unitAmountInCents=").append(unitAmountInCents);
         sb.append(", quantity=").append(quantity);
+        sb.append(", gatewayCode=").append(gatewayCode);
         sb.append('}');
         return sb.toString();
     }
@@ -69,6 +81,9 @@ public class SubscriptionAddOn extends AbstractAddOn {
         if (unitAmountInCents != null ? !unitAmountInCents.equals(addOn.unitAmountInCents) : addOn.unitAmountInCents != null) {
             return false;
         }
+        if (gatewayCode != null ? !gatewayCode.equals(addOn.gatewayCode) : addOn.gatewayCode != null) {
+            return false;
+        }
 
         return true;
     }
@@ -77,7 +92,8 @@ public class SubscriptionAddOn extends AbstractAddOn {
     public int hashCode() {
         return Objects.hashCode(
                 unitAmountInCents,
-                quantity
+                quantity,
+                gatewayCode
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/TaxDetail.java
+++ b/src/main/java/com/ning/billing/recurly/model/TaxDetail.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import com.google.common.base.Objects;
+
+import java.math.BigDecimal;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "tax_detail")
+public class TaxDetail extends RecurlyObject{
+
+    @XmlElement(name = "name")
+    protected String name;
+
+    @XmlElement(name = "type")
+    private String type;
+
+    @XmlElement(name = "tax_rate")
+    private BigDecimal taxRate;
+
+    @XmlElement(name = "tax_in_cents")
+    private Integer taxInCents;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final Object name) {
+        this.name = stringOrNull(name);
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(final Object type) {
+        this.type = stringOrNull(type);
+    }
+
+    public BigDecimal getTaxRate() {
+        return taxRate;
+    }
+
+    public void setTaxRate(final Object taxRate) {
+        this.taxRate = bigDecimalOrNull(taxRate);
+    }
+
+    public Integer getTaxInCents() {
+        return taxInCents;
+    }
+
+    public void setTaxInCents(final Object taxInCents) {
+        this.taxInCents = integerOrNull(taxInCents);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("TaxDetail{");
+        sb.append("name='").append(name).append('\'');
+        sb.append(", type='").append(type).append('\'');
+        sb.append(", taxRate=").append(taxRate);
+        sb.append(", taxInCents=").append(taxInCents);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final TaxDetail that = (TaxDetail) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) {
+            return false;
+        }
+        if (type != null ? !type.equals(that.type) : that.type != null) {
+            return false;
+        }
+        if (taxRate != null ? !taxRate.equals(that.taxRate) : that.taxRate != null) {
+            return false;
+        }
+        if (taxInCents != null ? !taxInCents.equals(that.taxInCents) : that.taxInCents != null) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(
+            name,
+            type,
+            taxRate,
+            taxInCents
+        );
+    }
+
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
@@ -47,6 +47,9 @@ public class TestAddOns extends TestModelBase {
                                   "    <revenue_schedule_type>evenly</revenue_schedule_type>\n" +
                                   "    <created_at type=\"dateTime\">2011-06-28T12:34:56Z</created_at>\n" +
                                   "    <updated_at type=\"dateTime\">2011-06-28T12:34:56Z</updated_at>\n" +
+                                  "    <accounting_code>ABC123</accounting_code>\n" +
+                                  "    <tax_code>digital</tax_code>\n" +
+                                  "    <optional type=\"boolean\">true</optional>\n" +
                                   "  </add_on>\n" +
                                   "  <!-- Continued... -->\n" +
                                   "</add_ons>";
@@ -86,5 +89,8 @@ public class TestAddOns extends TestModelBase {
         Assert.assertEquals(addOn.getRevenueScheduleType(), RevenueScheduleType.EVENLY);
         Assert.assertEquals(addOn.getCreatedAt(), new DateTime("2011-06-28T12:34:56Z"));
         Assert.assertEquals(addOn.getUpdatedAt(), new DateTime("2011-06-28T12:34:56Z"));
+        Assert.assertEquals(addOn.getTaxCode(), "digital");
+        Assert.assertEquals(addOn.getAccountingCode(), "ABC123");
+        Assert.assertEquals(addOn.getOptional(), (Boolean) true);
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestAdjustment.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAdjustment.java
@@ -17,7 +17,11 @@
 
 package com.ning.billing.recurly.model;
 
+import com.ning.billing.recurly.model.TaxDetail;
+
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.ArrayList;
 
 import org.joda.time.DateTime;
 import org.testng.Assert;
@@ -32,6 +36,7 @@ public class TestAdjustment extends TestModelBase {
                                       "<adjustment type=\"credit\" href=\"https://api.recurly.com/v2/adjustments/626db120a84102b1809909071c701c60\">\n" +
                                       "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n" +
                                       "  <uuid>626db120a84102b1809909071c701c60</uuid>\n" +
+                                      "  <type>charge</type>\n" +
                                       "  <state>invoiced</state>\n" +
                                       "  <description>Charge for extra bandwidth</description>\n" +
                                       "  <refundable_total_in_cents type=\"integer\">1000</refundable_total_in_cents>\n" +
@@ -46,6 +51,19 @@ public class TestAdjustment extends TestModelBase {
                                       "  <proration_rate type=\"float\">0.133</proration_rate>\n" +
                                       "  <product_code>product123</product_code>\n" +
                                       "  <taxable type=\"boolean\">false</taxable>\n" +
+                                      "  <tax_type>usst</tax_type>\n" +
+                                      "  <tax_region>CA</tax_region>\n" +
+                                      "  <tax_rate type=\"float\">0.0875</tax_rate>\n" +
+                                      "  <tax_exempt type=\"boolean\">false</tax_exempt>\n" +
+                                      "  <tax_code>digital</tax_code>\n" +
+                                      "  <tax_details type=\"array\">\n" +
+                                      "    <tax_detail>\n" +
+                                      "      <name>Special Tax</name>\n" +
+                                      "      <type>state</type>\n" +
+                                      "      <tax_rate type=\"float\">0.065</tax_rate>\n" +
+                                      "      <tax_in_cents type=\"integer\">-52</tax_in_cents>\n" +
+                                      "    </tax_detail>\n" +
+                                      "  </tax_details>\n" +
                                       "  <start_date type=\"dateTime\">2011-08-31T03:30:00Z</start_date>\n" +
                                       "  <revenue_schedule_type>at_invoice</revenue_schedule_type>\n" +
                                       "  <end_date nil=\"nil\"></end_date>\n" +
@@ -68,6 +86,11 @@ public class TestAdjustment extends TestModelBase {
         Assert.assertEquals((int) adjustment.getTotalInCents(), 5000);
         Assert.assertEquals(adjustment.getCurrency(), "USD");
         Assert.assertEquals((boolean) adjustment.getTaxable(), false);
+        Assert.assertEquals(adjustment.getType(), "charge");
+        Assert.assertEquals(adjustment.getTaxType(), "usst");
+        Assert.assertEquals(adjustment.getTaxRegion(), "CA");
+        Assert.assertEquals(adjustment.getTaxCode(), "digital");
+        Assert.assertEquals(adjustment.getTaxDetails(), this.getTaxDetails());
         Assert.assertEquals(adjustment.getProductCode(), "product123");
         Assert.assertEquals(adjustment.getStartDate(), new DateTime("2011-08-31T03:30:00Z"));
         Assert.assertNull(adjustment.getEndDate());
@@ -92,5 +115,18 @@ public class TestAdjustment extends TestModelBase {
         Assert.assertEquals(readValue.getEndDate(), adjustment.getEndDate());
         Assert.assertEquals(readValue.getCreatedAt(), adjustment.getCreatedAt());
         Assert.assertEquals(readValue.getRevenueScheduleType(), adjustment.getRevenueScheduleType());
+    }
+
+    private List<TaxDetail> getTaxDetails() {
+        final List<TaxDetail> taxDetails = new ArrayList<TaxDetail>();
+        final TaxDetail taxDetail = new TaxDetail();
+
+        taxDetail.setName("Special Tax");
+        taxDetail.setType("state");
+        taxDetail.setTaxRate(BigDecimal.valueOf(0.065));
+        taxDetail.setTaxInCents(Integer.valueOf(-52));
+        taxDetails.add(taxDetail);
+
+        return taxDetails;
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -139,6 +139,8 @@ public class TestSubscription extends TestModelBase {
                                         "      <add_on_code>extra_users</add_on_code>\n" +
                                         "      <quantity>2</quantity>\n" +
                                         "      <unit_amount_in_cents>1000</unit_amount_in_cents>\n" +
+                                        "      <usage_percentage type=\"float\">2.1</usage_percentage>\n" +
+                                        "      <revenue_schedule_type>evenly</revenue_schedule_type>\n" +
                                         "    </subscription_add_on>\n" +
                                         "    <subscription_add_on>\n" +
                                         "      <add_on_code>extra_ip</add_on_code>\n" +
@@ -235,6 +237,8 @@ public class TestSubscription extends TestModelBase {
         Assert.assertEquals(subscription.getAddOns().get(0).getAddOnCode(), "extra_users");
         Assert.assertEquals(subscription.getAddOns().get(0).getQuantity(), (Integer) 2);
         Assert.assertEquals(subscription.getAddOns().get(0).getUnitAmountInCents(), (Integer) 1000);
+        Assert.assertEquals(subscription.getAddOns().get(0).getUsagePercentage(), BigDecimal.valueOf(2.1));
+        Assert.assertEquals(subscription.getAddOns().get(0).getRevenueScheduleType(), RevenueScheduleType.EVENLY);
         Assert.assertEquals(subscription.getAddOns().get(1).getAddOnCode(), "extra_ip");
         Assert.assertEquals(subscription.getAddOns().get(1).getQuantity(), (Integer) 3);
         Assert.assertEquals(subscription.getAddOns().get(1).getUnitAmountInCents(), (Integer) 200);


### PR DESCRIPTION
Fixes #338 and fixes #339 

There were some missing properties in the `AddOn`, `SubscriptionAddOn` and `Adjustment` classes. This PR adds those missing properties and adds them to the unit tests.