### PR TITLE
Use setup-java action to set Java version in ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,18 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: true
     steps:
       - name: Checkout recurly-java-library
         uses: actions/checkout@v2
+      - name: Set Java to version 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 8
       - name: Run tests
         env:
           API_KEY: ${{ secrets.API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout code
@@ -25,6 +25,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: '0'
+      - name: Set Java to version 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 8
       - name: Setup git user
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A cleaner solution than what was done in https://github.com/killbilling/recurly-java-library/pull/426