### PR TITLE
[WIP] Add term_end timeframe value

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
@@ -31,7 +31,8 @@ public class SubscriptionUpdate extends AbstractSubscription {
     public static enum Timeframe {
         now,
         renewal,
-        bill_date
+        bill_date,
+        term_end
     }
 
     @XmlElement

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
@@ -27,7 +27,7 @@ public class TestSubscriptionUpdate extends TestModelBase {
         // See https://dev.recurly.com/docs/list-subscriptions
         final String subscriptionData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                         "<subscription>\n" +
-                                        "  <timeframe>now</timeframe>\n" +
+                                        "  <timeframe>term_end</timeframe>\n" +
                                         "  <plan_code>gold</plan_code>\n" +
                                         "  <unit_amount_in_cents type=\"integer\">800</unit_amount_in_cents>\n" +
                                         "  <quantity type=\"integer\">1</quantity>\n" +
@@ -36,7 +36,7 @@ public class TestSubscriptionUpdate extends TestModelBase {
                                         "</subscription>";
 
         final SubscriptionUpdate subscription = xmlMapper.readValue(subscriptionData, SubscriptionUpdate.class);
-        Assert.assertEquals(subscription.getTimeframe(), SubscriptionUpdate.Timeframe.now);
+        Assert.assertEquals(subscription.getTimeframe(), SubscriptionUpdate.Timeframe.term_end);
         Assert.assertEquals(subscription.getPlanCode(), "gold");
         Assert.assertEquals(subscription.getUnitAmountInCents(), (Integer) 800);
         Assert.assertEquals(subscription.getQuantity(), (Integer) 1);


### PR DESCRIPTION
WIP: i've broken something around url building.

Adds term_end to the Timeframe values. This affects updateSubscription
and cancelSubscription.

updateSubscription has been updated to no longer include the "renewal" timeframe.
Instead, merchants will be able to send timeframes of "bill_date" or "term_end".
These timeframes are aligned to "current_period_ends_at" and "current_term_ends_at", respectively.

cancelSubscription has been updated to accept the "timeframe" parameter. They accept values of "bill_date" or "term_end".