### PR TITLE
Add IBAN attribute to BillingInfo

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -113,7 +113,7 @@ public class RecurlyClient {
     private static final Logger log = LoggerFactory.getLogger(RecurlyClient.class);
 
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
-    public static final String RECURLY_API_VERSION = "2.25";
+    public static final String RECURLY_API_VERSION = "2.26";
 
     private static final String X_RATELIMIT_REMAINING_HEADER_NAME = "X-RateLimit-Remaining";
     private static final String X_RECORDS_HEADER_NAME = "X-Records";

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -142,6 +142,9 @@ public class BillingInfo extends RecurlyObject {
     @XmlElement(name = "transaction_type")
     private String transactionType;
 
+    @XmlElement(name = "iban")
+    private String iban;
+
     public String getType() {
         return type;
     }
@@ -453,6 +456,14 @@ public class BillingInfo extends RecurlyObject {
         this.transactionType = stringOrNull(transactionType);
     }
 
+    public String getIban() {
+        return iban;
+    }
+
+    public void setIban(final Object iban) {
+        this.iban = stringOrNull(iban);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -497,6 +508,7 @@ public class BillingInfo extends RecurlyObject {
         sb.append(", amazonBillingAgreementId='").append(amazonBillingAgreementId).append('\'');
         sb.append(", amazonRegion='").append(amazonRegion).append('\'');
         sb.append(", threeDSecureActionResultTokenId='").append(threeDSecureActionResultTokenId).append('\'');
+        sb.append(", iban='").append(iban).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -610,6 +622,9 @@ public class BillingInfo extends RecurlyObject {
         if (transactionType != null ? !transactionType.equals(that.transactionType) : that.transactionType != null) {
             return false;
         }
+        if(iban != null ? !iban.equals(that.iban) : that.iban != null) {
+            return false;
+        }
 
         return true;
     }
@@ -650,7 +665,8 @@ public class BillingInfo extends RecurlyObject {
                 amazonBillingAgreementId,
                 amazonRegion,
                 threeDSecureActionResultTokenId,
-                transactionType
+                transactionType,
+                iban
         );
     }
 }

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -596,6 +596,20 @@ public class TestRecurlyClient {
     }
 
     @Test(groups = "integration")
+    public void testCreateAccountIbanBillingInfo() throws Exception {
+        final Account accountData = TestUtils.createRandomAccount();
+        final BillingInfo billingInfoData = TestUtils.createRandomIbanBillingInfo();
+        try {
+            final Account account = recurlyClient.createAccount(accountData);
+            billingInfoData.setAccount(account);
+            recurlyClient.createOrUpdateBillingInfo(billingInfoData);
+            Assert.fail("Should have thrown transaction exception");
+        } catch(TransactionErrorException e) {
+            Assert.assertEquals(e.getErrors().getTransactionError().getErrorCode(), "no_gateway");
+        }
+    }
+
+    @Test(groups = "integration")
     public void testGetAccountBalance() throws Exception {
         final Account accountData = TestUtils.createRandomAccount();
         final BillingInfo billingInfoData = TestUtils.createRandomBillingInfo();

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -426,7 +426,17 @@ public class TestUtils {
         info.setMonth(createTestCCMonth());
         info.setNumber(createTestCCNumber());
         info.setVerificationValue(createTestCCVerificationNumber());
+        return info;
+    }
 
+    public static BillingInfo createRandomIbanBillingInfo() {
+        return createRandomIbanBillingInfo(randomSeed());
+    }
+
+    public static BillingInfo createRandomIbanBillingInfo(final int seed) {
+        final BillingInfo info = new BillingInfo();
+        info.setIban("FR1420041010050500013M02606");
+        info.setNameOnAccount(randomAlphaNumericString(10, seed));
         return info;
     }
 


### PR DESCRIPTION
This feature is to allow support of the IBAN field in our V2 API for the applicable endpoints. This field is most similar to banking account information or credit card information, and is used to make payments for SEPA transactions.

IBAN numbers can be set in all endpoints that support BillingInfo:

PUT "/v2/accounts/{account_id}/billing_info"
PUT "/v2/accounts/{account_id}"
POST "/v2/accounts"
POST "/v2/subscriptions"
POST "/v2/purchases"
POST "/v2/purchases/preview"

A sample request payload is provided below:
```
<billing_info>
  <iban>IBANNUMBERHERE</iban>
  <name_on_account>Verena Example</name_on_account>
  <!-- address fields... ->
</billing_info>
```