### PR TITLE
Add BACS support

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -128,7 +128,7 @@ public class RecurlyClient {
     private static final Logger log = LoggerFactory.getLogger(RecurlyClient.class);
 
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
-    public static final String RECURLY_API_VERSION = "2.26";
+    public static final String RECURLY_API_VERSION = "2.27";
 
     private static final String X_RATELIMIT_REMAINING_HEADER_NAME = "X-RateLimit-Remaining";
     private static final String X_RECORDS_HEADER_NAME = "X-Records";

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -31,8 +31,11 @@ public class BillingInfo extends RecurlyObject {
     @XmlTransient
     public static final String BILLING_INFO_RESOURCE = "/billing_info";
 
-    @XmlAttribute(name = "type")
+    @XmlElement(name = "type")
     private String type;
+
+    @XmlAttribute(name = "type")
+    private String attributeType;
 
     @XmlElement(name = "account")
     private Account account;
@@ -148,11 +151,14 @@ public class BillingInfo extends RecurlyObject {
     @XmlElement(name = "iban")
     private String iban;
 
+    @XmlElement(name = "sort_code")
+    private String sortCode;
+
     public String getType() {
-        return type;
+        return this.type == null ? this.attributeType : this.type;
     }
 
-    protected void setType(final Object type) {
+    public void setType(final Object type) {
         this.type = stringOrNull(type);
     }
 
@@ -475,6 +481,14 @@ public class BillingInfo extends RecurlyObject {
         this.iban = stringOrNull(iban);
     }
 
+    public String getSortCode() {
+        return sortCode;
+    }
+
+    public void setSortCode(final Object sortCode) {
+        this.sortCode = stringOrNull(sortCode);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -521,6 +535,7 @@ public class BillingInfo extends RecurlyObject {
         sb.append(", amazonRegion='").append(amazonRegion).append('\'');
         sb.append(", threeDSecureActionResultTokenId='").append(threeDSecureActionResultTokenId).append('\'');
         sb.append(", iban='").append(iban).append('\'');
+        sb.append(", sortCode='").append(sortCode).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -637,7 +652,13 @@ public class BillingInfo extends RecurlyObject {
         if (transactionType != null ? !transactionType.equals(that.transactionType) : that.transactionType != null) {
             return false;
         }
-        if(iban != null ? !iban.equals(that.iban) : that.iban != null) {
+        if (iban != null ? !iban.equals(that.iban) : that.iban != null) {
+            return false;
+        }
+        if (type != null ? !type.equals(that.type) : that.type != null) {
+            return false;
+        }
+        if (sortCode != null ? !sortCode.equals(that.sortCode) : that.sortCode != null ) {
             return false;
         }
 
@@ -682,7 +703,8 @@ public class BillingInfo extends RecurlyObject {
                 amazonRegion,
                 threeDSecureActionResultTokenId,
                 transactionType,
-                iban
+                iban,
+                sortCode
         );
     }
 }

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -597,11 +597,25 @@ public class TestRecurlyClient {
         final BillingInfo billingInfoData = TestUtils.createRandomIbanBillingInfo();
         try {
             final Account account = recurlyClient.createAccount(accountData);
-            billingInfoData.setAccount(account);
-            recurlyClient.createOrUpdateBillingInfo(billingInfoData);
+            recurlyClient.createOrUpdateBillingInfo(account.getAccountCode(), billingInfoData);
             Assert.fail("Should have thrown transaction exception");
         } catch(TransactionErrorException e) {
             Assert.assertEquals(e.getErrors().getTransactionError().getErrorCode(), "no_gateway");
+            Assert.assertEquals(e.getErrors().getTransactionError().getMerchantMessage(), "There is no available payment gateway on your account capable of processing this transaction.");
+        }
+    }
+
+    @Test(groups = "integration")
+    public void testCreateAccountBacsBillingInfo() throws Exception {
+        final Account accountData = TestUtils.createRandomAccount();
+        final BillingInfo billingInfoData = TestUtils.createRandomBacsBillingInfo();
+        try {
+            final Account account = recurlyClient.createAccount(accountData);
+            recurlyClient.createOrUpdateBillingInfo(account.getAccountCode(), billingInfoData);
+            Assert.fail("Should have thrown transaction exception");
+        } catch(TransactionErrorException e) {
+            Assert.assertEquals(e.getErrors().getTransactionError().getErrorCode(), "no_gateway");
+            Assert.assertEquals(e.getErrors().getTransactionError().getMerchantMessage(), "There is no available payment gateway on your account capable of processing this transaction.");
         }
     }
 

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -431,16 +431,51 @@ public class TestUtils {
         return info;
     }
 
+    /**
+     * Creates a random {@link com.ning.billing.recurly.model.BillingInfo} object for testing use.
+     *
+     * @return The random {@link com.ning.billing.recurly.model.BillingInfo} object
+     */
     public static BillingInfo createRandomIbanBillingInfo() {
         return createRandomIbanBillingInfo(randomSeed());
     }
 
+    /**
+     * Creates a random {@link com.ning.billing.recurly.model.BillingInfo} object for testing use given a seed
+     *
+     * @param seed The RNG seed
+     * @return The random {@link com.ning.billing.recurly.model.BillingInfo} object
+     */
     public static BillingInfo createRandomIbanBillingInfo(final int seed) {
         final BillingInfo info = new BillingInfo();
         info.setIban("FR1420041010050500013M02606");
         info.setNameOnAccount(randomAlphaNumericString(10, seed));
         return info;
     }
+
+        /**
+     * Creates a random {@link com.ning.billing.recurly.model.BillingInfo} object for testing use.
+     *
+     * @return The random {@link com.ning.billing.recurly.model.BillingInfo} object
+     */
+    public static BillingInfo createRandomBacsBillingInfo() {
+      return createRandomBacsBillingInfo(randomSeed());
+  }
+
+  /**
+   * Creates a random {@link com.ning.billing.recurly.model.BillingInfo} object for testing use given a seed
+   *
+   * @param seed The RNG seed
+   * @return The random {@link com.ning.billing.recurly.model.BillingInfo} object
+   */
+  public static BillingInfo createRandomBacsBillingInfo(final int seed) {
+      final BillingInfo info = new BillingInfo();
+      info.setNameOnAccount("BACS");
+      info.setAccountNumber("12345678");
+      info.setType("bacs");
+      info.setSortCode("200000");
+      return info;
+  }
 
     /**
      * Creates a random {@link com.ning.billing.recurly.model.Item} object for testing use.

--- a/src/test/java/com/ning/billing/recurly/model/TestBillingInfo.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestBillingInfo.java
@@ -59,6 +59,7 @@ public class TestBillingInfo extends TestModelBase {
         billingInfo.setGatewayCode(randomString());
         billingInfo.setAmazonBillingAgreementId(randomString());
         billingInfo.setAmazonRegion(randomString());
+        billingInfo.setSortCode("200000");
 
         final String xml = xmlMapper.writeValueAsString(billingInfo);
         Assert.assertEquals(xmlMapper.readValue(xml, BillingInfo.class), billingInfo);


### PR DESCRIPTION
Added `sort_code` and `type` fields to support BACS payment type.

Previously, the `type` field was a xml attribute with a protected setter. When BACS is the payment option, however, `type` must accept `"bacs"` as a value.