### PR TITLE
BECS support

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -130,7 +130,7 @@ public class RecurlyClient {
     private static final Logger log = LoggerFactory.getLogger(RecurlyClient.class);
 
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
-    public static final String RECURLY_API_VERSION = "2.27";
+    public static final String RECURLY_API_VERSION = "2.28";
 
     private static final String X_RATELIMIT_REMAINING_HEADER_NAME = "X-RateLimit-Remaining";
     private static final String X_RECORDS_HEADER_NAME = "X-Records";

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -154,6 +154,9 @@ public class BillingInfo extends RecurlyObject {
     @XmlElement(name = "sort_code")
     private String sortCode;
 
+    @XmlElement(name = "bsb_code")
+    private String bsbCode;
+
     public String getType() {
         return this.type == null ? this.attributeType : this.type;
     }
@@ -489,6 +492,14 @@ public class BillingInfo extends RecurlyObject {
         this.sortCode = stringOrNull(sortCode);
     }
 
+    public String getBsbCode() {
+        return bsbCode;
+    }
+
+    public void setBsbCode(final Object bsbCode) {
+        this.bsbCode = stringOrNull(bsbCode);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -536,6 +547,7 @@ public class BillingInfo extends RecurlyObject {
         sb.append(", threeDSecureActionResultTokenId='").append(threeDSecureActionResultTokenId).append('\'');
         sb.append(", iban='").append(iban).append('\'');
         sb.append(", sortCode='").append(sortCode).append('\'');
+        sb.append(", bsbCode='").append(bsbCode).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -661,6 +673,9 @@ public class BillingInfo extends RecurlyObject {
         if (sortCode != null ? !sortCode.equals(that.sortCode) : that.sortCode != null ) {
             return false;
         }
+        if (bsbCode != null ? !bsbCode.equals(that.bsbCode) : that.bsbCode != null) {
+            return false;
+        }
 
         return true;
     }
@@ -704,7 +719,8 @@ public class BillingInfo extends RecurlyObject {
                 threeDSecureActionResultTokenId,
                 transactionType,
                 iban,
-                sortCode
+                sortCode,
+                bsbCode
         );
     }
 }

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -621,6 +621,20 @@ public class TestRecurlyClient {
     }
 
     @Test(groups = "integration")
+    public void testCreateAccountBecsBillingInfo() throws Exception {
+        final Account accountData = TestUtils.createRandomAccount();
+        final BillingInfo billingInfoData = TestUtils.createRandomBecsBillingInfo();
+        try {
+            final Account account = recurlyClient.createAccount(accountData);
+            recurlyClient.createOrUpdateBillingInfo(account.getAccountCode(), billingInfoData);
+            Assert.fail("Should have thrown transaction exception");
+        } catch(TransactionErrorException e) {
+            Assert.assertEquals(e.getErrors().getTransactionError().getErrorCode(), "no_gateway");
+            Assert.assertEquals(e.getErrors().getTransactionError().getMerchantMessage(), "There is no available payment gateway on your account capable of processing this transaction.");
+        }
+    }
+
+    @Test(groups = "integration")
     public void testGetAccountBalance() throws Exception {
         final Account accountData = TestUtils.createRandomAccount();
         final BillingInfo billingInfoData = TestUtils.createRandomBillingInfo();

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -453,29 +453,57 @@ public class TestUtils {
         return info;
     }
 
-        /**
+    /**
      * Creates a random {@link com.ning.billing.recurly.model.BillingInfo} object for testing use.
      *
      * @return The random {@link com.ning.billing.recurly.model.BillingInfo} object
      */
     public static BillingInfo createRandomBacsBillingInfo() {
       return createRandomBacsBillingInfo(randomSeed());
-  }
+    }
 
-  /**
-   * Creates a random {@link com.ning.billing.recurly.model.BillingInfo} object for testing use given a seed
-   *
-   * @param seed The RNG seed
-   * @return The random {@link com.ning.billing.recurly.model.BillingInfo} object
-   */
-  public static BillingInfo createRandomBacsBillingInfo(final int seed) {
-      final BillingInfo info = new BillingInfo();
-      info.setNameOnAccount("BACS");
-      info.setAccountNumber("12345678");
-      info.setType("bacs");
-      info.setSortCode("200000");
-      return info;
-  }
+    /**
+     * Creates a random {@link com.ning.billing.recurly.model.BillingInfo} object for testing use given a seed
+     *
+     * @param seed The RNG seed
+     * @return The random {@link com.ning.billing.recurly.model.BillingInfo} object
+     */
+    public static BillingInfo createRandomBacsBillingInfo(final int seed) {
+        final BillingInfo info = new BillingInfo();
+        info.setNameOnAccount("BACS");
+        info.setAccountNumber("12345678");
+        info.setType("bacs");
+        info.setSortCode("200000");
+        return info;
+    }
+
+    /**
+     * Creates a random {@link com.ning.billing.recurly.model.BillingInfo} object for testing use.
+     *
+     * @return The random {@link com.ning.billing.recurly.model.BillingInfo} object
+     */
+    public static BillingInfo createRandomBecsBillingInfo() {
+      return createRandomBecsBillingInfo(randomSeed());
+    }
+
+    /**
+     * Creates a random {@link com.ning.billing.recurly.model.BillingInfo} object for testing use given a seed
+     *
+     * @param seed The RNG seed
+     * @return The random {@link com.ning.billing.recurly.model.BillingInfo} object
+     */
+    public static BillingInfo createRandomBecsBillingInfo(final int seed) {
+        final BillingInfo info = new BillingInfo();
+        info.setNameOnAccount("BECS");
+        info.setAddress1("123 Paper Street");
+        info.setCity("Adelaide");
+        info.setZip("12345");
+        info.setCountry("AU");
+        info.setAccountNumber("12345678");
+        info.setType("becs");
+        info.setBsbCode("082-082");
+        return info;
+    }
 
     /**
      * Creates a random {@link com.ning.billing.recurly.model.Item} object for testing use.

--- a/src/test/java/com/ning/billing/recurly/model/TestBillingInfo.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestBillingInfo.java
@@ -60,6 +60,7 @@ public class TestBillingInfo extends TestModelBase {
         billingInfo.setAmazonBillingAgreementId(randomString());
         billingInfo.setAmazonRegion(randomString());
         billingInfo.setSortCode("200000");
+        billingInfo.setBsbCode("082-082");
 
         final String xml = xmlMapper.writeValueAsString(billingInfo);
         Assert.assertEquals(xmlMapper.readValue(xml, BillingInfo.class), billingInfo);


### PR DESCRIPTION
Completed:

- Added `bsb_code` field

Affects the following endpoints:
- `PUT /v2/accounts/{account_id}/billing_info`
- `PUT /v2/accounts/{account_id}`
- `POST /v2/accounts`
- `POST /v2/purchases`
- `POST /v2/purchases/preview`
- `POST /v2/subscriptions`

To create billing_info with BECS:
```java
final BillingInfo billingInfo = new BillingInfo();

billingInfo.setAccountNumber("12345678");
billingInfo.setType("becs");
billingInfo.setNameOnAccount("BECS Test");
billingInfo.setAddress1("125 Paper Street");
billingInfo.setCity("Adelaide");
billingInfo.setZip("12345");
billingInfo.setCountry("AU");
billingInfo.setType("becs");
billingInfo.setBsbCode("082-082");

client.createOrUpdateBillingInfo(account.getAccountCode(), billingInfo);
```