### PR TITLE
Bump to API version 2.21

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -111,7 +111,7 @@ public class RecurlyClient {
     private static final Logger log = LoggerFactory.getLogger(RecurlyClient.class);
 
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
-    public static final String RECURLY_API_VERSION = "2.20";
+    public static final String RECURLY_API_VERSION = "2.21";
 
     private static final String X_RATELIMIT_REMAINING_HEADER_NAME = "X-RateLimit-Remaining";
     private static final String X_RECORDS_HEADER_NAME = "X-Records";

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -124,6 +124,9 @@ public class BillingInfo extends RecurlyObject {
     @XmlElement(name = "amazon_region")
     private String amazonRegion;
 
+    @XmlElement(name = "three_d_secure_action_result_token_id")
+    private String threeDSecureActionResultTokenId;
+
     public String getType() {
         return type;
     }
@@ -387,6 +390,14 @@ public class BillingInfo extends RecurlyObject {
         this.amazonRegion = stringOrNull(amazonRegion);
     }
 
+    public String getThreeDSecureActionResultTokenId() {
+        return threeDSecureActionResultTokenId;
+    }
+
+    public void setThreeDSecureActionResultTokenId(final Object threeDSecureActionResultTokenId) {
+        this.threeDSecureActionResultTokenId = stringOrNull(threeDSecureActionResultTokenId);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -427,6 +438,7 @@ public class BillingInfo extends RecurlyObject {
         sb.append(", gatewayCode='").append(gatewayCode).append('\'');
         sb.append(", amazonBillingAgreementId='").append(amazonBillingAgreementId).append('\'');
         sb.append(", amazonRegion='").append(amazonRegion).append('\'');
+        sb.append(", threeDSecureActionResultTokenId='").append(threeDSecureActionResultTokenId).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -519,6 +531,9 @@ public class BillingInfo extends RecurlyObject {
         if (amazonRegion != null ? !amazonRegion.equals(that.amazonRegion) : that.amazonRegion != null) {
             return false;
         }
+        if (threeDSecureActionResultTokenId != null ? !threeDSecureActionResultTokenId.equals(that.threeDSecureActionResultTokenId) : that.threeDSecureActionResultTokenId != null) {
+            return false;
+        }
 
         return true;
     }
@@ -552,7 +567,8 @@ public class BillingInfo extends RecurlyObject {
                 gatewayToken,
                 gatewayCode,
                 amazonBillingAgreementId,
-                amazonRegion
+                amazonRegion,
+                threeDSecureActionResultTokenId
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/TransactionError.java
+++ b/src/main/java/com/ning/billing/recurly/model/TransactionError.java
@@ -40,6 +40,9 @@ public class TransactionError extends RecurlyObject {
     @XmlElement(name = "gateway_error_code")
     private String gatewayErrorCode;
 
+    @XmlElement(name = "three_d_secure_action_token_id")
+    private String threeDSecureActionTokenId;
+
     public String getErrorCode() {
         return errorCode;
     }
@@ -80,6 +83,14 @@ public class TransactionError extends RecurlyObject {
         this.gatewayErrorCode = stringOrNull(gatewayErrorCode);
     }
 
+    public String getThreeDSecureActionTokenId() {
+        return threeDSecureActionTokenId;
+    }
+
+    public void setThreeDSecureActionTokenId(final Object threeDSecureActionTokenId) {
+        this.threeDSecureActionTokenId = stringOrNull(threeDSecureActionTokenId);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -95,12 +106,14 @@ public class TransactionError extends RecurlyObject {
             return false;
         if (customerMessage != null ? !customerMessage.equals(that.customerMessage) : that.customerMessage != null)
             return false;
+        if (threeDSecureActionTokenId != null ? !threeDSecureActionTokenId.equals(that.threeDSecureActionTokenId) : that.threeDSecureActionTokenId != null)
+            return false;
         return gatewayErrorCode != null ? gatewayErrorCode.equals(that.gatewayErrorCode) : that.gatewayErrorCode == null;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(errorCode, errorCategory, merchantMessage, customerMessage, gatewayErrorCode);
+        return Objects.hashCode(errorCode, errorCategory, merchantMessage, customerMessage, gatewayErrorCode, threeDSecureActionTokenId);
     }
 
     @Override
@@ -111,6 +124,7 @@ public class TransactionError extends RecurlyObject {
                 ", merchantMessage='" + merchantMessage + '\'' +
                 ", customerMessage='" + customerMessage + '\'' +
                 ", gatewayErrorCode='" + gatewayErrorCode + '\'' +
+                ", threeDSecureActionTokenId='" + threeDSecureActionTokenId + '\'' +
                 '}';
     }
 


### PR DESCRIPTION
This will bring us up to API version 2.21. There are no breaking changes.

* Adds support for 3DS authentication #346

Note: This API version corrects the error of an invalid Recurly.js token sent to `v2/accounts/:account_code/billing_info` from a `404 Not Found` to a `422 Unprocessable Entity`