### PR TITLE
Support item-specific coupons

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Coupon.java
+++ b/src/main/java/com/ning/billing/recurly/model/Coupon.java
@@ -113,6 +113,12 @@ public class Coupon extends RecurlyObject {
     private Boolean appliesToAllPlans;
 
     /**
+     * The coupon is valid for all items if true, defaults to false
+     */
+    @XmlElement(name = "applies_to_all_items")
+    private Boolean appliesToAllItems;
+
+    /**
      * If true, the coupon applies to the first invoice only
      * @deprecated Please use duration
      */
@@ -157,6 +163,18 @@ public class Coupon extends RecurlyObject {
     @XmlElement(name = "plan_code")
     @XmlElementWrapper(name = "plan_codes")
     private PlanCodes planCodes;
+
+    public ItemCodes getItemCodes() {
+        return itemCodes;
+    }
+
+    public void setItemCodes(final ItemCodes itemCodes) {
+        this.itemCodes = itemCodes;
+    }
+
+    @XmlElement(name = "item_code")
+    @XmlElementWrapper(name = "item_codes")
+    private ItemCodes itemCodes;
 
     /**
      * forever, single_use, or temporal. If single_use, the coupon applies to
@@ -360,6 +378,14 @@ public class Coupon extends RecurlyObject {
         this.appliesToAllPlans = booleanOrNull(appliesToAllPlans);
     }
 
+    public Boolean getAppliesToAllItems() {
+        return appliesToAllItems;
+    }
+
+    public void setAppliesToAllItems(final Object appliesToAllItems) {
+        this.appliesToAllItems = booleanOrNull(appliesToAllItems);
+    }
+
     public FreeTrialUnit getFreeTrialUnit() {
         return freeTrialUnit;
     }
@@ -511,10 +537,16 @@ public class Coupon extends RecurlyObject {
         if (appliesToAllPlans != null ? !appliesToAllPlans.equals(coupon.appliesToAllPlans) : coupon.appliesToAllPlans != null) {
             return false;
         }
+        if (appliesToAllItems != null ? !appliesToAllItems.equals(coupon.appliesToAllItems) : coupon.appliesToAllItems != null) {
+            return false;
+        }
         if (couponCode != null ? !couponCode.equals(coupon.couponCode) : coupon.couponCode != null) {
             return false;
         }
         if (planCodes != null ? !planCodes.equals(coupon.planCodes) : coupon.planCodes != null) {
+            return false;
+        }
+        if (itemCodes != null ? !itemCodes.equals(coupon.itemCodes) : coupon.itemCodes != null) {
             return false;
         }
         if (createdAt != null ? createdAt.compareTo(coupon.createdAt) != 0 : coupon.createdAt != null) {
@@ -586,10 +618,12 @@ public class Coupon extends RecurlyObject {
         return Objects.hashCode(
                 appliesForMonths,
                 appliesToAllPlans,
+                appliesToAllItems,
                 appliesToNonPlanCharges,
                 name,
                 couponCode,
                 planCodes,
+                itemCodes,
                 description,
                 discountType,
                 discountPercent,

--- a/src/main/java/com/ning/billing/recurly/model/ItemCode.java
+++ b/src/main/java/com/ning/billing/recurly/model/ItemCode.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Objects;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@JsonSerialize(using = ItemCodeSerializer.class)
+@XmlRootElement(name = "item_code")
+public class ItemCode extends RecurlyObject {
+
+    private String name;
+
+    public ItemCode() { /* Required for Jackson */ }
+
+    public ItemCode(final String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final Object name) {
+        this.name = stringOrNull(name);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ItemCode{");
+        sb.append("name=").append(name);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final ItemCode field = (ItemCode) o;
+
+        if (name != null ? !name.equals(field.name) : field.name != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name);
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/ItemCodeSerializer.java
+++ b/src/main/java/com/ning/billing/recurly/model/ItemCodeSerializer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class ItemCodeSerializer extends StdSerializer<ItemCode> {
+
+    public ItemCodeSerializer() {
+        this(null);
+    }
+
+    public ItemCodeSerializer(final Class<ItemCode> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(final ItemCode value, final JsonGenerator jgen, final SerializerProvider provider) throws IOException, JsonGenerationException {
+        jgen.writeObject(value.getName());
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/ItemCodes.java
+++ b/src/main/java/com/ning/billing/recurly/model/ItemCodes.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+@JsonSerialize(using = ItemCodesSerializer.class)
+@XmlRootElement(name = "item_codes")
+public class ItemCodes extends RecurlyObjects<ItemCode> {
+
+    @XmlTransient
+    private static final String PROPERTY_NAME = "item_code";
+
+    @JsonSetter(value = PROPERTY_NAME)
+    @Override
+    public void setRecurlyObject(final ItemCode value) {
+        super.setRecurlyObject(value);
+    }
+
+    @JsonIgnore
+    @Override
+    public ItemCodes getStart() {
+        return getStart(ItemCodes.class);
+    }
+
+    @JsonIgnore
+    @Override
+    public ItemCodes getNext() {
+        return getNext(ItemCodes.class);
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/ItemCodesSerializer.java
+++ b/src/main/java/com/ning/billing/recurly/model/ItemCodesSerializer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+public class ItemCodesSerializer extends StdSerializer<ItemCodes> {
+
+    public ItemCodesSerializer() {
+        this(null);
+    }
+
+    public ItemCodesSerializer(final Class<ItemCodes> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(final ItemCodes value, final JsonGenerator jgen, final SerializerProvider provider) throws IOException, JsonGenerationException {
+        for (final ItemCode itemCode : value) {
+            jgen.writeObject(itemCode);
+        }
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
@@ -284,6 +284,56 @@ public class TestCoupon extends TestModelBase {
     }
 
     @Test(groups = "fast")
+    public void testItemCodes() throws Exception {
+        // See https://dev.recurly.com/docs/list-active-coupons
+        final String couponData =
+                "<coupon href=\"https://api.recurly.com/v2/coupons/f8028\">" +
+                        "<redemptions href=\"https://api.recurly.com/v2/coupons/f8028/redemptions\"/>" +
+                        "<coupon_code>f8028</coupon_code>" +
+                        "<name>t</name>" +
+                        "<state>redeemable</state>" +
+                        "<description>test description.</description>" +
+                        "<discount_type>percent</discount_type>" +
+                        "<discount_percent type=\"integer\">100</discount_percent>" +
+                        "<invoice_description>invoice description</invoice_description>" +
+                        "<redeem_by_date type=\"dateTime\">2017-12-31T00:00:00Z</redeem_by_date>" +
+                        "<single_use type=\"boolean\">true</single_use>" +
+                        "<applies_for_months nil=\"nil\"/>" +
+                        "<max_redemptions type=\"integer\">200</max_redemptions>" +
+                        "<applies_to_all_plans type=\"boolean\">false</applies_to_all_plans>" +
+                        "<applies_to_all_items type=\"boolean\">false</applies_to_all_items>" +
+                        "<created_at type=\"dateTime\">2016-07-11T18:50:17Z</created_at>" +
+                        "<updated_at type=\"dateTime\">2016-07-11T18:50:17Z</updated_at>" +
+                        "<deleted_at nil=\"nil\"/>" +
+                        "<duration>single_use</duration>" +
+                        "<temporal_unit nil=\"nil\"/>" +
+                        "<temporal_amount nil=\"nil\"/>" +
+                        "<applies_to_non_plan_charges type=\"boolean\">false</applies_to_non_plan_charges>" +
+                        "<redemption_resource>account</redemption_resource>" +
+                        "<max_redemptions_per_account type=\"integer\">1</max_redemptions_per_account>" +
+                        "<coupon_type>single_code</coupon_type>" +
+                        "<plan_codes type=\"array\">" +
+                            "<plan_code>gold</plan_code>" +
+                            "<plan_code>platinum</plan_code>" +
+                        "</plan_codes>" +
+                        "<item_codes type=\"array\">" +
+                            "<item_code>best_item</item_code>" +
+                            "<item_code>second_best_item</item_code>" +
+                            "<item_code>just_okay_item</item_code>" +
+                        "</item_codes>" +
+                        "<a name=\"redeem\" href=\"https://api.recurly.com/v2/coupons/special/redeem\" method=\"post\"/>" +
+                    "</coupon>";
+
+        final Coupon coupon = xmlMapper.readValue(couponData, Coupon.class);
+
+        assertEquals(coupon.getAppliesToAllItems(), Boolean.FALSE);
+        assertEquals(coupon.getItemCodes().size(), 3);
+        assertTrue(coupon.getItemCodes().contains(new ItemCode("best_item")));
+        assertTrue(coupon.getItemCodes().contains(new ItemCode("second_best_item")));
+        assertTrue(coupon.getItemCodes().contains(new ItemCode("just_okay_item")));
+    }
+
+    @Test(groups = "fast")
     public void testHashCodeAndEquality() throws Exception {
         // create coupons of the same value but difference references
         Coupon coupon = TestUtils.createRandomCoupon(0);


### PR DESCRIPTION
Add `item_codes` and `applies_to_all_items` to Coupon

Example
```java
final Coupon coupon = new Coupon();
coupon.setCouponCode("special");
coupon.setName("Special");
coupon.setDiscountType("percent");
coupon.setDiscountPercent(10);

coupon.setAppliesToAllItems(false);

final ItemCodes itemCodes = new ItemCodes();
final ItemCode itemCode = new ItemCode();
itemCode.setName("one_item");
itemCodes.add(itemCode);
coupon.setItemCodes(itemCodes);

client.createCoupon(coupon);
```