### PR TITLE
Expose fields in response xml to developer

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/AddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/AddOn.java
@@ -37,6 +37,12 @@ public class AddOn extends AbstractAddOn {
     @XmlElement(name = "item_code")
     private String itemCode;
 
+    @XmlElement(name = "item_state")
+    private String itemState;
+
+    @XmlElement(name = "external_sku")
+    private String externalSku;
+
     @XmlElement(name = "display_quantity_on_hosted_page")
     private Boolean displayQuantityOnHostedPage;
 
@@ -84,6 +90,22 @@ public class AddOn extends AbstractAddOn {
 
     public void setItemCode(final Object itemCode) {
         this.itemCode = stringOrNull(itemCode);
+    }
+
+    public String getItemState() {
+        return itemState;
+    }
+
+    public void setItemState(final Object itemState) {
+        this.itemState = stringOrNull(itemState);
+    }
+
+    public String getExternalSku() {
+        return externalSku;
+    }
+
+    public void setExternalSku(final Object externalSku) {
+        this.externalSku = stringOrNull(externalSku);
     }
 
     public Boolean getDisplayQuantityOnHostedPage() {
@@ -182,6 +204,8 @@ public class AddOn extends AbstractAddOn {
         final StringBuilder sb = new StringBuilder("AddOn{");
         sb.append("name='").append(name).append('\'');
         sb.append(", itemCode='").append(itemCode).append('\'');
+        sb.append(", itemState='").append(itemState).append('\'');
+        sb.append(", externalSku='").append(externalSku).append('\'');
         sb.append(", measuredUnit='").append(measuredUnit).append('\'');
         sb.append(", addOnType='").append(addOnType).append('\'');
         sb.append(", displayQuantityOnHostedPage=").append(displayQuantityOnHostedPage);
@@ -240,7 +264,12 @@ public class AddOn extends AbstractAddOn {
         if (itemCode != null ? !itemCode.equals(addOn.itemCode) : addOn.itemCode != null) {
             return false;
         }
-
+        if (itemState != null ? !itemState.equals(addOn.itemState) : addOn.itemState != null) {
+            return false;
+        }  
+        if (externalSku != null ? !externalSku.equals(addOn.externalSku) : addOn.externalSku != null) {
+            return false;
+        }
         if (tierType != null ? !tierType.equals(addOn.tierType) : addOn.tierType != null) {
             return false;
         }
@@ -253,6 +282,8 @@ public class AddOn extends AbstractAddOn {
         return Objects.hashCode(
                 name,
                 itemCode,
+                itemState,
+                externalSku,
                 measuredUnit,
                 addOnType,
                 displayQuantityOnHostedPage,

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -151,6 +151,9 @@ public class BillingInfo extends RecurlyObject {
     @XmlElement(name = "iban")
     private String iban;
 
+    @XmlElement(name = "last_two")
+    private String lastTwo;
+
     @XmlElement(name = "sort_code")
     private String sortCode;
 
@@ -490,6 +493,14 @@ public class BillingInfo extends RecurlyObject {
         this.iban = stringOrNull(iban);
     }
 
+    public String getLastTwo() {
+        return lastTwo;
+    }
+
+    public void setLastTwo(final Object lastTwo) {
+        this.lastTwo = stringOrNull(lastTwo);
+    }
+
     public String getSortCode() {
         return sortCode;
     }
@@ -570,6 +581,7 @@ public class BillingInfo extends RecurlyObject {
         sb.append(", amazonRegion='").append(amazonRegion).append('\'');
         sb.append(", threeDSecureActionResultTokenId='").append(threeDSecureActionResultTokenId).append('\'');
         sb.append(", iban='").append(iban).append('\'');
+        sb.append(", lastTwo='").append(lastTwo).append('\'');
         sb.append(", sortCode='").append(sortCode).append('\'');
         sb.append(", bsbCode='").append(bsbCode).append('\'');
         sb.append(", taxIdentifier='").append(taxIdentifier).append('\'');
@@ -693,6 +705,9 @@ public class BillingInfo extends RecurlyObject {
         if (iban != null ? !iban.equals(that.iban) : that.iban != null) {
             return false;
         }
+        if (lastTwo != null ? !lastTwo.equals(that.lastTwo) : that.lastTwo != null) {
+            return false;
+        }
         if (type != null ? !type.equals(that.type) : that.type != null) {
             return false;
         }
@@ -751,6 +766,7 @@ public class BillingInfo extends RecurlyObject {
                 threeDSecureActionResultTokenId,
                 transactionType,
                 iban,
+                lastTwo,
                 sortCode,
                 bsbCode,
                 taxIdentifier,


### PR DESCRIPTION
- Because `item_state` and `external_sku` are included in the xml response for item-based add-ons, it would be good practice to expose this fields to the programmer.
- Same applies to `last_two` for `BillingInfo`