### PR TITLE
Re-throw SSLException as ConnectionErrorException rather than return null

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -105,6 +105,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLException;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -2491,7 +2492,7 @@ public class RecurlyClient {
             return callRecurlyXmlContent(builder, clazz);
         } catch (IOException e) {
             if (e instanceof ConnectException || e instanceof NoHttpResponseException
-                    || e instanceof ConnectTimeoutException) {
+                    || e instanceof ConnectTimeoutException || e instanceof SSLException) {
                 // See https://github.com/killbilling/recurly-java-library/issues/185
                 throw new ConnectionErrorException(e);
             }


### PR DESCRIPTION
## What

- Add `SSLException` to the subset of `IOException` which throw `ConnectionErrorException` rather than warn and return null

## Why

- Currently, there is no way to handle `SSLException`, which may be ephemeral and retried, because the exception is swallowed
- Conceptually, `SSLException` is an ephemeral error at the connection level, so the inclusion makes sense
- Practically, most `IOException` instances which aren't re-thrown in this branch are XML-related
