### PR TITLE
Add 3DS tokens to transaction error and billing info

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -124,6 +124,9 @@ public class BillingInfo extends RecurlyObject {
     @XmlElement(name = "amazon_region")
     private String amazonRegion;
 
+    @XmlElement(name = "three_d_secure_action_result_token_id")
+    private String threeDSecureActionResultTokenId;
+
     public String getType() {
         return type;
     }
@@ -387,6 +390,14 @@ public class BillingInfo extends RecurlyObject {
         this.amazonRegion = stringOrNull(amazonRegion);
     }
 
+    public String getThreeDSecureActionResultTokenId() {
+        return threeDSecureActionResultTokenId;
+    }
+
+    public void setThreeDSecureActionResultTokenId(final Object threeDSecureActionResultTokenId) {
+        this.threeDSecureActionResultTokenId = stringOrNull(threeDSecureActionResultTokenId);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -427,6 +438,7 @@ public class BillingInfo extends RecurlyObject {
         sb.append(", gatewayCode='").append(gatewayCode).append('\'');
         sb.append(", amazonBillingAgreementId='").append(amazonBillingAgreementId).append('\'');
         sb.append(", amazonRegion='").append(amazonRegion).append('\'');
+        sb.append(", threeDSecureActionResultTokenId='").append(threeDSecureActionResultTokenId).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -519,6 +531,9 @@ public class BillingInfo extends RecurlyObject {
         if (amazonRegion != null ? !amazonRegion.equals(that.amazonRegion) : that.amazonRegion != null) {
             return false;
         }
+        if (threeDSecureActionResultTokenId != null ? !threeDSecureActionResultTokenId.equals(that.threeDSecureActionResultTokenId) : that.threeDSecureActionResultTokenId != null) {
+            return false;
+        }
 
         return true;
     }
@@ -552,7 +567,8 @@ public class BillingInfo extends RecurlyObject {
                 gatewayToken,
                 gatewayCode,
                 amazonBillingAgreementId,
-                amazonRegion
+                amazonRegion,
+                threeDSecureActionResultTokenId
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/TransactionError.java
+++ b/src/main/java/com/ning/billing/recurly/model/TransactionError.java
@@ -40,6 +40,9 @@ public class TransactionError extends RecurlyObject {
     @XmlElement(name = "gateway_error_code")
     private String gatewayErrorCode;
 
+    @XmlElement(name = "three_d_secure_action_token_id")
+    private String threeDSecureActionTokenId;
+
     public String getErrorCode() {
         return errorCode;
     }
@@ -80,6 +83,14 @@ public class TransactionError extends RecurlyObject {
         this.gatewayErrorCode = stringOrNull(gatewayErrorCode);
     }
 
+    public String getThreeDSecureActionTokenId() {
+        return threeDSecureActionTokenId;
+    }
+
+    public void setThreeDSecureActionTokenId(final Object threeDSecureActionTokenId) {
+        this.threeDSecureActionTokenId = stringOrNull(threeDSecureActionTokenId);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -95,12 +106,14 @@ public class TransactionError extends RecurlyObject {
             return false;
         if (customerMessage != null ? !customerMessage.equals(that.customerMessage) : that.customerMessage != null)
             return false;
+        if (threeDSecureActionTokenId != null ? !threeDSecureActionTokenId.equals(that.threeDSecureActionTokenId) : that.threeDSecureActionTokenId != null)
+            return false;
         return gatewayErrorCode != null ? gatewayErrorCode.equals(that.gatewayErrorCode) : that.gatewayErrorCode == null;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(errorCode, errorCategory, merchantMessage, customerMessage, gatewayErrorCode);
+        return Objects.hashCode(errorCode, errorCategory, merchantMessage, customerMessage, gatewayErrorCode, threeDSecureActionTokenId);
     }
 
     @Override
@@ -111,6 +124,7 @@ public class TransactionError extends RecurlyObject {
                 ", merchantMessage='" + merchantMessage + '\'' +
                 ", customerMessage='" + customerMessage + '\'' +
                 ", gatewayErrorCode='" + gatewayErrorCode + '\'' +
+                ", threeDSecureActionTokenId='" + threeDSecureActionTokenId + '\'' +
                 '}';
     }
 


### PR DESCRIPTION
This allows the client to use the new 3DSecure features of the API. This involves a 2 step flow with RecurlyJS, see https://github.com/recurly/recurly-js/pull/527 for technical details on that side of this process.

Script 1: Attempt to update a billing info with a credit card that requires 3DS authentication:
```java
try {
    client.open();

    final BillingInfo billingInfo = new BillingInfo();

    billingInfo.setFirstName("John");
    billingInfo.setLastName("Smith");
    billingInfo.setAddress1("125 Paper Street");
    billingInfo.setCity("Los Angeles");
    billingInfo.setState("CA");
    billingInfo.setZip("95312");
    billingInfo.setCountry("US");
    billingInfo.setPhone("213-555-5555");
    billingInfo.setNumber("4000000000003220");
    billingInfo.setMonth(12);
    billingInfo.setYear(20);
    billingInfo.setThreeDSecureActionResultTokenId("Xk6cVz7eistL-9o_UdWczA");

    client.createOrUpdateBillingInfo("f", billingInfo);
} catch (TransactionErrorException e) {
    String actionTokenId = e.getErrors().getTransactionError().getThreeDSecureActionTokenId();
    System.out.println(actionTokenId); // Pass the 3DS Action Token ID into RJS
} catch (Exception e) {
    e.printStackTrace();
} finally {
    client.close();
}
```

The `TransactionErrorException`'s `TransactionError` will contain a `threeDSecureActionTokenId` which you can get with `getThreeDSecureActionTokenId()`. This value needs to be passed to RJS for authentication. Upon successful authentication, RJS will return a result token, which can then be passed with the billing info.

Script 2: Update the billing info using 3DS:
```java
try {
    client.open();

    final BillingInfo billingInfo = new BillingInfo();

    billingInfo.setFirstName("John");
    billingInfo.setLastName("Smith");
    billingInfo.setAddress1("125 Paper Street");
    billingInfo.setCity("Los Angeles");
    billingInfo.setState("CA");
    billingInfo.setZip("95312");
    billingInfo.setCountry("US");
    billingInfo.setPhone("213-555-5555");
    billingInfo.setNumber("4000000000003220");
    billingInfo.setMonth(12);
    billingInfo.setYear(20);

    // Set 3DS Result Token ID from RecurlyJS
    billingInfo.setThreeDSecureActionResultTokenId("Xk6cVz7eistL-9o_UdWczA");

    client.createOrUpdateBillingInfo("f", billingInfo);
} catch (Exception e) {
    e.printStackTrace();
} finally {
    client.close();
}
```

This flow still applies when passing a `BillingInfo` object to the `/accounts`, `/subscriptions`, and `/purchases` endpoints.