### PR TITLE
Add mandateReference attribute to BillingInfo

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -113,7 +113,7 @@ public class RecurlyClient {
     private static final Logger log = LoggerFactory.getLogger(RecurlyClient.class);
 
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
-    public static final String RECURLY_API_VERSION = "2.25";
+    public static final String RECURLY_API_VERSION = "2.26";
 
     private static final String X_RATELIMIT_REMAINING_HEADER_NAME = "X-RateLimit-Remaining";
     private static final String X_RECORDS_HEADER_NAME = "X-Records";

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -46,6 +46,9 @@ public class BillingInfo extends RecurlyObject {
     @XmlElement(name = "last_name")
     private String lastName;
 
+    @XmlElement(name = "mandate_reference")
+    private String mandateReference;
+
     @XmlElement(name = "company")
     private String company;
 
@@ -195,6 +198,14 @@ public class BillingInfo extends RecurlyObject {
 
     public void setLastName(final Object lastName) {
         this.lastName = stringOrNull(lastName);
+    }
+
+    public String getMandateReference() {
+        return mandateReference;
+    }
+
+    public void setMandateReference(final Object mandateReference) {
+        this.mandateReference = stringOrNull(mandateReference);
     }
 
     public String getCompany() {
@@ -471,6 +482,7 @@ public class BillingInfo extends RecurlyObject {
         sb.append(", nameOnAccount='").append(nameOnAccount).append('\'');
         sb.append(", firstName='").append(firstName).append('\'');
         sb.append(", lastName='").append(lastName).append('\'');
+        sb.append(", mandateReference='").append(mandateReference).append('\'');
         sb.append(", company='").append(company).append('\'');
         sb.append(", address1='").append(address1).append('\'');
         sb.append(", address2='").append(address2).append('\'');
@@ -533,6 +545,9 @@ public class BillingInfo extends RecurlyObject {
             return false;
         }
         if (firstName != null ? !firstName.equals(that.firstName) : that.firstName != null) {
+            return false;
+        }
+        if (mandateReference != null ? !mandateReference.equals(that.mandateReference) : that.mandateReference != null) {
             return false;
         }
         if (firstSix != null ? !firstSix.equals(that.firstSix) : that.firstSix != null) {
@@ -621,6 +636,7 @@ public class BillingInfo extends RecurlyObject {
                 nameOnAccount,
                 firstName,
                 lastName,
+                mandateReference,
                 company,
                 address1,
                 address2,


### PR DESCRIPTION
A mandate reference is a specific ID used in a payment system to show that an agreement was made between the customer and the merchant. It is often required for compliance reasons to display when a billing info is created or a payment is created.