### PR TITLE
Add URL encoding to URL path segments

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -2669,7 +2669,7 @@ public class RecurlyClient {
     private static String urlEncode(String s) {
         try {
             return URLEncoder.encode(s, Charsets.UTF_8.name())
-                    .replace("+", "%20").replace("*", "%2A").replace("%7E", "~");
+                    .replace("+", "%20").replace("*", "%2A");
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e); // should not happen
         }

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -2660,12 +2660,16 @@ public class RecurlyClient {
         return matcher.find() ? matcher.group(1) : null;
     }
 
+    /**
+     * RFC 3986 URL encoding
+     */
     private static String urlEncode(String s) {
-    	try {
-			return URLEncoder.encode(s, Charsets.UTF_8.name());
-		} catch (UnsupportedEncodingException e) {
-			throw new RuntimeException(e); // should not happen
-		}
+        try {
+            return URLEncoder.encode(s, Charsets.UTF_8.name())
+                    .replace("+", "%20").replace("*", "%2A").replace("%7E", "~");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e); // should not happen
+        }
     }
 
 }

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -2661,7 +2661,8 @@ public class RecurlyClient {
     }
 
     /**
-     * RFC 3986 URL encoding
+     * RFC 3986 URL encoding. The vanilla {@link URLEncoder} does not work since
+     * Recurly does not decode '+' back to ' '.
      */
     private static String urlEncode(String s) {
         try {

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -1228,7 +1228,7 @@ public class RecurlyClient {
      * @return the original invoices associated with this invoice on success. Throws RecurlyAPIError if not found
      */
     public Invoices getOriginalInvoices(final String invoiceId) {
-        return doGET(Invoices.INVOICES_RESOURCE + "/" + invoiceId + "/original_invoices",
+        return doGET(Invoices.INVOICES_RESOURCE + "/" + urlEncode(invoiceId) + "/original_invoices",
                     Invoices.class, new QueryParams());
     }
 
@@ -1923,7 +1923,7 @@ public class RecurlyClient {
      * @param redemptionUuid recurly coupon redemption uuid
      */
     public void deleteCouponRedemption(final String accountCode, final String redemptionUuid) {
-        doDELETE(Accounts.ACCOUNTS_RESOURCE + "/" + urlEncode(accountCode) + Redemption.REDEMPTIONS_RESOURCE + "/" + redemptionUuid);
+        doDELETE(Accounts.ACCOUNTS_RESOURCE + "/" + urlEncode(accountCode) + Redemption.REDEMPTIONS_RESOURCE + "/" + urlEncode(redemptionUuid));
     }
 
     /**

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -2663,7 +2663,7 @@ public class RecurlyClient {
     }
 
     /**
-     * RFC 3986 URL encoding. The vanilla {@link URLEncoder} does not work since
+     * (Not quite) RFC 3986 URL encoding. The vanilla {@link URLEncoder} does not work since
      * Recurly does not decode '+' back to ' '.
      */
     private static String urlEncode(String s) {

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -69,7 +69,6 @@ import com.ning.billing.recurly.model.MeasuredUnits;
 import com.ning.billing.recurly.model.AccountAcquisition;
 import com.ning.billing.recurly.model.ShippingMethod;
 import com.ning.billing.recurly.model.ShippingMethods;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.None;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
@@ -568,7 +567,7 @@ public class RecurlyClient {
     public Subscription convertTrialMoto(final String subscriptionUuid) {
         Subscription request = new Subscription();
         request.setTransactionType("moto");
-        return doPUT(Subscription.SUBSCRIPTION_RESOURCE + "/" + subscriptionUuid + "/convert_trial",
+        return doPUT(Subscription.SUBSCRIPTION_RESOURCE + "/" + urlEncode(subscriptionUuid) + "/convert_trial",
             request, Subscription.class);
     }
 
@@ -599,7 +598,7 @@ public class RecurlyClient {
             account.setBillingInfo(billingInfo);
             request.setAccount(account);   
         }
-        return doPUT(Subscription.SUBSCRIPTION_RESOURCE + "/" + subscriptionUuid + "/convert_trial",
+        return doPUT(Subscription.SUBSCRIPTION_RESOURCE + "/" + urlEncode(subscriptionUuid) + "/convert_trial",
             request, Subscription.class);
     }
 


### PR DESCRIPTION
I've run into an issue using this library where account codes with spaces and special characters wouldn't work. And the apparent cause was that URL path segments are not getting URL encoded. So I went ahead and added URL encoding to all the path segments. The behavior should not change for Strings without special characters.