### PR TITLE
URL encoding cleanup

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -2544,7 +2544,7 @@ public class RecurlyClient {
                 return null;
             }
 
-            final Header locationHeader = response.getFirstHeader("Location");
+            final Header locationHeader = response.getFirstHeader(HttpHeaders.LOCATION);
             String location = locationHeader == null ? null : locationHeader.getValue();
             if (clazz == Coupons.class && location != null && !location.isEmpty()) {
                 final RecurlyObjects recurlyObjects = new Coupons();

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -2562,7 +2562,7 @@ public class RecurlyClient {
             }
 
             final Header locationHeader = response.getFirstHeader(HttpHeaders.LOCATION);
-            String location = locationHeader == null ? null : locationHeader.getValue();
+            final String location = locationHeader == null ? null : locationHeader.getValue();
             if (clazz == Coupons.class && location != null && !location.isEmpty()) {
                 final RecurlyObjects recurlyObjects = new Coupons();
                 recurlyObjects.setRecurlyClient(this);


### PR DESCRIPTION
I recently noticed that Apache Commons Codec is a transitive dependency of Apache HttpClient, so I switched the not-so-great String replace implementation of URL encoding to using the `URLCodec` class in Apache Commons Codec, which is a lot faster than Java's built-in `URLEncoder` even without the String replace.