### PR TITLE
V2 add processingPrepaymentBalanceInCents to AccountBalance

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/AccountBalance.java
+++ b/src/main/java/com/ning/billing/recurly/model/AccountBalance.java
@@ -38,6 +38,9 @@ public class AccountBalance extends RecurlyObject {
     @XmlElement(name = "balance_in_cents")
     private RecurlyUnitCurrency balanceInCents;
 
+    @XmlElement(name = "processing_prepayment_balance_in_cents")
+    private RecurlyUnitCurrency processingPrepaymentBalanceInCents;
+
     public Boolean getPastDue() {
         return pastDue;
     }
@@ -50,11 +53,18 @@ public class AccountBalance extends RecurlyObject {
 
     public void setBalanceInCents(final RecurlyUnitCurrency balanceInCents) { this.balanceInCents = balanceInCents; }
 
+    public RecurlyUnitCurrency getProcessingPrepaymentBalanceInCents() {
+        return processingPrepaymentBalanceInCents;
+    }
+
+    public void setProcessingPrepaymentBalanceInCents(final RecurlyUnitCurrency processingPrepaymentBalanceInCents) { this.processingPrepaymentBalanceInCents = processingPrepaymentBalanceInCents; }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("AccountBalance{");
         sb.append(", pastDue=").append(pastDue);
         sb.append(", balanceInCents=").append(balanceInCents);
+        sb.append(", processingPrepaymentBalanceInCents=").append(processingPrepaymentBalanceInCents);
         sb.append('}');
         return sb.toString();
     }
@@ -72,6 +82,9 @@ public class AccountBalance extends RecurlyObject {
         if (balanceInCents != null ? !balanceInCents.equals(accountBalance.balanceInCents) : accountBalance.balanceInCents != null) {
             return false;
         }
+        if (processingPrepaymentBalanceInCents != null ? !processingPrepaymentBalanceInCents.equals(accountBalance.processingPrepaymentBalanceInCents) : accountBalance.processingPrepaymentBalanceInCents != null) {
+            return false;
+        }
 
         return true;
     }
@@ -80,6 +93,7 @@ public class AccountBalance extends RecurlyObject {
     public int hashCode() {
         return Objects.hashCode(
                 pastDue,
+                balanceInCents,
                 balanceInCents
         );
     }

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -703,6 +703,7 @@ public class TestRecurlyClient {
             final AccountBalance balance = recurlyClient.getAccountBalance(account.getAccountCode());
 
             Assert.assertEquals(balance.getBalanceInCents().getUnitAmountUSD(), new Integer(150));
+            Assert.assertEquals(balance.getProcessingPrepaymentBalanceInCents().getUnitAmountUSD(), new Integer(0));
             Assert.assertEquals(balance.getPastDue(), Boolean.FALSE);
         } finally {
             // Clean up

--- a/src/test/java/com/ning/billing/recurly/model/TestAccountBalance.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccountBalance.java
@@ -30,6 +30,9 @@ public class TestAccountBalance extends TestModelBase {
                 "<balance_in_cents>\n" +
                     "<USD type=\"integer\">400</USD>\n" +
                 "</balance_in_cents>\n" +
+                "<processing_prepayment_balance_in_cents>\n" +
+                    "<USD type=\"integer\">-300</USD>\n" +
+                "</processing_prepayment_balance_in_cents>\n" +
                 "</account_balance>\n";
 
         final AccountBalance balance = xmlMapper.readValue(accountBalanceData, AccountBalance.class);
@@ -37,5 +40,6 @@ public class TestAccountBalance extends TestModelBase {
         Assert.assertEquals(balance.getHref(), "https://api.recurly.com/v2/accounts/1/balance");
         Assert.assertEquals(balance.getPastDue(), Boolean.TRUE);
         Assert.assertEquals(balance.getBalanceInCents().getUnitAmountUSD(), new Integer(400));
+        Assert.assertEquals(balance.getProcessingPrepaymentBalanceInCents().getUnitAmountUSD(), new Integer(-300));
     }
 }


### PR DESCRIPTION
Add new add `processingPrepaymentBalanceInCents` attribute to `AccountBalance`. The `processingPrepaymentBalanceInCents` attribute is a similar format to the `balanceInCents` attribute and contains
the total for processing prepayment credit invoices in each currency. This value is useful when trying to determine if the customer's prepayment balance has run out or if it is currently processing while waiting on a payment for the corresponding purchase invoice.