### PR TITLE
MOTO transactions

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -1327,6 +1327,18 @@ public class RecurlyClient {
     }
 
     /**
+     * Force collect an invoice
+     *
+     * @param transactionType String The gateway transaction type. Currency accepts value "moto".
+     * @param invoiceId String Recurly Invoice ID
+     */
+    public Invoice forceCollectInvoice(final String invoiceId, final String transactionType) {
+        Invoice request = new Invoice();
+        request.setTransactionType(transactionType);
+        return doPUT(Invoices.INVOICES_RESOURCE + "/" + invoiceId + "/collect", request, Invoice.class);
+    }
+
+    /**
      * Void Invoice
      *
      * @param invoiceId String Recurly Invoice ID

--- a/src/main/java/com/ning/billing/recurly/model/Account.java
+++ b/src/main/java/com/ning/billing/recurly/model/Account.java
@@ -147,6 +147,9 @@ public class Account extends RecurlyObject {
     @XmlElement(name = "preferred_locale")
     private String preferredLocale;
 
+    @XmlElement(name = "transaction_type")
+    private String transactionType;
+
     @Override
     public void setHref(final Object href) {
         super.setHref(href);
@@ -429,6 +432,14 @@ public class Account extends RecurlyObject {
         this.preferredLocale = stringOrNull(preferredLocale);
     }
 
+    public String getTransactionType() {
+        return transactionType;
+    }
+
+    public void setTransactionType(final Object transactionType) {
+        this.transactionType = stringOrNull(transactionType);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("Account{");
@@ -466,6 +477,7 @@ public class Account extends RecurlyObject {
         sb.append(", vatNumber=").append(vatNumber);
         sb.append(", accountAcquisition=").append(accountAcquisition);
         sb.append(", preferredLocale=").append(preferredLocale);
+        sb.append(", transactionType='").append(transactionType).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -576,6 +588,9 @@ public class Account extends RecurlyObject {
         if (vatNumber != null ? !vatNumber.equals(account.vatNumber) : account.vatNumber != null) {
             return false;
         }
+        if (transactionType != null ? !transactionType.equals(account.transactionType) : account.transactionType != null) {
+            return false;
+        }
 
         return true;
     }
@@ -616,7 +631,8 @@ public class Account extends RecurlyObject {
                 vatNumber,
                 accountAcquisition,
                 preferredLocale,
-                closedAt
+                closedAt,
+                transactionType
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -127,6 +127,9 @@ public class BillingInfo extends RecurlyObject {
     @XmlElement(name = "three_d_secure_action_result_token_id")
     private String threeDSecureActionResultTokenId;
 
+    @XmlElement(name = "transaction_type")
+    private String transactionType;
+
     public String getType() {
         return type;
     }
@@ -398,6 +401,14 @@ public class BillingInfo extends RecurlyObject {
         this.threeDSecureActionResultTokenId = stringOrNull(threeDSecureActionResultTokenId);
     }
 
+    public String getTransactionType() {
+        return transactionType;
+    }
+
+    public void setTransactionType(final Object transactionType) {
+        this.transactionType = stringOrNull(transactionType);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -534,6 +545,9 @@ public class BillingInfo extends RecurlyObject {
         if (threeDSecureActionResultTokenId != null ? !threeDSecureActionResultTokenId.equals(that.threeDSecureActionResultTokenId) : that.threeDSecureActionResultTokenId != null) {
             return false;
         }
+        if (transactionType != null ? !transactionType.equals(that.transactionType) : that.transactionType != null) {
+            return false;
+        }
 
         return true;
     }
@@ -568,7 +582,8 @@ public class BillingInfo extends RecurlyObject {
                 gatewayCode,
                 amazonBillingAgreementId,
                 amazonRegion,
-                threeDSecureActionResultTokenId
+                threeDSecureActionResultTokenId,
+                transactionType
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -147,6 +147,9 @@ public class Invoice extends RecurlyObject {
     @XmlElement(name = "surcharge_in_cents")
     private Integer surchargeInCents;
 
+    @XmlElement(name = "transaction_type")
+    private String transactionType;
+
     public Account getAccount() {
         if (account != null && account.getCreatedAt() == null) {
             account = fetch(account, Account.class);
@@ -485,6 +488,14 @@ public class Invoice extends RecurlyObject {
         this.surchargeInCents = integerOrNull(surchargeInCents);
     }
 
+    public String getTransactionType() {
+        return transactionType;
+    }
+
+    public void setTransactionType(final Object transactionType) {
+        this.transactionType = stringOrNull(transactionType);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("Invoice{");
@@ -652,6 +663,9 @@ public class Invoice extends RecurlyObject {
         if (gatewayCode != null ? !gatewayCode.equals(invoice.gatewayCode) : invoice.gatewayCode != null) {
             return false;
         }
+        if (transactionType != null ? !transactionType.equals(invoice.transactionType) : invoice.transactionType != null) {
+            return false;
+        }
 
         return true;
     }
@@ -696,7 +710,8 @@ public class Invoice extends RecurlyObject {
                 origin,
                 address,
                 shippingAddress,
-                surchargeInCents
+                surchargeInCents,
+                transactionType
         );
     }
 

--- a/src/main/java/com/ning/billing/recurly/model/Purchase.java
+++ b/src/main/java/com/ning/billing/recurly/model/Purchase.java
@@ -76,6 +76,9 @@ public class Purchase extends RecurlyObject {
     @XmlElement(name = "gateway_code")
     private String gatewayCode;
 
+    @XmlElement(name = "transaction_type")
+    private String transactionType;
+
     @XmlList
     @XmlElementWrapper(name = "coupon_codes")
     @XmlElement(name = "coupon_code")
@@ -201,6 +204,14 @@ public class Purchase extends RecurlyObject {
         this.gatewayCode = stringOrNull(gatewayCode);
     }
 
+    public String getTransactionType() {
+        return transactionType;
+    }
+
+    public void setTransactionType(final Object transactionType) {
+        this.transactionType = stringOrNull(transactionType);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -220,6 +231,7 @@ public class Purchase extends RecurlyObject {
         sb.append(", vatReverseChargeNotes='").append(vatReverseChargeNotes).append('\'');
         sb.append(", shippingAddressId='").append(shippingAddressId).append('\'');
         sb.append(", gatewayCode='").append(gatewayCode).append('\'');
+        sb.append(", transactionType='").append(transactionType).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -273,6 +285,9 @@ public class Purchase extends RecurlyObject {
         if (termsAndConditions != null ? !termsAndConditions.equals(purchase.termsAndConditions) : purchase.termsAndConditions != null) {
             return false;
         }
+        if (transactionType != null ? !transactionType.equals(purchase.transactionType) : purchase.transactionType != null) {
+            return false;
+        }
         if (vatReverseChargeNotes != null ? !vatReverseChargeNotes.equals(purchase.vatReverseChargeNotes) : purchase.vatReverseChargeNotes != null) {
             return false;
         }
@@ -297,7 +312,8 @@ public class Purchase extends RecurlyObject {
                 termsAndConditions,
                 vatReverseChargeNotes,
                 shippingAddressId,
-                gatewayCode
+                gatewayCode,
+                transactionType
         );
     }
 

--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -183,6 +183,9 @@ public class Subscription extends AbstractSubscription {
     @XmlElement(name = "current_term_ends_at")
     private DateTime currentTermEndsAt;
 
+    @XmlElement(name = "transaction_type")
+    private String transactionType;
+
     public Account getAccount() {
         if (account != null && account.getHref() != null && !account.getHref().isEmpty()) {
             account = fetch(account, Account.class);
@@ -580,6 +583,14 @@ public class Subscription extends AbstractSubscription {
         this.currentTermEndsAt = dateTimeOrNull(currentTermEndsAt);
     }
 
+    public String getTransactionType() {
+        return transactionType;
+    }
+
+    public void setTransactionType(final Object transactionType) {
+        this.transactionType = stringOrNull(transactionType);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -632,6 +643,7 @@ public class Subscription extends AbstractSubscription {
         sb.append(", nextBillDate=").append(nextBillDate);
         sb.append(", currentPeriodStartedAt=").append(currentPeriodStartedAt);
         sb.append(", currentPeriodEndsAt=").append(currentPeriodEndsAt);
+        sb.append(", transactionType='").append(transactionType).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -790,7 +802,9 @@ public class Subscription extends AbstractSubscription {
         if (currentPeriodEndsAt != null ? currentPeriodEndsAt.compareTo(that.currentPeriodEndsAt) != 0 : that.currentPeriodEndsAt != null) {
             return false;
         }
-
+        if (transactionType != null ? !transactionType.equals(that.transactionType) : that.transactionType != null) {
+            return false;
+        }
 
         return true;
     }
@@ -845,7 +859,8 @@ public class Subscription extends AbstractSubscription {
                 firstBillDate,
                 nextBillDate,
                 currentPeriodStartedAt,
-                currentPeriodEndsAt
+                currentPeriodEndsAt,
+                transactionType
         );
     }
 


### PR DESCRIPTION
As a part of PSD2, there is an exemption to exclude MOTO transactions from SCA scope.
In order to pass this indicator to the gateways, merchants need a mechanism via API
to inform Recurly of these transactions. These transactions will be initiated from
within a merchants customer service / support admin portal UI, where the customer
is not authenticated to be able to complete an SCA flow.

This is exposed to the programmer as transaction_type on many of the resources. Set the value to moto to mark the transaction as MOTO. Ex use with purchases:

```java
final Purchase purchaseData = new Purchase();
purchaseData.setCurrency("USD");
purchaseData.setTransactionType("moto");
purchaseData.setAccount(accountData);
purchaseData.setSubscriptions(subscriptionsData);
InvoiceCollection collection = recurlyClient.purchase(purchaseData);
```