### PR TITLE
Explicit locale in String.format

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -123,6 +123,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.BitSet;
 import java.util.List;
+import java.util.Locale;
 
 public class RecurlyClient {
 
@@ -209,7 +210,7 @@ public class RecurlyClient {
 
     public RecurlyClient(final String apiKey, final String scheme, final String host, final int port, final String version) {
         this.key = BaseEncoding.base64().encode(apiKey.getBytes(Charsets.UTF_8));
-        this.baseUrl = String.format("%s://%s:%d/%s", scheme, host, port, version);
+        this.baseUrl = String.format(Locale.ROOT, "%s://%s:%d/%s", scheme, host, port, version);
         this.userAgent = buildUserAgent();
         this.rateLimitRemaining = -1;
         loggerWarning();
@@ -2660,7 +2661,7 @@ public class RecurlyClient {
         host = host.substring(host.indexOf(".")+1);
 
         if (!validHosts.contains(host)) {
-            String exc = String.format("Attempted to make call to %s instead of Recurly", host);
+            String exc = String.format(Locale.ROOT, "Attempted to make call to %s instead of Recurly", host);
             throw new RuntimeException(exc);
         }
     }
@@ -2691,9 +2692,9 @@ public class RecurlyClient {
 
             final String version = MoreObjects.firstNonNull(getVersionFromGitRepositoryState(gitRepositoryState), defaultVersion);
             final String javaVersion = MoreObjects.firstNonNull(StandardSystemProperty.JAVA_VERSION.value(), defaultJavaVersion);
-            return String.format("KillBill/%s; %s", version, javaVersion);
+            return String.format(Locale.ROOT, "KillBill/%s; %s", version, javaVersion);
         } catch (final Exception e) {
-            return String.format("KillBill/%s; %s", defaultVersion, defaultJavaVersion);
+            return String.format(Locale.ROOT, "KillBill/%s; %s", defaultVersion, defaultJavaVersion);
         }
     }
 

--- a/src/main/java/com/ning/billing/recurly/RecurlyJs.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyJs.java
@@ -27,6 +27,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 public class RecurlyJs {
@@ -83,8 +84,8 @@ public class RecurlyJs {
     public static String getRecurlySignature(String privateJsKey, Long unixTime, String nonce, List<String> extraParams) {
         // Mandatory parameters shared by all signatures (as per spec)
         extraParams = (extraParams == null) ? new ArrayList<String>() : extraParams;
-        extraParams.add(String.format(PARAMETER_FORMAT, TIMESTAMP_PARAMETER, unixTime));
-        extraParams.add(String.format(PARAMETER_FORMAT, NONCE_PARAMETER, nonce));
+        extraParams.add(String.format(Locale.ROOT, PARAMETER_FORMAT, TIMESTAMP_PARAMETER, unixTime));
+        extraParams.add(String.format(Locale.ROOT, PARAMETER_FORMAT, NONCE_PARAMETER, nonce));
         String protectedParams = Joiner.on(PARAMETER_SEPARATOR).join(extraParams);
 
         return generateRecurlyHMAC(privateJsKey, protectedParams) + "|" + protectedParams;

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import com.ning.billing.recurly.model.Account;
@@ -98,11 +99,11 @@ public class TestRecurlyClient {
             Assert.fail("You need to set your Recurly api key to run integration tests:" +
                         " -Dkillbill.payment.recurly.apiKey=...");
         }
-        
+
         if (subDomainTemp == null) {
           subDomainTemp = "api";
         }
-        
+
         final String subDomain = subDomainTemp;
 
         recurlyClient = new RecurlyClient(apiKey, subDomain);
@@ -267,13 +268,13 @@ public class TestRecurlyClient {
             // Fetch the corresponding invoice
             final Invoice subInvoice = subscriptionWithAddons.getInvoice();
             Assert.assertNotNull(subInvoice);
-            
+
             // Refetch the invoice using the getInvoice method
             final String invoiceID = subInvoice.getId();
             final Invoice gotInvoice = recurlyClient.getInvoice(invoiceID);
 
             Assert.assertEquals(subInvoice.hashCode(), gotInvoice.hashCode());
-            
+
             // Remove all addons
             final SubscriptionUpdate subscriptionUpdate = new SubscriptionUpdate();
             subscriptionUpdate.setAddOns(new SubscriptionAddOns());
@@ -653,7 +654,7 @@ public class TestRecurlyClient {
     @Test(groups = "integration")
     public void testCreateItem() throws Exception {
         final Item itemData = TestUtils.createRandomItem();
-        
+
         try {
             // Create an item
             final Item item = recurlyClient.createItem(itemData);
@@ -947,7 +948,7 @@ public class TestRecurlyClient {
 
             // Create a plan
             final Plan plan = recurlyClient.createPlan(planData);
-            
+
             // Set up a subscription to invoice
             final Subscription invoiceSubscription = new Subscription();
             invoiceSubscription.setPlanCode(plan.getPlanCode());
@@ -1414,7 +1415,7 @@ public class TestRecurlyClient {
     public void testBulkCoupons() throws Exception {
         final Coupon couponData = TestUtils.createRandomCoupon();
         couponData.setType(Coupon.Type.bulk);
-        couponData.setUniqueCodeTemplate(String.format("'%s'99999", couponData.getCouponCode()));
+        couponData.setUniqueCodeTemplate(String.format(Locale.ROOT, "'%s'99999", couponData.getCouponCode()));
 
         Coupon coupon = recurlyClient.createCoupon(couponData);
 
@@ -1987,7 +1988,7 @@ public class TestRecurlyClient {
 
         billingInfoData.setAccount(null); // null out random account fixture
         accountData.setBillingInfo(billingInfoData); // add the billing info to account data
- 
+
         try {
             final Plan plan = recurlyClient.createPlan(planData);
             final GiftCard purchasedGiftCard = recurlyClient.purchaseGiftCard(giftCardData);

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyJs.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyJs.java
@@ -21,6 +21,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Locale;
 
 public class TestRecurlyJs {
 
@@ -47,8 +48,8 @@ public class TestRecurlyJs {
         final String expected = "aa2743b6e686bf50940881733f2da37b551804f5|subscription%5Bplan_code%5D=testsub&account%5Baccount_code%5D=johndoe123&timestamp=1329942896&nonce=unique";
 
         ArrayList<String> customParams = new ArrayList<String>();
-        customParams.add(String.format(PARAMETER_FORMAT, SUBSCRIPTION_PARAMETER, "testsub"));
-        customParams.add(String.format(PARAMETER_FORMAT, ACCOUNT_CODE_PARAMETER, "johndoe123"));
+        customParams.add(String.format(Locale.ROOT, PARAMETER_FORMAT, SUBSCRIPTION_PARAMETER, "testsub"));
+        customParams.add(String.format(Locale.ROOT, PARAMETER_FORMAT, ACCOUNT_CODE_PARAMETER, "johndoe123"));
 
         String actual = RecurlyJs.getRecurlySignature(jsPrivateKey, mockUnixTime, mockNonce, customParams);
         Assert.assertEquals(actual, expected);


### PR DESCRIPTION
The `String.format(String, Object...)` method is environment dependent and uses the system's default locale.
Here's a simple example of how that might go wrong:
```java
public static void main(String[] args) {
    System.out.println(String.format(new Locale("hi", "IN"), "%d", 1234));
}
```
This will actually print `१२३४` instead of `1234`.