### PR TITLE
Fix deserialization of 422 invalid token error

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -2315,8 +2315,13 @@ public class RecurlyClient {
                         return null;
                     }
 
-                    // Sometimes a single `Error` response is returned rather than `Errors`
-                    if (errors.getRecurlyErrors() == null && errors.getTransaction() == null && errors.getTransactionError() == null) {
+                    // Sometimes a single `Error` response is returned rather than `Errors`.
+                    // In this case, all fields will be null.
+                    if (errors == null || (
+                        errors.getRecurlyErrors() == null &&
+                        errors.getTransaction() == null &&
+                        errors.getTransactionError() == null
+                    )) {
                         recurlyError = RecurlyAPIError.buildFromXml(xmlMapper, payload, response);
                         throw new RecurlyAPIException(recurlyError);
                     }

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -2305,14 +2305,20 @@ public class RecurlyClient {
                 RecurlyAPIError recurlyError = RecurlyAPIError.buildFromResponse(response);
 
                 if (response.getStatusCode() == 422) {
+                    // 422 is returned for transaction errors (see https://dev.recurly.com/page/transaction-errors)
+                    // as well as bad input payloads
                     final Errors errors;
                     try {
                         errors = xmlMapper.readValue(payload, Errors.class);
                     } catch (Exception e) {
-                        // 422 is returned for transaction errors (see https://recurly.readme.io/v2.0/page/transaction-errors)
-                        // as well as bad input payloads
                         log.warn("Unable to extract error", e);
                         return null;
+                    }
+
+                    // Sometimes a single `Error` response is returned rather than `Errors`
+                    if (errors.getRecurlyErrors() == null && errors.getTransaction() == null && errors.getTransactionError() == null) {
+                        recurlyError = RecurlyAPIError.buildFromXml(xmlMapper, payload, response);
+                        throw new RecurlyAPIException(recurlyError);
                     }
                     throw new TransactionErrorException(errors);
                 } else if (response.getStatusCode() == 401) {


### PR DESCRIPTION
Sometimes 422 errors can return a single error rather than multiple (for
example, on invalid billing token). This changes the deserialization
logic to attempt reading the response as a single error if the original
attempt fails.

Fixes #354