### PR TITLE
Enable item-backed add-ons

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/AddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/AddOn.java
@@ -33,6 +33,9 @@ public class AddOn extends AbstractAddOn {
     @XmlElement(name = "name")
     private String name;
 
+    @XmlElement(name = "item_code")
+    private String itemCode;
+
     @XmlElement(name = "display_quantity_on_hosted_page")
     private Boolean displayQuantityOnHostedPage;
 
@@ -71,6 +74,14 @@ public class AddOn extends AbstractAddOn {
         this.name = stringOrNull(name);
     }
 
+    public String getItemCode() {
+        return itemCode;
+    }
+
+    public void setItemCode(final Object itemCode) {
+        this.itemCode = stringOrNull(itemCode);
+    }
+
     public Boolean getDisplayQuantityOnHostedPage() {
         return displayQuantityOnHostedPage;
     }
@@ -91,8 +102,8 @@ public class AddOn extends AbstractAddOn {
         return unitAmountInCents;
     }
 
-    public void setUnitAmountInCents(final RecurlyUnitCurrency unitAmountInCents) {
-        this.unitAmountInCents = unitAmountInCents;
+    public void setUnitAmountInCents(final Object unitAmountInCents) {
+        this.unitAmountInCents = RecurlyUnitCurrency.build(unitAmountInCents);
     }
 
     public DateTime getCreatedAt() {
@@ -158,6 +169,7 @@ public class AddOn extends AbstractAddOn {
     public String toString() {
         final StringBuilder sb = new StringBuilder("AddOn{");
         sb.append("name='").append(name).append('\'');
+        sb.append(", itemCode='").append(itemCode).append('\'');
         sb.append(", measuredUnit='").append(measuredUnit).append('\'');
         sb.append(", addOnType='").append(addOnType).append('\'');
         sb.append(", displayQuantityOnHostedPage=").append(displayQuantityOnHostedPage);
@@ -212,6 +224,9 @@ public class AddOn extends AbstractAddOn {
         if (optional != null ? !optional.equals(addOn.optional) : addOn.optional != null) {
             return false;
         }
+        if (itemCode != null ? !itemCode.equals(addOn.itemCode) : addOn.itemCode != null) {
+            return false;
+        }
 
         return true;
     }
@@ -220,6 +235,7 @@ public class AddOn extends AbstractAddOn {
     public int hashCode() {
         return Objects.hashCode(
                 name,
+                itemCode,
                 measuredUnit,
                 addOnType,
                 displayQuantityOnHostedPage,

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -734,6 +734,21 @@ public class TestUtils {
     }
 
     /**
+     * Creates a random item-backed {@link AddOn} for use in Tests given a seed.
+     *
+     * @param seed The RNG seed
+     * @return The random {@link AddOn}
+     */
+    public static AddOn createRandomItemBackedAddOn(final int seed) {
+        final AddOn addOn = new AddOn();
+
+        addOn.setItemCode(randomAlphaNumericString(10, seed));
+        addOn.setUnitAmountInCents(createRandomPrice());
+
+        return addOn;
+    }
+
+    /**
      * Creates a random {@link SubscriptionAddOn} for use in Tests.
      *
      * @param addOnCode AddOn code

--- a/src/test/java/com/ning/billing/recurly/model/TestItemBackedAddOns.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestItemBackedAddOns.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.ning.billing.recurly.TestUtils;
+import org.joda.time.DateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+public class TestItemBackedAddOns extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        // See https://dev.recurly.com/docs/list-add-ons-for-a-plan
+        final String addOnsData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                  "<add_ons type=\"array\">\n" +
+                                  "   <add_on href=\"https://your-subdomain.recurly.com/v2/plans/bluekitsch/add_ons/health_everyday\">\n" +
+                                  "     <plan href=\"https://your-subdomain.recurly.com/v2/plans/bluekitsch\"/>\n" +
+                                  "     <external_sku></external_sku>\n" +
+                                  "     <item href=\"https://your-subdomain.recurly.com/v2/items/health_everyday\"/>\n" +
+                                  "     <item_state>active</item_state>\n" +
+                                  "     <add_on_code>health_everyday</add_on_code>\n" +
+                                  "     <name>Health Everyday</name>\n" +
+                                  "     <default_quantity type=\"integer\">1</default_quantity>\n" +
+                                  "     <display_quantity_on_hosted_page type=\"boolean\">false</display_quantity_on_hosted_page>\n" +
+                                  "     <unit_amount_in_cents>\n" +
+                                  "       <USD type=\"integer\">10</USD>\n" +
+                                  "     </unit_amount_in_cents>\n" +
+                                  "     <accounting_code nil=\"nil\"></accounting_code>\n" +
+                                  "     <add_on_type>fixed</add_on_type>\n" +
+                                  "     <optional type=\"boolean\">true</optional>\n" +
+                                  "     <revenue_schedule_type>never</revenue_schedule_type>\n" +
+                                  "     <created_at type=\"datetime\">2020-03-11T15:32:55Z</created_at>\n" +
+                                  "     <updated_at type=\"datetime\">2020-03-11T15:32:55Z</updated_at>\n" +
+                                  "   </add_on>\n" +
+                                  "</add_ons>";
+
+        final AddOns addOns = xmlMapper.readValue(addOnsData, AddOns.class);
+        verifyAddOns(addOns);
+
+        // Verify serialization
+        final String addOnsSerialized = xmlMapper.writeValueAsString(addOns);
+        final AddOns addOns2 = xmlMapper.readValue(addOnsSerialized, AddOns.class);
+        verifyAddOns(addOns2);
+    }
+
+    @Test(groups = "fast")
+    public void testHashCodeAndEquality() throws Exception {
+        // create AddOns of the same value but difference references
+        AddOn addOn = TestUtils.createRandomItemBackedAddOn(0);
+        AddOn otherAddOn = TestUtils.createRandomItemBackedAddOn(0);
+
+        assertNotEquals(System.identityHashCode(addOn), System.identityHashCode(otherAddOn));
+        assertEquals(addOn.hashCode(), otherAddOn.hashCode());
+        assertEquals(addOn, otherAddOn);
+    }
+
+    private void verifyAddOns(final AddOns addOns) {
+        Assert.assertEquals(addOns.size(), 1);
+
+        final AddOn addOn = addOns.get(0);
+        Assert.assertEquals(addOn.getAddOnCode(), "health_everyday");
+        Assert.assertEquals(addOn.getName(), "Health Everyday");
+        Assert.assertEquals((int) addOn.getUnitAmountInCents().getUnitAmountUSD(), 10);
+    }
+}


### PR DESCRIPTION
To create item-backed add-on:
```java
final AddOn addon1 = new AddOn();
addon1.setItemCode(item.getItemCode());
final RecurlyUnitCurrency price = new RecurlyUnitCurrency();
price.setUnitAmountUSD(10);
addon1.setUnitAmountInCents(price);

final AddOn addon2 = client.createPlanAddOn(plan.getPlanCode(), addon1);
```

To get item-backed add-on:
```java
final AddOn addon = client.getAddOn(plan.getPlanCode(), item.getItemCode());
```

To update item-backed add-on:
```java
AddOn addOnData = new AddOn();
addOnData.setDefaultQuantity(5);

final AddOn updatedAddOn = client.updateAddOn(plan.getPlanCode(), addon.getAddOnCode(), addOnData);
```

When add-on has an associated item, only the following attributes are updatable:
```java
unit_amount_in_cents
default_quantity
display_quantity_on_hosted_page
optional
```