### PR TITLE
Support items on subscriptions

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -128,7 +128,7 @@ public class RecurlyClient {
     private static final Logger log = LoggerFactory.getLogger(RecurlyClient.class);
 
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
-    public static final String RECURLY_API_VERSION = "2.26";
+    public static final String RECURLY_API_VERSION = "2.27";
 
     private static final String X_RATELIMIT_REMAINING_HEADER_NAME = "X-RateLimit-Remaining";
     private static final String X_RECORDS_HEADER_NAME = "X-Records";

--- a/src/main/java/com/ning/billing/recurly/model/Plan.java
+++ b/src/main/java/com/ning/billing/recurly/model/Plan.java
@@ -116,6 +116,9 @@ public class Plan extends RecurlyObject {
     @XmlElement(name = "tax_code")
     private String taxCode;
 
+    @XmlElement(name = "allow_any_item_on_subscriptions")
+    private Boolean allowAnyItemOnSubscriptions;
+
     public String getPlanCode() {
         return planCode;
     }
@@ -340,6 +343,14 @@ public class Plan extends RecurlyObject {
         this.taxCode = stringOrNull(taxCode);
     }
 
+    public Boolean getAllowAnyItemOnSubscriptions() {
+        return this.allowAnyItemOnSubscriptions;
+    }
+
+    public void setAllowAnyItemOnSubscriptions(final Object allowAnyItemOnSubscriptions) {
+        this.allowAnyItemOnSubscriptions = booleanOrNull(allowAnyItemOnSubscriptions);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -372,6 +383,7 @@ public class Plan extends RecurlyObject {
         sb.append(", autoRenew=").append(autoRenew);
         sb.append(", taxExempt=").append(taxExempt);
         sb.append(", taxCode=").append(taxCode);
+        sb.append(", allowAnyItemOnSubscriptions=").append(allowAnyItemOnSubscriptions);
         sb.append('}');
         return sb.toString();
     }
@@ -467,6 +479,9 @@ public class Plan extends RecurlyObject {
         if (taxCode != null ? taxCode.compareTo(plan.taxCode) != 0: plan.taxCode != null) {
             return false;
         }
+        if (allowAnyItemOnSubscriptions != null ? allowAnyItemOnSubscriptions.compareTo(plan.allowAnyItemOnSubscriptions) != 0: plan.allowAnyItemOnSubscriptions != null) {
+            return false;
+        }
 
         return true;
     }
@@ -501,7 +516,8 @@ public class Plan extends RecurlyObject {
                 trialRequiresBillingInfo,
                 autoRenew,
                 taxExempt,
-                taxCode
+                taxCode,
+                allowAnyItemOnSubscriptions
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionAddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionAddOn.java
@@ -34,6 +34,9 @@ public class SubscriptionAddOn extends AbstractAddOn {
     @XmlElement(name = "gateway_code")
     private String gatewayCode;
 
+    @XmlElement(name = "add_on_source")
+    private String addOnSource;
+
     public Integer getUnitAmountInCents() {
         return unitAmountInCents;
     }
@@ -58,12 +61,21 @@ public class SubscriptionAddOn extends AbstractAddOn {
         this.gatewayCode = stringOrNull(gatewayCode);
     }
 
+    public String getAddOnSource() {
+        return addOnSource;
+    }
+
+    public void setAddOnSource(final Object addOnSource) {
+        this.addOnSource = stringOrNull(addOnSource);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("SubscriptionAddOn{");
         sb.append("unitAmountInCents=").append(unitAmountInCents);
         sb.append(", quantity=").append(quantity);
         sb.append(", gatewayCode=").append(gatewayCode);
+        sb.append(", addOnSource=").append(addOnSource);
         sb.append('}');
         return sb.toString();
     }
@@ -84,6 +96,9 @@ public class SubscriptionAddOn extends AbstractAddOn {
         if (gatewayCode != null ? !gatewayCode.equals(addOn.gatewayCode) : addOn.gatewayCode != null) {
             return false;
         }
+        if (addOnSource != null ? !addOnSource.equals(addOn.addOnSource) : addOn.addOnSource != null) {
+            return false;
+        }
 
         return true;
     }
@@ -93,7 +108,8 @@ public class SubscriptionAddOn extends AbstractAddOn {
         return Objects.hashCode(
                 unitAmountInCents,
                 quantity,
-                gatewayCode
+                gatewayCode,
+                addOnSource
         );
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -154,6 +154,12 @@ public class TestSubscription extends TestModelBase {
                                         "      <quantity>3</quantity>\n" +
                                         "      <unit_amount_in_cents>200</unit_amount_in_cents>\n" +
                                         "    </subscription_add_on>\n" +
+                                        "    <subscription_add_on>\n" +
+                                        "      <add_on_code>mockitem</add_on_code>\n" +
+                                        "      <quantity>1</quantity>\n" +
+                                        "      <unit_amount_in_cents>199</unit_amount_in_cents>\n" +
+                                        "      <add_on_source>item</add_on_source>\n" +
+                                        "    </subscription_add_on>\n" +
                                         "   </subscription_add_ons>" +
                                         "</subscription>";
 
@@ -265,7 +271,7 @@ public class TestSubscription extends TestModelBase {
     }
 
     private void verifySubscriptionAddons(final Subscription subscription) {
-        Assert.assertEquals(subscription.getAddOns().size(), 2);
+        Assert.assertEquals(subscription.getAddOns().size(), 3);
         Assert.assertEquals(subscription.getAddOns().get(0).getAddOnCode(), "extra_users");
         Assert.assertEquals(subscription.getAddOns().get(0).getQuantity(), (Integer) 2);
         Assert.assertEquals(subscription.getAddOns().get(0).getUnitAmountInCents(), (Integer) 1000);
@@ -274,6 +280,9 @@ public class TestSubscription extends TestModelBase {
         Assert.assertEquals(subscription.getAddOns().get(1).getAddOnCode(), "extra_ip");
         Assert.assertEquals(subscription.getAddOns().get(1).getQuantity(), (Integer) 3);
         Assert.assertEquals(subscription.getAddOns().get(1).getUnitAmountInCents(), (Integer) 200);
+        Assert.assertEquals(subscription.getAddOns().get(2).getAddOnCode(), "mockitem");
+        Assert.assertEquals(subscription.getAddOns().get(2).getAddOnSource(), "item");
+        Assert.assertEquals(subscription.getAddOns().get(2).getUnitAmountInCents(), (Integer) 199);
     }
 
     private void verifySubscriptionCustomFields(final Subscription subscription) {


### PR DESCRIPTION
This PR adds support for items on subscriptions, where merchants may now associate a subscription add-on with an item in their catalog.

`allow_any_item_on_subscriptions` has been added to the `Plan` class. It is used to determine whether items can be assigned as add-ons to individual subscriptions. If `true`, items can be assigned as add-ons to individual subscription add-ons. If `false`, only plan add-ons can be used.

`add_on_source`, added to the `SubscriptionAddOn` class, is used to determine where the associated add-on data is pulled from. If this value is set to `plan_add_on` or left blank, then add-on data will be pulled from the plan's add-ons. If the associated  `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to `item`, then the associated add-on data will be pulled from the site's item catalog.

Code example:
```java
final Subscription subscriptionData = new Subscription();
subscriptionData.setPlanCode(plan.getPlanCode());
subscriptionData.setCurrency("USD");
subscriptionData.setAccount(account);

final SubscriptionAddOns addOns = new SubscriptionAddOns();

// create sub add-on from existing add-on
final SubscriptionAddOn subAO1 = new SubscriptionAddOn();
subAO1.setAddOnCode(addon1.getAddOnCode());

// create sub add-on from item
final SubscriptionAddOn subAO2 = new SubscriptionAddOn();
subAO2.setAddOnCode(item.getItemCode());
subAO2.setAddOnSource("item");
subAO2.setUnitAmountInCents(299);

addOns.add(subAO1);
addOns.add(subAO2);
subscriptionData.setAddOns(addOns);
client.createSubscription(subscriptionData);
```