### PR TITLE
Enable updating tiers on subscription add-ons

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/AbstractAddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/AbstractAddOn.java
@@ -20,6 +20,7 @@ package com.ning.billing.recurly.model;
 import java.math.BigDecimal;
 
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import com.google.common.base.Objects;
 
 public class AbstractAddOn extends RecurlyObject {
@@ -38,6 +39,10 @@ public class AbstractAddOn extends RecurlyObject {
 
     @XmlElement(name = "revenue_schedule_type")
     private RevenueScheduleType revenueScheduleType;
+
+    @XmlElementWrapper(name = "tiers")
+    @XmlElement(name = "tier")
+    protected Tiers tiers;
 
     public String getAddOnCode() {
         return addOnCode;
@@ -79,6 +84,14 @@ public class AbstractAddOn extends RecurlyObject {
         this.revenueScheduleType = enumOrNull(RevenueScheduleType.class, revenueScheduleType, true);
     }
 
+    public Tiers getTiers() {
+        return tiers;
+    }
+
+    public void setTiers(final Tiers tiers) {
+        this.tiers = tiers;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("AbstractAddOn{");
@@ -87,6 +100,7 @@ public class AbstractAddOn extends RecurlyObject {
         sb.append("usageType='").append(usageType).append('\'');
         sb.append("usagePercentage=").append(usagePercentage);
         sb.append(", revenueScheduleType='").append(revenueScheduleType).append('\'');
+        sb.append(", tiers=").append(tiers);
         sb.append('}');
         return sb.toString();
     }
@@ -118,6 +132,10 @@ public class AbstractAddOn extends RecurlyObject {
             return false;
         }
 
+        if (tiers != null ? !tiers.equals(that.tiers) : that.tiers != null) {
+            return false;
+        }
+
         return true;
     }
 
@@ -128,7 +146,8 @@ public class AbstractAddOn extends RecurlyObject {
             measuredUnitId,
             usageType,
             usagePercentage,
-            revenueScheduleType
+            revenueScheduleType,
+            tiers
         );
                 
     }

--- a/src/main/java/com/ning/billing/recurly/model/AddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/AddOn.java
@@ -70,10 +70,6 @@ public class AddOn extends AbstractAddOn {
     @XmlElement(name = "tier_type")
     private String tierType;
 
-    @XmlElementWrapper(name = "tiers")
-    @XmlElement(name = "tier")
-    protected Tiers tiers;
-
     public String getName() {
         return name;
     }
@@ -181,14 +177,6 @@ public class AddOn extends AbstractAddOn {
         this.tierType = stringOrNull(tierType);
     }
 
-    public Tiers getTiers() {
-        return tiers;
-    }
-
-    public void setTiers(final Tiers tiers) {
-        this.tiers = tiers;
-    }
-
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("AddOn{");
@@ -205,7 +193,6 @@ public class AddOn extends AbstractAddOn {
         sb.append(", accountingCode=").append(accountingCode);
         sb.append(", optional=").append(optional);
         sb.append(", tierType=").append(tierType);
-        sb.append(", tiers=").append(tiers);
         sb.append('}');
         return sb.toString();
     }
@@ -258,10 +245,6 @@ public class AddOn extends AbstractAddOn {
             return false;
         }
 
-        if (tiers != null ? !tiers.equals(addOn.tiers) : addOn.tiers != null) {
-            return false;
-        }
-
         return true;
     }
 
@@ -280,8 +263,7 @@ public class AddOn extends AbstractAddOn {
                 taxCode,
                 accountingCode,
                 optional,
-                tierType,
-                tiers
+                tierType
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
@@ -20,6 +20,7 @@ package com.ning.billing.recurly.model;
 import com.google.common.base.Objects;
 
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 
 /**
  * Subscription object for update calls.
@@ -70,6 +71,10 @@ public class SubscriptionUpdate extends AbstractSubscription {
 
     @XmlElement(name = "auto_renew")
     private Boolean autoRenew;
+
+    @XmlElementWrapper(name = "subscription_add_ons")
+    @XmlElement(name = "subscription_add_on")
+    private SubscriptionAddOns addOns;
 
     public Timeframe getTimeframe() {
         return timeframe;
@@ -163,6 +168,14 @@ public class SubscriptionUpdate extends AbstractSubscription {
         this.autoRenew = booleanOrNull(autoRenew);
     }
 
+    public SubscriptionAddOns getAddOns() {
+        return addOns;
+    }
+
+    public void setAddOns(final SubscriptionAddOns addOns) {
+        this.addOns = addOns;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
@@ -209,6 +222,9 @@ public class SubscriptionUpdate extends AbstractSubscription {
         if (autoRenew != null ? !autoRenew.equals(that.autoRenew) : that.autoRenew != null) {
             return false;
         }
+        if (addOns != null ? !addOns.equals(that.addOns) : that.addOns != null) {
+          return false;
+        }
 
         return true;
     }
@@ -228,7 +244,8 @@ public class SubscriptionUpdate extends AbstractSubscription {
                 remainingBillingCycles,
                 importedTrial,
                 renewalBillingCycles,
-                autoRenew
+                autoRenew,
+                addOns
         );
     }
 }


### PR DESCRIPTION
- Relocate tiers to AbstractAddOn so it is accessible to both AddOn and SubscriptionAddOn
- Add SubscriptionAddOns to SubscriptionUpdate

Note that this change will trigger the following error because `unit_amount_in_cents` is sent as `Recurly::Money` instead of as an `Integer`. This error will be addressed in a separate ticket.
```
<error>
  <symbol>invalid_xml</symbol>
  <description>The provided XML was invalid.</description>
  <details>Tag &lt;unit_amount_in_cents&gt; must contain only text</details>
</error>
```

Sample code:
```java
Tier updateTierData = new Tier();
final RecurlyUnitCurrency updatePrice = new RecurlyUnitCurrency();
updatePrice.setUnitAmountUSD(99);
updateTierData.setUnitAmountInCents(updatePrice);
updateTierData.setEndingQuantity(19);
tiers.set(0, updateTierData);

SubscriptionAddOns updatedAddOnsData = new SubscriptionAddOns();

SubscriptionAddOn updatedAddOnData = new SubscriptionAddOn();
updatedAddOnData.setTiers(tiers);
updatedAddOnsData.add(updatedAddOnData);

final SubscriptionUpdate updateData = new SubscriptionUpdate();
updateData.setAddOns(updatedAddOnsData);

client.updateSubscription(subscription.getUuid(), updateData);
```