### PR TITLE
Cache user agent + reduce Guava beta API usage

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -74,8 +74,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.StandardSystemProperty;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.BaseEncoding;
-import com.google.common.io.CharSource;
-import com.google.common.io.Resources;
 import com.google.common.net.HttpHeaders;
 import com.ning.billing.recurly.util.http.SslUtils;
 
@@ -109,6 +107,7 @@ import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.ConnectException;
@@ -210,7 +209,7 @@ public class RecurlyClient {
     public RecurlyClient(final String apiKey, final String scheme, final String host, final int port, final String version) {
         this.key = BaseEncoding.base64().encode(apiKey.getBytes(Charsets.UTF_8));
         this.baseUrl = String.format("%s://%s:%d/%s", scheme, host, port, version);
-        this.userAgent = buildUserAgent();
+        this.userAgent = UserAgentHolder.userAgent;
         this.rateLimitRemaining = -1;
         loggerWarning();
     }
@@ -2670,18 +2669,19 @@ public class RecurlyClient {
         return userAgent;
     }
 
-    private String buildUserAgent() {
+    private static String buildUserAgent() {
         final String defaultVersion = "0.0.0";
         final String defaultJavaVersion = "0.0.0";
 
         try {
             final Properties gitRepositoryState = new Properties();
-            final URL resourceURL = Resources.getResource(GIT_PROPERTIES_FILE);
-            final CharSource charSource = Resources.asCharSource(resourceURL, Charsets.UTF_8);
+            final URL resourceURL = MoreObjects.firstNonNull(
+                    Thread.currentThread().getContextClassLoader(),
+                    RecurlyClient.class.getClassLoader()).getResource(GIT_PROPERTIES_FILE);
 
             Reader reader = null;
             try {
-                reader = charSource.openStream();
+                reader = new InputStreamReader(resourceURL.openStream(), Charsets.UTF_8);
                 gitRepositoryState.load(reader);
             } finally {
                 if (reader != null) {
@@ -2698,7 +2698,7 @@ public class RecurlyClient {
     }
 
     @VisibleForTesting
-    String getVersionFromGitRepositoryState(final Properties gitRepositoryState) {
+    static String getVersionFromGitRepositoryState(final Properties gitRepositoryState) {
         final String gitDescribe = gitRepositoryState.getProperty(GIT_COMMIT_ID_DESCRIBE_SHORT);
         if (gitDescribe == null) {
             return null;
@@ -2714,6 +2714,17 @@ public class RecurlyClient {
     private static String urlEncode(String s) {
         return new String(URLCodec.encodeUrl(RFC_3986_SAFE_CHARS, s.getBytes(Charsets.UTF_8)),
                 Charsets.UTF_8);
+    }
+
+    /**
+     * Class that holds the cached user agent. This class exists so
+     * {@link RecurlyClient#buildUserAgent()} will only run when the first instance
+     * of {@link RecurlyClient} is created.
+     */
+    private static class UserAgentHolder {
+
+        private static final String userAgent = buildUserAgent();
+
     }
 
 }

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClientUserAgent.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClientUserAgent.java
@@ -46,19 +46,19 @@ public class TestRecurlyClientUserAgent {
     public void testUnreleasedVersion() throws Exception {
         final Properties gitRepositoryState = new Properties();
         gitRepositoryState.put(RecurlyClient.GIT_COMMIT_ID_DESCRIBE_SHORT, "recurly-java-library-0.2.4-12");
-        Assert.assertEquals(recurlyClient.getVersionFromGitRepositoryState(gitRepositoryState), "0.2.4");
+        Assert.assertEquals(RecurlyClient.getVersionFromGitRepositoryState(gitRepositoryState), "0.2.4");
     }
 
     @Test(groups = "fast")
     public void testReleasedVersion() throws Exception {
         final Properties gitRepositoryState = new Properties();
         gitRepositoryState.put(RecurlyClient.GIT_COMMIT_ID_DESCRIBE_SHORT, "recurly-java-library-0.2.5");
-        Assert.assertEquals(recurlyClient.getVersionFromGitRepositoryState(gitRepositoryState), "0.2.5");
+        Assert.assertEquals(RecurlyClient.getVersionFromGitRepositoryState(gitRepositoryState), "0.2.5");
     }
 
     @Test(groups = "fast")
     public void testEmptyGitRepositoryState() throws Exception {
         final Properties gitRepositoryState = new Properties();
-        Assert.assertNull(recurlyClient.getVersionFromGitRepositoryState(gitRepositoryState));
+        Assert.assertNull(RecurlyClient.getVersionFromGitRepositoryState(gitRepositoryState));
     }
 }


### PR DESCRIPTION
This pull request has 2 things.
1. The user agent is now being cached. Before whenever you created a new instance of `RecurlyClient`, it would unnecessarily perform some file IO to build the user agent, and you would get the same result every time.
2. I've replaced the usage of the `com.google.common.io.Resources` class, which is still marked as `@Beta` in Guava [as of July 1, 2020](https://github.com/google/guava/blob/d44669df2f1540ae52c278181377f0adea88f8fb/guava/src/com/google/common/io/Resources.java#L45). I know this library uses some other `@Beta` Guava class like `BaseEncoding` and `StandardSystemProperty`, but those classes are now out of beta in the latest version of Guava, so they should be stable.