### PR TITLE
Add support for updating subscription at next bill date

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
@@ -30,7 +30,8 @@ public class SubscriptionUpdate extends AbstractSubscription {
 
     public static enum Timeframe {
         now,
-        renewal
+        renewal,
+        bill_date
     }
 
     @XmlElement


### PR DESCRIPTION
This adds support for updating the subscription at next bill date rather than just immediately or at renewal.

```java
final String uuid = "4c2a90c55cfe520e7f33744dc09ae922";
final SubscriptionUpdate subscriptionData = new SubscriptionUpdate();

subscriptionData.setTimeframe(SubscriptionUpdate.Timeframe.bill_date);
subscriptionData.setPlanCode("gold");

Subscription sub = client.updateSubscription(uuid, subscriptionData);
System.out.println(sub);
```