### PR TITLE
Add method for reopening a closed account

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -353,6 +353,19 @@ public class RecurlyClient {
     }
 
     /**
+     * Reopen Account
+     * <p>
+     * Transitions a closed account back to active.
+     *
+     * @param accountCode recurly account id
+     */
+    public Account reopenAccount(final String accountCode) {
+        return doPUT(Account.ACCOUNT_RESOURCE + "/" + accountCode + "/reopen",
+                     null, Account.class);
+    }
+
+
+    /**
      * Get Child Accounts
      * <p>
      * Returns information about a the child accounts of an account.

--- a/src/main/java/com/ning/billing/recurly/model/Account.java
+++ b/src/main/java/com/ning/billing/recurly/model/Account.java
@@ -100,6 +100,9 @@ public class Account extends RecurlyObject {
     @XmlElement(name = "updated_at")
     private DateTime updatedAt;
 
+    @XmlElement(name = "closed_at")
+    private DateTime closedAt;
+
     @XmlElement(name = "billing_info")
     private BillingInfo billingInfo;
 
@@ -306,6 +309,14 @@ public class Account extends RecurlyObject {
         this.updatedAt = dateTimeOrNull(updatedAt);
     }
 
+    public DateTime getClosedAt() {
+        return closedAt;
+    }
+
+    public void setClosedAt(final Object closedAt) {
+        this.closedAt = dateTimeOrNull(closedAt);
+    }
+
     public BillingInfo getBillingInfo() {
         return billingInfo;
     }
@@ -428,7 +439,7 @@ public class Account extends RecurlyObject {
         sb.append(", subscriptions=").append(subscriptions);
         sb.append(", transactions=").append(transactions);
         sb.append(", accountCode='").append(accountCode).append('\'');
-        sb.append(", parent_account_code='").append(parentAccountCode).append('\'');
+        sb.append(", parentAccountCode='").append(parentAccountCode).append('\'');
         sb.append(", state='").append(state).append('\'');
         sb.append(", username='").append(username).append('\'');
         sb.append(", email='").append(email).append('\'');
@@ -440,6 +451,7 @@ public class Account extends RecurlyObject {
         sb.append(", hostedLoginToken='").append(hostedLoginToken).append('\'');
         sb.append(", createdAt=").append(createdAt);
         sb.append(", updatedAt=").append(updatedAt);
+        sb.append(", closedAt=").append(closedAt);
         sb.append(", billingInfo=").append(billingInfo);
         sb.append(", taxExempt=").append(taxExempt);
         sb.append(", exemptionCertificate='").append(exemptionCertificate).append('\'');
@@ -484,6 +496,9 @@ public class Account extends RecurlyObject {
             return false;
         }
         if (billingInfo != null ? !billingInfo.equals(account.billingInfo) : account.billingInfo != null) {
+            return false;
+        }
+        if (closedAt != null ? closedAt.compareTo(account.closedAt) != 0 : account.closedAt != null) {
             return false;
         }
         if (this.getCompanyName() != null ? !this.getCompanyName().equals(account.getCompanyName()) : account.getCompanyName() != null) {
@@ -600,7 +615,8 @@ public class Account extends RecurlyObject {
                 customFields,
                 vatNumber,
                 accountAcquisition,
-                preferredLocale
+                preferredLocale,
+                closedAt
         );
     }
 }

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -152,6 +152,33 @@ public class TestRecurlyClient {
     }
 
     @Test(groups = "integration")
+    public void testReopenAccount() throws Exception {
+        final Account accountData = TestUtils.createRandomAccount();
+
+        try {
+            // Create account
+            final Account newAccount = recurlyClient.createAccount(accountData);
+            Assert.assertNull(newAccount.getClosedAt());
+
+            // Close the account
+            recurlyClient.closeAccount(accountData.getAccountCode());
+            final Account closedAccount = recurlyClient.getAccount(accountData.getAccountCode());
+            Assert.assertNotNull(closedAccount.getClosedAt());
+
+            // Reopen the account
+            final Account reopenedAccount = recurlyClient.reopenAccount(accountData.getAccountCode());
+
+            // Confirm that the reopened account is the same as the original
+            // (besides `updated_at`, which may differ)
+            newAccount.setUpdatedAt(reopenedAccount.getUpdatedAt());
+            Assert.assertEquals(reopenedAccount, newAccount);
+        } finally {
+            // Close the account
+            recurlyClient.closeAccount(accountData.getAccountCode());
+        }
+    }
+
+    @Test(groups = "integration")
     public void testGetBillingInfo() throws Exception {
         final Account accountData = TestUtils.createRandomAccount();
         final BillingInfo billingInfoData = TestUtils.createRandomBillingInfo();


### PR DESCRIPTION
Also adds the `closed_at` field from the XML to the Account object,
and fixes up some inconsistencies (underscores instead of camelcase)
in the `toString` implementation.