### PR TITLE
Lock down the github actions virtual environment to Ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     timeout-minutes: 10
     strategy:
       fail-fast: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     timeout-minutes: 10
     steps:
       - name: Checkout code


### PR DESCRIPTION
The `ubuntu-latest` recently updated from Ubuntu 18.04 to Ubuntu 20.04. As a part of that upgrade, the default java version changed from [1.8.0_282](https://github.com/actions/virtual-environments/blob/ubuntu18/20210131.1/images/linux/Ubuntu1804-README.md#java) to [11.0.10+9](https://github.com/actions/virtual-environments/blob/ubuntu20/20210412.1/images/linux/Ubuntu2004-README.md#java).

This addresses the `error: package javax.xml.bind.annotation does not exist` error in test runs.