### PR TITLE
New endpoint to verify an account's billing information

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -27,6 +27,7 @@ import com.ning.billing.recurly.model.Adjustment;
 import com.ning.billing.recurly.model.AdjustmentRefund;
 import com.ning.billing.recurly.model.Adjustments;
 import com.ning.billing.recurly.model.BillingInfo;
+import com.ning.billing.recurly.model.BillingInfoVerification;
 import com.ning.billing.recurly.model.Coupon;
 import com.ning.billing.recurly.model.Coupons;
 import com.ning.billing.recurly.model.CreditPayments;
@@ -970,6 +971,34 @@ public class RecurlyClient {
      */
     public void clearBillingInfo(final String accountCode) {
         doDELETE(Account.ACCOUNT_RESOURCE + "/" + urlEncode(accountCode) + BillingInfo.BILLING_INFO_RESOURCE);
+    }
+
+    /**
+     * Verify an account's billing info
+     * <p>
+     * Verifies an account's billing info without providing a specific gateway. 
+     * @param accountCode recurly account id
+     * @return the transaction generated from the verification
+     */
+
+    public Transaction verifyBillingInfo(final String accountCode) {
+      final String url = Account.ACCOUNT_RESOURCE + "/" + urlEncode(accountCode) + BillingInfo.BILLING_INFO_RESOURCE + "/verify";
+      final BillingInfoVerification gateway = new BillingInfoVerification();
+      return doPOST(url, gateway, Transaction.class);
+    }
+
+    /**
+     * Verify an account's billing info
+     * <p>
+     * Verifies an account's billing info using a gateway code param. 
+     * @param accountCode recurly account id
+     * @param gatewayVerification BillingInfoVerification object used to verify billing info
+     * @return the transaction generated from the verification
+     */
+
+    public Transaction verifyBillingInfo(final String accountCode, final BillingInfoVerification gatewayVerification) {
+      final String url = Account.ACCOUNT_RESOURCE + "/" + urlEncode(accountCode) + BillingInfo.BILLING_INFO_RESOURCE + "/verify";
+      return doPOST(url, gatewayVerification, Transaction.class);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfoVerification.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfoVerification.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.Objects;
+
+@XmlRootElement(name = "verify")
+public class BillingInfoVerification extends RecurlyObject {
+
+    @XmlElement(name = "gateway_code")
+    private String gatewayCode;
+
+    public String getGatewayCode() {
+        return gatewayCode;
+    }
+
+    public void setGatewayCode(final Object gatewayCode) {
+        this.gatewayCode = stringOrNull(gatewayCode);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("Verify");
+        sb.append("{gatewayCode=").append(gatewayCode);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final BillingInfoVerification that = (BillingInfoVerification) o;
+
+        if (gatewayCode != null ? !gatewayCode.equals(that.gatewayCode) : that.gatewayCode != null) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(
+                gatewayCode
+        );
+    }
+
+}


### PR DESCRIPTION
If the account has billing information for anything other than a credit card, this will return 422, with an appropriate error message. If successful, this will return 200, with the transaction's data.
`gateway_code` (optional) is the code for the gateway to use for the verification. If unspecified, a gateway will be selected using the normal rules.

Example
```java
// verify without specifying gateway code to use 
client.verifyBillingInfo(account.getAccountCode());
// verify with a specific gateway code
final BillingInfoVerification gateway = new BillingInfoVerification();
gateway.setGatewayCode("gateway-code");
client.verifyBillingInfo(account.getAccountCode(), gateway);
```