### PR TITLE
Replace IO layer to use Apache HC + trivial cleanups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,9 +110,9 @@
             <version>2.0.3</version>
         </dependency>
         <dependency>
-            <groupId>com.ning</groupId>
-            <artifactId>async-http-client</artifactId>
-            <version>1.9.8</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.12</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/src/main/java/com/ning/billing/recurly/QueryParams.java
+++ b/src/main/java/com/ning/billing/recurly/QueryParams.java
@@ -16,11 +16,16 @@
  */
 package com.ning.billing.recurly;
 
-import com.ning.billing.recurly.model.Subscription;
-import com.ning.billing.recurly.model.Transaction;
+import com.google.common.base.Charsets;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
 import org.joda.time.DateTime;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -152,18 +157,11 @@ public class QueryParams {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-
-        for (Map.Entry<String,String> entry : params.entrySet()) {
-            if (sb.length() > 0) {
-                sb.append("&");
-            } else {
-                sb.append("?");
-            }
-
-            sb.append(String.format("%s=%s", entry.getKey(), entry.getValue()));
+        if (params.isEmpty()) return "";
+        final List<NameValuePair> pairList = new ArrayList<NameValuePair>(params.size());
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            pairList.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
         }
-
-        return sb.toString();
+        return '?' + URLEncodedUtils.format(pairList, Charsets.UTF_8);
     }
 }

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -50,7 +50,6 @@ import com.ning.billing.recurly.model.Redemption;
 import com.ning.billing.recurly.model.Redemptions;
 import com.ning.billing.recurly.model.RefundMethod;
 import com.ning.billing.recurly.model.RefundOption;
-import com.ning.billing.recurly.model.ResponseMetadata;
 import com.ning.billing.recurly.model.ShippingAddress;
 import com.ning.billing.recurly.model.ShippingAddresses;
 import com.ning.billing.recurly.model.Subscription;
@@ -58,8 +57,6 @@ import com.ning.billing.recurly.model.SubscriptionState;
 import com.ning.billing.recurly.model.SubscriptionUpdate;
 import com.ning.billing.recurly.model.SubscriptionNotes;
 import com.ning.billing.recurly.model.Subscriptions;
-import com.ning.billing.recurly.model.Tier;
-import com.ning.billing.recurly.model.Tiers;
 import com.ning.billing.recurly.model.Transaction;
 import com.ning.billing.recurly.model.TransactionState;
 import com.ning.billing.recurly.model.TransactionType;
@@ -76,21 +73,40 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.StandardSystemProperty;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.BaseEncoding;
 import com.google.common.io.CharSource;
 import com.google.common.io.Resources;
 import com.google.common.net.HttpHeaders;
-
 import com.ning.billing.recurly.util.http.SslUtils;
-import com.ning.http.client.AsyncHttpClient;
-import com.ning.http.client.AsyncHttpClientConfig;
-import com.ning.http.client.FluentCaseInsensitiveStringsMap;
-import com.ning.http.client.Response;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.NoHttpResponseException;
+import org.apache.http.ParseException;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.HeaderGroup;
+import org.apache.http.util.EntityUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import javax.xml.bind.DatatypeConverter;
+
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -100,17 +116,13 @@ import java.net.ConnectException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-import java.util.NoSuchElementException;
 import java.util.Properties;
