### PR TITLE
Fix multiple coupon codes

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -17,14 +17,15 @@
 
 package com.ning.billing.recurly.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Objects;
 import org.joda.time.DateTime;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlList;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 @XmlRootElement(name = "subscription")
@@ -99,11 +100,11 @@ public class Subscription extends AbstractSubscription {
     @XmlElement(name = "net_terms")
     private Integer netTerms;
 
-    @XmlElement(name = "coupon_code")
+    @JsonIgnore
     private String couponCode;
 
-    @XmlList
     @XmlElementWrapper(name = "coupon_codes")
+    @XmlElement(name = "coupon_code")
     private List<String> couponCodes;
 
     //Purchase Order Number
@@ -398,6 +399,8 @@ public class Subscription extends AbstractSubscription {
 
     public void setCouponCode(final String couponCode) {
         this.couponCode = couponCode;
+        if (this.couponCodes == null) this.couponCodes = new ArrayList<String>();
+        this.couponCodes.add(couponCode);
     }
 
     public void setCouponCodes(final List<String> couponCodes) {

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -19,6 +19,7 @@ package com.ning.billing.recurly.model;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 
 import com.ning.billing.recurly.TestUtils;
 import org.joda.time.DateTime;
@@ -27,6 +28,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestSubscription extends TestModelBase {
 
@@ -92,6 +94,11 @@ public class TestSubscription extends TestModelBase {
         verifyPaginationData(subscription);
         verifyPendingSubscription(subscription);
         Assert.assertEquals(subscription.getAddOns().size(), 0);
+
+        ArrayList<String> codes = new ArrayList<String>();
+        codes.add("123");
+        codes.add("abc");
+        assertEquals(subscription.getCouponCodes(), codes);
     }
 
     @Test(groups = "fast")
@@ -219,6 +226,31 @@ public class TestSubscription extends TestModelBase {
         final String subscriptionDataSerialized = xmlMapper.writeValueAsString(subscription);
         final Subscription subscription2 = verifySubscription(subscriptionDataSerialized);
         verifySubscriptionCustomFields(subscription2);
+    }
+
+    @Test(groups = "fast")
+    public void testSerializationWithSingleCoupon() throws Exception {
+        Subscription subscription = TestUtils.createRandomSubscription(0);
+        subscription.setCouponCode("my-coupon");
+        String xmlString = xmlMapper.writeValueAsString(subscription);
+        assertTrue(xmlString.contains("<coupon_codes><coupon_code>my-coupon</coupon_code></coupon_codes>"));
+    }
+
+    @Test(groups = "fast")
+    public void testSerializationWithMultipleCoupon() throws Exception {
+        Subscription subscription = TestUtils.createRandomSubscription(0);
+        ArrayList<String> codes = new ArrayList<String>();
+        codes.add("my-first-coupon");
+        subscription.setCouponCodes(codes);
+        String xmlString = xmlMapper.writeValueAsString(subscription);
+        String xmlSubstring = "<coupon_codes><coupon_code>my-first-coupon</coupon_code></coupon_codes>";
+        assertTrue(xmlString.contains(xmlSubstring));
+
+        codes.add("my-second-coupon");
+        subscription.setCouponCodes(codes);
+        xmlSubstring = "<coupon_codes><coupon_code>my-first-coupon</coupon_code><coupon_code>my-second-coupon</coupon_code></coupon_codes>";
+        xmlString = xmlMapper.writeValueAsString(subscription);
+        assertTrue(xmlString.contains(xmlSubstring));
     }
 
     @Test(groups = "fast")


### PR DESCRIPTION
Fixes #349 

The root cause of the problem described in #349 is as follows:

The Recurly v2 API Create Subscription and Preview Subscription endpoints accept both a single coupon code, e.g.
```xml
<coupon_code>my-coupon</coupon_code>
```
and multiple coupon codes, e.g.
```xml
<coupon_codes>
  <coupon_code>my-coupon</coupon_code>
  <coupon_code>my-other-coupon</coupon_code>
<coupon_codes>
```

As such, there are two fields in the `Subscription` class:
```java
private String couponCode;
```
and
```java
private List<String> couponCodes;
```

FasterXML Jackson only allows for one field to be associated with the tag `<coupon_code>` as documented by this issue https://github.com/FasterXML/jackson-dataformat-xml/issues/192

This PR gets around this limitation by having Jackson ignore the field `couponCode` and when the programmer uses `setCouponCode()`, adding that as the first element of the list for `couponCodes`. It should be noted that both of the following are accepted by the Recurly API Subscription endpoints as equivalent:
```xml
<coupon_code>my-coupon</coupon_code>
```
```xml
<coupon_codes>
  <coupon_code>my-coupon</coupon_code>
<coupon_codes>
```

It's kind of gross to have to do it this way, but I could not find another suitable workaround with this limitation of Jackson.