-import java.util.Scanner;
-import java.util.concurrent.ExecutionException;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.List;
-import java.util.Arrays;
 
 public class RecurlyClient {
 
@@ -130,7 +142,7 @@ public class RecurlyClient {
 
     public static final String FETCH_RESOURCE = "/recurly_js/result";
 
-    private static final List<String> validHosts = Arrays.asList("recurly.com");
+    private static final Set<String> validHosts = ImmutableSet.of("recurly.com");
 
     /**
      * Checks a system property to see if debugging output is
@@ -152,13 +164,12 @@ public class RecurlyClient {
         }
     }
 
-    // TODO: should we make it static?
-    private final XmlMapper xmlMapper;
+    private static final XmlMapper xmlMapper = RecurlyObject.newXmlMapper();
     private final String userAgent;
 
     private final String key;
     private final String baseUrl;
-    private AsyncHttpClient client;
+    private CloseableHttpClient client;
 
     // Allows error messages to be returned in a specified language
     private String acceptLanguage = "en-US";
@@ -182,9 +193,8 @@ public class RecurlyClient {
     }
 
     public RecurlyClient(final String apiKey, final String scheme, final String host, final int port, final String version) {
-        this.key = DatatypeConverter.printBase64Binary(apiKey.getBytes());
+        this.key = BaseEncoding.base64().encode(apiKey.getBytes(Charsets.UTF_8));
         this.baseUrl = String.format("%s://%s:%d/%s", scheme, host, port, version);
-        this.xmlMapper = RecurlyObject.newXmlMapper();
         this.userAgent = buildUserAgent();
         this.rateLimitRemaining = -1;
         loggerWarning();
@@ -192,17 +202,32 @@ public class RecurlyClient {
 
     /**
      * Open the underlying http client
+     * If you are supplying your own http client, do not call this method.
      */
     public synchronized void open() throws NoSuchAlgorithmException, KeyManagementException {
         client = createHttpClient();
     }
 
     /**
+     * Set the underlying http client with your custom client. This allows the creation of
+     * "lightweight" {@link RecurlyClient}s where each can have its own apiKey, etc.
+     * If {@link #open()} had already been called, do not call this method.
+     */
+    public synchronized void open(CloseableHttpClient client) {
+        this.client = client;
+    }
+
+    /**
      * Close the underlying http client
+     * If you are supplying your own http client, do not call this method.
      */
     public synchronized void close() {
         if (client != null) {
-            client.close();
+            try {
+                client.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 
@@ -268,8 +293,8 @@ public class RecurlyClient {
      * @return Integer on success, null otherwise
      */
     public Integer getAccountsCount(final QueryParams params) {
-        FluentCaseInsensitiveStringsMap map = doHEAD(Accounts.ACCOUNTS_RESOURCE, params);
-        return Integer.parseInt(map.getFirstValue(X_RECORDS_HEADER_NAME));
+        HeaderGroup map = doHEAD(Accounts.ACCOUNTS_RESOURCE, params);
+        return Integer.parseInt(map.getFirstHeader(X_RECORDS_HEADER_NAME).getValue());
     }
 
     /**
@@ -302,8 +327,8 @@ public class RecurlyClient {
      * @return Integer on success, null otherwise
      */
     public Integer getCouponsCount(final QueryParams params) {
-        FluentCaseInsensitiveStringsMap map = doHEAD(Coupons.COUPONS_RESOURCE, params);
-        return Integer.parseInt(map.getFirstValue(X_RECORDS_HEADER_NAME));
+        HeaderGroup map = doHEAD(Coupons.COUPONS_RESOURCE, params);
+        return Integer.parseInt(map.getFirstHeader(X_RECORDS_HEADER_NAME).getValue());
     }
 
     /**
@@ -596,9 +621,9 @@ public class RecurlyClient {
             request = new Subscription();
             Account account = new Account();
             BillingInfo billingInfo = new BillingInfo();
-            billingInfo.setThreeDSecureActionResultTokenId(ThreeDSecureActionResultTokenId); 
+            billingInfo.setThreeDSecureActionResultTokenId(ThreeDSecureActionResultTokenId);
             account.setBillingInfo(billingInfo);
-            request.setAccount(account);   
+            request.setAccount(account);
         }
         return doPUT(Subscription.SUBSCRIPTION_RESOURCE + "/" + urlEncode(subscriptionUuid) + "/convert_trial",
             request, Subscription.class);
@@ -753,8 +778,8 @@ public class RecurlyClient {
      * @return Integer on success, null otherwise
      */
     public Integer getSubscriptionsCount(final QueryParams params) {
-        FluentCaseInsensitiveStringsMap map = doHEAD(Subscription.SUBSCRIPTION_RESOURCE,  params);
-        return Integer.parseInt(map.getFirstValue(X_RECORDS_HEADER_NAME));
+        HeaderGroup map = doHEAD(Subscription.SUBSCRIPTION_RESOURCE,  params);
+        return Integer.parseInt(map.getFirstHeader(X_RECORDS_HEADER_NAME).getValue());
     }
 
     /**
@@ -796,9 +821,9 @@ public class RecurlyClient {
      */
     public Subscriptions getInvoiceSubscriptions(final String invoiceId, final QueryParams params) {
         return doGET(Invoices.INVOICES_RESOURCE
-                        + "/" + urlEncode(invoiceId) 
+                        + "/" + urlEncode(invoiceId)
                         + Subscriptions.SUBSCRIPTIONS_RESOURCE,
-                Subscriptions.class, 
+                Subscriptions.class,
                 params);
     }
 
@@ -1024,8 +1049,8 @@ public class RecurlyClient {
      * @return Integer on success, null otherwise
      */
     public Integer getTransactionsCount(final QueryParams params) {
-        FluentCaseInsensitiveStringsMap map = doHEAD(Transactions.TRANSACTIONS_RESOURCE, params);
-        return Integer.parseInt(map.getFirstValue(X_RECORDS_HEADER_NAME));
+        HeaderGroup map = doHEAD(Transactions.TRANSACTIONS_RESOURCE, params);
+        return Integer.parseInt(map.getFirstHeader(X_RECORDS_HEADER_NAME).getValue());
     }
 
     /**
@@ -1191,8 +1216,8 @@ public class RecurlyClient {
      * @return the count of invoices matching the query
      */
     public int getInvoicesCount(final QueryParams params) {
-        FluentCaseInsensitiveStringsMap map = doHEAD(Invoices.INVOICES_RESOURCE, params);
-        return Integer.parseInt(map.getFirstValue(X_RECORDS_HEADER_NAME));
+        HeaderGroup map = doHEAD(Invoices.INVOICES_RESOURCE, params);
+        return Integer.parseInt(map.getFirstHeader(X_RECORDS_HEADER_NAME).getValue());
     }
 
     /**
@@ -1207,7 +1232,7 @@ public class RecurlyClient {
         return doGET(Invoices.INVOICES_RESOURCE + "/" + urlEncode(invoiceId) + Transactions.TRANSACTIONS_RESOURCE,
                      Transactions.class, new QueryParams());
     }
-    
+
     /**
      * Lookup an account's invoices
      * <p>
@@ -1615,8 +1640,8 @@ public class RecurlyClient {
      * @return Integer on success, null otherwise
      */
     public Integer getPlansCount(final QueryParams params) {
-        FluentCaseInsensitiveStringsMap map = doHEAD(Plans.PLANS_RESOURCE, params);
-        return Integer.parseInt(map.getFirstValue(X_RECORDS_HEADER_NAME));
+        HeaderGroup map = doHEAD(Plans.PLANS_RESOURCE, params);
+        return Integer.parseInt(map.getFirstHeader(X_RECORDS_HEADER_NAME).getValue());
     }
 
     /**
@@ -2036,8 +2061,8 @@ public class RecurlyClient {
      * @return Integer on success, null otherwise
      */
     public Integer getGiftCardsCount(final QueryParams params) {
-        FluentCaseInsensitiveStringsMap map = doHEAD(GiftCards.GIFT_CARDS_RESOURCE, params);
-        return Integer.parseInt(map.getFirstValue(X_RECORDS_HEADER_NAME));
+        HeaderGroup map = doHEAD(GiftCards.GIFT_CARDS_RESOURCE, params);
+        return Integer.parseInt(map.getFirstHeader(X_RECORDS_HEADER_NAME).getValue());
     }
 
     /**
@@ -2322,8 +2347,7 @@ public class RecurlyClient {
         if (debug()) {
             log.info("Msg to Recurly API [GET] :: URL : {}", url);
         }
-        validateHost(url);
-        return callRecurlySafeXmlContent(client.prepareGet(url), clazz);
+        return callRecurlySafeXmlContent(new HttpGet(url), clazz);
     }
 
     private InputStream doGETPdfWithFullURL(final String url) {
@@ -2335,32 +2359,30 @@ public class RecurlyClient {
     }
 
     private InputStream callRecurlySafeGetPdf(String url) {
-        validateHost(url);
-
-        final Response response;
-        final InputStream pdfInputStream;
+        CloseableHttpResponse response = null;
+        InputStream pdfInputStream = null;
         try {
-            response = clientRequestBuilderCommon(client.prepareGet(url))
-                    .addHeader("Accept", "application/pdf")
-                    .addHeader("Content-Type", "application/pdf")
-                    .execute()
-                    .get();
-            pdfInputStream = response.getResponseBodyAsStream();
+            final HttpGet builder = new HttpGet(url);
+            clientRequestBuilderCommon(builder);
+            builder.setHeader(HttpHeaders.ACCEPT, "application/pdf");
+            builder.setHeader(HttpHeaders.CONTENT_TYPE, "application/pdf");
+            response = client.execute(builder);
+            if (response.getStatusLine().getStatusCode() != 200) {
+                final RecurlyAPIError recurlyAPIError = RecurlyAPIError.buildFromResponse(response);
+                throw new RecurlyAPIException(recurlyAPIError);
+            }
 
-        } catch (InterruptedException e) {
-            log.error("Interrupted while calling recurly", e);
-            return null;
-        } catch (ExecutionException e) {
-            log.error("Execution error", e);
-            return null;
+            // Buffer the pdf in memory on purpose, because this was actually the behavior of AsyncHttpClient.
+            final HttpEntity entity = response.getEntity();
+            if (entity != null) {
+                final byte[] pdfBytes = EntityUtils.toByteArray(entity);
+                pdfInputStream = new ByteArrayInputStream(pdfBytes);
+            }
         } catch (IOException e) {
             log.error("Error retrieving response body", e);
             return null;
-        }
-
-        if (response.getStatusCode() != 200) {
-            final RecurlyAPIError recurlyAPIError = RecurlyAPIError.buildFromResponse(response);
-            throw new RecurlyAPIException(recurlyAPIError);
+        } finally {
+            closeResponse(response);
         }
 
         return pdfInputStream;
@@ -2379,9 +2401,12 @@ public class RecurlyClient {
             return null;
         }
 
-        validateHost(baseUrl + resource);
-
-        return callRecurlySafeXmlContent(client.preparePost(baseUrl + resource).setBody(xmlPayload), clazz);
+        final HttpPost builder = new HttpPost(baseUrl + resource);
+        if (xmlPayload != null) {
+            builder.setEntity(new StringEntity(xmlPayload,
+                    ContentType.APPLICATION_XML.withCharset(Charsets.UTF_8)));
+        }
+        return callRecurlySafeXmlContent(builder, clazz);
     }
 
     private <T> T doPUT(final String resource, final RecurlyObject payload, final Class<T> clazz) {
@@ -2406,13 +2431,15 @@ public class RecurlyClient {
             return null;
         }
 
-        final String url = baseUrl + resource;
-        validateHost(url);
-
-        return callRecurlySafeXmlContent(client.preparePut(url).setBody(xmlPayload), clazz);
+        final HttpPut builder = new HttpPut(constructUrl(resource, params));
+        if (xmlPayload != null) {
+            builder.setEntity(new StringEntity(xmlPayload,
+                    ContentType.APPLICATION_XML.withCharset(Charsets.UTF_8)));
+        }
+        return callRecurlySafeXmlContent(builder, clazz);
     }
 
-    private FluentCaseInsensitiveStringsMap doHEAD(final String resource, QueryParams params) {
+    private HeaderGroup doHEAD(final String resource, QueryParams params) {
         if (params == null) {
             params = new QueryParams();
         }
@@ -2422,86 +2449,69 @@ public class RecurlyClient {
             log.info("Msg to Recurly API [HEAD]:: URL : {}", url);
         }
 
-        validateHost(url);
-
-        return callRecurlyNoContent(client.prepareHead(url));
+        return callRecurlyNoContent(new HttpHead(url));
     }
 
     private void doDELETE(final String resource) {
-        validateHost(baseUrl + resource);
-
-        callRecurlySafeXmlContent(client.prepareDelete(baseUrl + resource), null);
+        callRecurlySafeXmlContent(new HttpDelete(baseUrl + resource), null);
     }
 
-    private FluentCaseInsensitiveStringsMap callRecurlyNoContent(final AsyncHttpClient.BoundRequestBuilder builder) {
+    private HeaderGroup callRecurlyNoContent(final HttpRequestBase builder) {
+        clientRequestBuilderCommon(builder);
+        builder.setHeader(HttpHeaders.ACCEPT, "application/xml");
+        builder.setHeader(HttpHeaders.CONTENT_TYPE, "application/xml; charset=utf-8");
+        CloseableHttpResponse response = null;
         try {
-            final Response response = clientRequestBuilderCommon(builder)
-                    .addHeader("Accept", "application/xml")
-                    .addHeader("Content-Type", "application/xml; charset=utf-8")
-                    .execute()
-                    .get();
-
-            return response.getHeaders();
-        } catch (ExecutionException e) {
+            response = client.execute(builder);
+            // Copy all the headers into a HeaderGroup, which will handle case insensitive headers for us
+            final HeaderGroup headerGroup = new HeaderGroup();
+            for (Header header : response.getAllHeaders()) {
+                headerGroup.addHeader(header);
+            }
+            return headerGroup;
+        } catch (IOException e) {
             log.error("Execution error", e);
             return null;
-        }
-        catch (InterruptedException e) {
-            log.error("Interrupted while calling Recurly", e);
-            return null;
+        } finally {
+            closeResponse(response);
         }
     }
 
-    private <T> T callRecurlySafeXmlContent(final AsyncHttpClient.BoundRequestBuilder builder, @Nullable final Class<T> clazz) {
+    private <T> T callRecurlySafeXmlContent(final HttpRequestBase builder, @Nullable final Class<T> clazz) {
         try {
             return callRecurlyXmlContent(builder, clazz);
         } catch (IOException e) {
+            if (e instanceof ConnectException || e instanceof NoHttpResponseException
+                    || e instanceof ConnectTimeoutException) {
+                // See https://github.com/killbilling/recurly-java-library/issues/185
+                throw new ConnectionErrorException(e);
+            }
             log.warn("Error while calling Recurly", e);
             return null;
-        } catch (ExecutionException e) {
-            // Extract the errors exception, if any
-            if (e.getCause() instanceof ConnectException) {
-                // See https://github.com/killbilling/recurly-java-library/issues/185
-                throw new ConnectionErrorException(e.getCause());
-            } else if (e.getCause() != null &&
-                e.getCause().getCause() != null &&
-                e.getCause().getCause() instanceof TransactionErrorException) {
-                throw (TransactionErrorException) e.getCause().getCause();
-            } else if (e.getCause() != null &&
-                       e.getCause() instanceof TransactionErrorException) {
-                // See https://github.com/killbilling/recurly-java-library/issues/16
-                throw (TransactionErrorException) e.getCause();
-            }
-            log.error("Execution error", e);
-            return null;
-        } catch (InterruptedException e) {
-            log.error("Interrupted while calling Recurly", e);
-            return null;
         }
+        // No need to extract TransactionErrorException since it's already a RuntimeException
     }
 
-    private <T> T callRecurlyXmlContent(final AsyncHttpClient.BoundRequestBuilder builder, @Nullable final Class<T> clazz)
-            throws IOException, ExecutionException, InterruptedException {
-        final Response response = clientRequestBuilderCommon(builder)
-                .addHeader("Accept", "application/xml")
-                .addHeader("Content-Type", "application/xml; charset=utf-8")
-                .execute()
-                .get();
-
-        final InputStream in = response.getResponseBodyAsStream();
+    private <T> T callRecurlyXmlContent(final HttpRequestBase builder, @Nullable final Class<T> clazz)
+            throws IOException {
+        clientRequestBuilderCommon(builder);
+        builder.setHeader(HttpHeaders.ACCEPT, "application/xml");
+        builder.setHeader(HttpHeaders.CONTENT_TYPE, "application/xml; charset=utf-8");
+        CloseableHttpResponse response = null;
         try {
-            final String payload = convertStreamToString(in);
+            response = client.execute(builder);
+            final String payload = convertEntityToString(response.getEntity());
             if (debug()) {
                 log.info("Msg from Recurly API :: {}", payload);
             }
 
             // Handle errors payload
-            if (response.getStatusCode() >= 300) {
-                log.warn("Recurly error whilst calling: {}\n{}", response.getUri(), payload);
-                log.warn("Error status code: {}\n", response.getStatusCode());
+            if (response.getStatusLine().getStatusCode() >= 300) {
+                log.warn("Recurly error whilst calling: {}\n{}", builder.getURI(), payload);
+                log.warn("Error status code: {}\n", response.getStatusLine().getStatusCode());
                 RecurlyAPIError recurlyError = RecurlyAPIError.buildFromResponse(response);
 
-                if (response.getStatusCode() == 422) {
+                if (response.getStatusLine().getStatusCode() == 422) {
                     // 422 is returned for transaction errors (see https://dev.recurly.com/page/transaction-errors)
                     // as well as bad input payloads
                     final Errors errors;
@@ -2523,7 +2533,7 @@ public class RecurlyClient {
                         throw new RecurlyAPIException(recurlyError);
                     }
                     throw new TransactionErrorException(errors);
-                } else if (response.getStatusCode() == 401) {
+                } else if (response.getStatusLine().getStatusCode() == 401) {
                     recurlyError.setSymbol("unauthorized");
                     recurlyError.setDescription("We could not authenticate your request. Either your subdomain and private key are not set or incorrect");
 
@@ -2543,16 +2553,18 @@ public class RecurlyClient {
                 return null;
             }
 
-            String location = response.getHeader("Location");
+            final Header locationHeader = response.getFirstHeader("Location");
+            String location = locationHeader == null ? null : locationHeader.getValue();
             if (clazz == Coupons.class && location != null && !location.isEmpty()) {
                 final RecurlyObjects recurlyObjects = new Coupons();
                 recurlyObjects.setRecurlyClient(this);
                 recurlyObjects.setStartUrl(location);
-                return (T) recurlyObjects;
+                @SuppressWarnings("unchecked")
+                final T castResult = (T) recurlyObjects;
+                return castResult;
             }
 
             final T obj = xmlMapper.readValue(payload, clazz);
-            final ResponseMetadata meta = new ResponseMetadata(response);
             if (obj instanceof RecurlyObject) {
                 ((RecurlyObject) obj).setRecurlyClient(this);
             } else if (obj instanceof RecurlyObjects) {
@@ -2565,64 +2577,78 @@ public class RecurlyClient {
                 }
 
                 // Set links for pagination
-                final String linkHeader = response.getHeader(LINK_HEADER_NAME);
+                final Header linkHeader = response.getFirstHeader(LINK_HEADER_NAME);
                 if (linkHeader != null) {
-                    final String[] links = PaginationUtils.getLinks(linkHeader);
+                    final String[] links = PaginationUtils.getLinks(linkHeader.getValue());
                     recurlyObjects.setStartUrl(links[0]);
                     recurlyObjects.setNextUrl(links[1]);
                 }
             }
 
             // Save value of rate limit remaining header
-            String rateLimitRemainingString = response.getHeader(X_RATELIMIT_REMAINING_HEADER_NAME);
+            Header rateLimitRemainingString = response.getFirstHeader(X_RATELIMIT_REMAINING_HEADER_NAME);
             if (rateLimitRemainingString != null)
-                rateLimitRemaining = Integer.parseInt(rateLimitRemainingString);
+                rateLimitRemaining = Integer.parseInt(rateLimitRemainingString.getValue());
 
             return obj;
         } finally {
-            closeStream(in);
+            closeResponse(response);
         }
     }
 
-    private AsyncHttpClient.BoundRequestBuilder clientRequestBuilderCommon(AsyncHttpClient.BoundRequestBuilder requestBuilder) {
-        return requestBuilder.addHeader("Authorization", "Basic " + key)
-                .addHeader("X-Api-Version", RECURLY_API_VERSION)
-                .addHeader(HttpHeaders.USER_AGENT, userAgent)
-                .addHeader("Accept-Language", acceptLanguage)
-                .setBodyEncoding("UTF-8");
+    private void clientRequestBuilderCommon(HttpRequestBase requestBuilder) {
+        validateHost(requestBuilder.getURI());
+        requestBuilder.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + key);
+        requestBuilder.setHeader("X-Api-Version", RECURLY_API_VERSION);
+        requestBuilder.setHeader(HttpHeaders.USER_AGENT, userAgent);
+        requestBuilder.setHeader(HttpHeaders.ACCEPT_LANGUAGE, acceptLanguage);
     }
 
-    private String convertStreamToString(final java.io.InputStream is) {
-        try {
-            return new Scanner(is).useDelimiter("\\A").next();
-        } catch (final NoSuchElementException e) {
+    private String convertEntityToString(HttpEntity entity) {
+        if (entity == null) {
             return "";
         }
+        final String entityString;
+        try {
+            entityString = EntityUtils.toString(entity, Charsets.UTF_8);
+        } catch (ParseException e) {
+            return "";
+        } catch (IOException e) {
+            return "";
+        }
+        return entityString == null ? "" : entityString;
     }
 
-    private void closeStream(final InputStream in) {
-        if (in != null) {
+    protected CloseableHttpClient createHttpClient() throws KeyManagementException, NoSuchAlgorithmException {
+        // Don't limit the number of connections per host
+        // See https://github.com/ning/async-http-client/issues/issue/28
+        final HttpClientBuilder httpClientBuilder = HttpClients.custom()
+                .disableCookieManagement() // We don't need cookies
+                /*
+                 * The following limits are not quite truly unlimited, but in practice they
+                 * should be more than enough.
+                 */
+                .setMaxConnPerRoute(256) // default is 2
+                .setMaxConnTotal(512) // default is 20
+                // Use the default timeouts from AHC
+                .setDefaultRequestConfig(RequestConfig.custom()
+                        .setConnectTimeout(5000).setSocketTimeout(60000).build())
+                .setSSLContext(SslUtils.getInstance().getSSLContext());
+        return httpClientBuilder.build();
+    }
+
+    private void closeResponse(final CloseableHttpResponse response) {
+        if (response != null) {
             try {
-                in.close();
+                response.close();
             } catch (IOException e) {
-                log.warn("Failed to close http-client - provided InputStream: {}", e.getLocalizedMessage());
+                log.warn("Failed to close {}: {}", response.getClass().getSimpleName(), e.getLocalizedMessage());
             }
         }
     }
 
-    protected AsyncHttpClient createHttpClient() throws KeyManagementException, NoSuchAlgorithmException {
-        final AsyncHttpClientConfig.Builder builder = new AsyncHttpClientConfig.Builder();
-
-        // Don't limit the number of connections per host
-        // See https://github.com/ning/async-http-client/issues/issue/28
-        builder.setMaxConnectionsPerHost(-1);
-        builder.setSSLContext(SslUtils.getInstance().getSSLContext());
-
-        return new AsyncHttpClient(builder.build());
-    }
-
-    private void validateHost(String url) {
-        String host = URI.create(url).getHost();
+    private void validateHost(URI uri) {
+        String host = uri.getHost();
 
         // Remove the subdomain from the host
         host = host.substring(host.indexOf(".")+1);
@@ -2645,7 +2671,7 @@ public class RecurlyClient {
         try {
             final Properties gitRepositoryState = new Properties();
             final URL resourceURL = Resources.getResource(GIT_PROPERTIES_FILE);
-            final CharSource charSource = Resources.asCharSource(resourceURL, Charset.forName("UTF-8"));
+            final CharSource charSource = Resources.asCharSource(resourceURL, Charsets.UTF_8);
 
             Reader reader = null;
             try {

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -641,8 +641,10 @@ public class RecurlyClient {
      * @return Subscription
      */
     public Subscription postponeSubscription(final Subscription subscription, final DateTime renewaldate) {
-        return doPUT(Subscription.SUBSCRIPTION_RESOURCE + "/" + urlEncode(subscription.getUuid()) + "/postpone?next_renewal_date=" + renewaldate,
-                     subscription, Subscription.class);
+        final QueryParams params = new QueryParams();
+        params.put("next_renewal_date", renewaldate.toString());
+        return doPUT(Subscription.SUBSCRIPTION_RESOURCE + "/" + urlEncode(subscription.getUuid()) + "/postpone",
+                     subscription, Subscription.class, params);
     }
 
     /**
@@ -651,8 +653,10 @@ public class RecurlyClient {
      * @param subscription Subscription to terminate
      */
     public void terminateSubscription(final Subscription subscription, final RefundOption refund) {
-        doPUT(Subscription.SUBSCRIPTION_RESOURCE + "/" + urlEncode(subscription.getUuid()) + "/terminate?refund=" + refund,
-              subscription, Subscription.class);
+        final QueryParams params = new QueryParams();
+        params.put("refund", refund.toString());
+        doPUT(Subscription.SUBSCRIPTION_RESOURCE + "/" + urlEncode(subscription.getUuid()) + "/terminate",
+              subscription, Subscription.class, params);
     }
 
     /**

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -200,24 +200,13 @@ public class RecurlyClient {
 
     /**
      * Open the underlying http client
-     * If you are supplying your own http client, do not call this method.
      */
     public synchronized void open() throws NoSuchAlgorithmException, KeyManagementException {
         client = createHttpClient();
     }
 
     /**
-     * Set the underlying http client with your custom client. This allows the creation of
-     * "lightweight" {@link RecurlyClient}s where each can have its own apiKey, etc.
-     * If {@link #open()} had already been called, do not call this method.
-     */
-    public synchronized void open(CloseableHttpClient client) {
-        this.client = client;
-    }
-
-    /**
      * Close the underlying http client
-     * If you are supplying your own http client, do not call this method.
      */
     public synchronized void close() {
         if (client != null) {

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -2617,6 +2617,16 @@ public class RecurlyClient {
         return entityString == null ? "" : entityString;
     }
 
+    private void closeResponse(final CloseableHttpResponse response) {
+        if (response != null) {
+            try {
+                response.close();
+            } catch (IOException e) {
+                log.warn("Failed to close {}: {}", response.getClass().getSimpleName(), e.getLocalizedMessage());
+            }
+        }
+    }
+
     protected CloseableHttpClient createHttpClient() throws KeyManagementException, NoSuchAlgorithmException {
         // Don't limit the number of connections per host
         // See https://github.com/ning/async-http-client/issues/issue/28
@@ -2633,16 +2643,6 @@ public class RecurlyClient {
                         .setConnectTimeout(5000).setSocketTimeout(60000).build())
                 .setSSLContext(SslUtils.getInstance().getSSLContext());
         return httpClientBuilder.build();
-    }
-
-    private void closeResponse(final CloseableHttpResponse response) {
-        if (response != null) {
-            try {
-                response.close();
-            } catch (IOException e) {
-                log.warn("Failed to close {}: {}", response.getClass().getSimpleName(), e.getLocalizedMessage());
-            }
-        }
     }
 
     private void validateHost(URI uri) {

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -68,7 +68,6 @@ import com.ning.billing.recurly.model.MeasuredUnits;
 import com.ning.billing.recurly.model.AccountAcquisition;
 import com.ning.billing.recurly.model.ShippingMethod;
 import com.ning.billing.recurly.model.ShippingMethods;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.MoreObjects;
@@ -164,7 +163,6 @@ public class RecurlyClient {
         }
     }
 
-    private static final XmlMapper xmlMapper = RecurlyObject.newXmlMapper();
     private final String userAgent;
 
     private final String key;
@@ -2391,7 +2389,7 @@ public class RecurlyClient {
     private <T> T doPOST(final String resource, final RecurlyObject payload, final Class<T> clazz) {
         final String xmlPayload;
         try {
-            xmlPayload = xmlMapper.writeValueAsString(payload);
+            xmlPayload = RecurlyObject.sharedXmlMapper().writeValueAsString(payload);
             if (debug()) {
                 log.info("Msg to Recurly API [POST]:: URL : {}", baseUrl + resource);
                 log.info("Payload for [POST]:: {}", xmlPayload);
@@ -2417,7 +2415,7 @@ public class RecurlyClient {
         final String xmlPayload;
         try {
             if (payload != null) {
-                xmlPayload = xmlMapper.writeValueAsString(payload);
+                xmlPayload = RecurlyObject.sharedXmlMapper().writeValueAsString(payload);
             } else {
                 xmlPayload = null;
             }
@@ -2516,7 +2514,7 @@ public class RecurlyClient {
                     // as well as bad input payloads
                     final Errors errors;
                     try {
-                        errors = xmlMapper.readValue(payload, Errors.class);
+                        errors = RecurlyObject.sharedXmlMapper().readValue(payload, Errors.class);
                     } catch (Exception e) {
                         log.warn("Unable to extract error", e);
                         return null;
@@ -2529,7 +2527,7 @@ public class RecurlyClient {
                         errors.getTransaction() == null &&
                         errors.getTransactionError() == null
                     )) {
-                        recurlyError = RecurlyAPIError.buildFromXml(xmlMapper, payload, response);
+                        recurlyError = RecurlyAPIError.buildFromXml(RecurlyObject.sharedXmlMapper(), payload, response);
                         throw new RecurlyAPIException(recurlyError);
                     }
                     throw new TransactionErrorException(errors);
@@ -2540,7 +2538,7 @@ public class RecurlyClient {
                     throw new RecurlyAPIException(recurlyError);
                 } else {
                     try {
-                        recurlyError = RecurlyAPIError.buildFromXml(xmlMapper, payload, response);
+                        recurlyError = RecurlyAPIError.buildFromXml(RecurlyObject.sharedXmlMapper(), payload, response);
                     } catch (Exception e) {
                         log.debug("Unable to extract error", e);
                     }
@@ -2564,7 +2562,7 @@ public class RecurlyClient {
                 return castResult;
             }
 
-            final T obj = xmlMapper.readValue(payload, clazz);
+            final T obj = RecurlyObject.sharedXmlMapper().readValue(payload, clazz);
             if (obj instanceof RecurlyObject) {
                 ((RecurlyObject) obj).setRecurlyClient(this);
             } else if (obj instanceof RecurlyObjects) {

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -2557,9 +2557,7 @@ public class RecurlyClient {
                 final RecurlyObjects recurlyObjects = new Coupons();
                 recurlyObjects.setRecurlyClient(this);
                 recurlyObjects.setStartUrl(location);
-                @SuppressWarnings("unchecked")
-                final T castResult = (T) recurlyObjects;
-                return castResult;
+                return (T) recurlyObjects;
             }
 
             final T obj = RecurlyObject.sharedXmlMapper().readValue(payload, clazz);

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyAPIError.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyAPIError.java
@@ -21,9 +21,10 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
+import org.apache.http.HttpResponse;
+
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.google.common.base.Objects;
-import com.ning.http.client.Response;
 
 import java.io.IOException;
 
@@ -44,13 +45,13 @@ public class RecurlyAPIError extends RecurlyObject {
 
     private int httpStatusCode;
 
-    public static RecurlyAPIError buildFromResponse(final Response response) {
+    public static RecurlyAPIError buildFromResponse(final HttpResponse response) {
         final RecurlyAPIError recurlyAPIError = new RecurlyAPIError();
         recurlyAPIError.setResponse(response);
         return recurlyAPIError;
     }
 
-    public static RecurlyAPIError buildFromXml(final XmlMapper xmlMapper, final String payload, final Response response) throws IOException {
+    public static RecurlyAPIError buildFromXml(final XmlMapper xmlMapper, final String payload, final HttpResponse response) throws IOException {
         final RecurlyAPIError recurlyAPIError = xmlMapper.readValue(payload, RecurlyAPIError.class);
         recurlyAPIError.setResponse(response);
         return recurlyAPIError;
@@ -94,8 +95,8 @@ public class RecurlyAPIError extends RecurlyObject {
         return this.responseMetadata;
     }
 
-    protected void setResponse(final Response response) {
-        this.setHttpStatusCode(response.getStatusCode());
+    protected void setResponse(final HttpResponse response) {
+        this.setHttpStatusCode(response.getStatusLine().getStatusCode());
         this.setResponseMetadata(new ResponseMetadata(response));
     }
 

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
@@ -105,6 +105,10 @@ public abstract class RecurlyObject {
         return xmlMapper;
     }
 
+    public static XmlMapper sharedXmlMapper() {
+        return XmlMapperHolder.xmlMapper;
+    }
+
     public static Boolean booleanOrNull(@Nullable final Object object) {
         if (isNull(object)) {
             return null;
@@ -256,4 +260,15 @@ public abstract class RecurlyObject {
 
         return this.hashCode() == o.hashCode();
     }
+
+    /**
+     * Holder for the shared {@link XmlMapper}. Not putting it directly under {@link RecurlyObject}
+     * to maker it (sort of) lazy.
+     */
+    private static class XmlMapperHolder {
+
+        private static final XmlMapper xmlMapper = newXmlMapper();
+
+    }
+
 }

--- a/src/main/java/com/ning/billing/recurly/model/ResponseMetadata.java
+++ b/src/main/java/com/ning/billing/recurly/model/ResponseMetadata.java
@@ -16,7 +16,8 @@
  */
 package com.ning.billing.recurly.model;
 
-import com.ning.http.client.Response;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
 
 public class ResponseMetadata {
     /**
@@ -38,10 +39,12 @@ public class ResponseMetadata {
      */
     private int statusCode;
 
-    public ResponseMetadata(Response response) {
-        this.requestId = response.getHeader("X-Request-Id");
-        this.cfRay = response.getHeader("CF-RAY");
-        this.statusCode = response.getStatusCode();
+    public ResponseMetadata(HttpResponse response) {
+        final Header requestIdHeader = response.getFirstHeader("X-Request-Id");
+        this.requestId = requestIdHeader == null ? null : requestIdHeader.getValue();
+        final Header cfRayHeader = response.getFirstHeader("CF-RAY");
+        this.cfRay = cfRayHeader == null ? null : cfRayHeader.getValue();
+        this.statusCode = response.getStatusLine().getStatusCode();
     }
 
     public String getRequestId() {
@@ -56,6 +59,7 @@ public class ResponseMetadata {
         return this.getStatusCode();
     }
 
+    @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("ResponseMetadata{");
         sb.append("requestId=").append(requestId);

--- a/src/main/java/com/ning/billing/recurly/model/push/Notification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/Notification.java
@@ -113,8 +113,7 @@ public abstract class Notification extends RecurlyObject {
 
     public static <T> T read(final String payload, final Class<T> clazz) {
         try {
-            // TODO Should we cache the mapper?
-            return RecurlyObject.newXmlMapper().readValue(payload, clazz);
+            return RecurlyObject.sharedXmlMapper().readValue(payload, clazz);
         } catch (IOException e) {
             log.warn("Enable to read notification, de-serialization failed : {}", e.getMessage());
             return null;


### PR DESCRIPTION
As you probably know, I've created a few smaller pull requests in the past, and those were actually brought over from my fork, which is what we use today on production at SaaSquatch.

The pull request you see here represents the entirety of my fork, which is at this moment up and running on SaaSquatch servers, and has been battle tested for over a year without any issue.

While my previous smaller pull requests mainly focus on fixing obvious bugs and issues, this large pull request mainly aims to "modernize" this library to make it work well on a modern environment, as well as to make some minor improvements.

Here are some key points:
- Even though I said the word "modernize", this fork still targets Java 6.
- The outdated version of async-http-client (hereinafter referred to as AHC) has been replaced with Apache HC (version 4). The old version of AHC conflicts with some newer dependencies we use, and Apache HC is IMO the perfect choice as the IO layer for a couple of reasons:
	- It targets Java 6 (HC5 is already out, but that targets Java 7).
	- Apache has been very good about API stability and not making breaking changes. HC5 is out already, and that is under a different namespace, so this library will not conflict with projects that depend on HC5.
	- It's a blocking client, which makes exception handling a breeze. recurly-java-library is blocking anyway and really doesn't need an async HTTP client, and as you probably already know, AHC unnecessarily complicates exception handling.
	- It comes with a handful of useful utilities that this library needs. For example, the `QueryParams` class right now is building parameters by manually concatenating Strings without any kind of URL encoding. `URLEncodedUtils` from Apache HC solves exactly that.
- While switching to Apache HC, there are obviously classes from AHC that need to be replaced with their equivalents, and you will clearly see them in the pull request.
- I have attempted to maintain all of the existing behaviors and quirks of AHwith Apache HC. These include:
	- (Not quite) unlimited number of connections. I've configured Apache HC to do 256 maximum connections, which should be more than enough in practice. If you would like me to increase that, please let me know.
	- The default timeouts from AHC have been brought over. Although I think the default timeouts are a little too generous.
	- The `InputStream`s returned are in-memory `ByteArrayInputStream`s. This is one of the quirks of AHC, as well as a number of other non-blocking Netty based HTTP clients. Apache HC supports streaming InputStreams, but I'm arbitrarily buffering it in memory to replicate the old behavior.
- There are some minor cleanups and improvements. I'll try to list all of them here:
	- I switched to using Guava to do Base64 encoding instead of using `DataTypeConverter`, which can cause problems with Java 9+.
	- As I've mentioned above, `QueryParams` now uses a proper library to generate query parameters.
	- I've replaced all the references to UTF-8 with Guava's `Charsets.UTF_8`.
	- I've replaced all the hard coded HTTP header names with Guava's `HttpHeaders`.
	- The `validateHost` method was scattered all over the place. Now it's only called in one place.
	- The `validHosts` `List` has been replaced with a `Set`, which should be much faster at doing `contains`.
	- I've created a shared `XmlMapper` in `RecurlyObject`, and it's used by `RecurlyClient` and `Notification`. There are already `TODO` comments for it, and it actually supports our use case at SaaSquatch. We need to be able to create "lightweight" `RecurlyClient`s to use multiple API keys. The `createHttpClient` method can already be overridden so I can already use a shared instance of the HTTP client, the `XmlMapper` is just the next and final thing that prevents us from creating a "lightweight" `RecurlyClient`.
- I don't know if you already know this but a while back I actually created a ticket (not a pull request) with a different approach of doing an API key agnostic `RecurlyClient`. I do agree that those changes were finicky and hard to verify. I do not believe that this pull request has those problems.
- And my final point is that, even though this is a pretty big pull request, there are 0 breaking changes on the API layer, and I have also attempted to maintain existing implicit behaviors. And again, this is the version of this library that we at SaaSquatch have been using.

If you have any questions or suggestions, please don't hesitate to ask.

Thanks!
