### PR TITLE
Added support for creating/updating/viewing Plans with Ramp Pricing

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/AbstractRampInterval.java
+++ b/src/main/java/com/ning/billing/recurly/model/AbstractRampInterval.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "ramp_interval")
+public class AbstractRampInterval<T> extends RecurlyObject {
+
+  @XmlElement(name = "starting_billing_cycle")
+  protected Integer startingBillingCycle;
+
+  @XmlElement(name = "unit_amount_in_cents")
+  protected T unitAmountInCents;
+
+  public Integer getStartingBillingCycle() {
+    return startingBillingCycle;
+  }
+
+  public void setStartingBillingCycle(final Object startingBillingCycle) {
+    this.startingBillingCycle = integerOrNull(startingBillingCycle);
+  }
+
+  public T getUnitAmountInCents() {
+    return unitAmountInCents;
+  }
+
+  public void setUnitAmountInCents(final T unitAmountInCents) {
+    this.unitAmountInCents = unitAmountInCents;
+  }
+
+  @Override
+  public String toString() {
+    final String className = getClass().getSimpleName();
+    final StringBuilder builder = new StringBuilder(className + "{ ");
+    builder.append("startingBillingCycle=").append(startingBillingCycle);
+    builder.append(", unitAmountInCents=").append(unitAmountInCents);
+    builder.append(" }");
+    return builder.toString();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    final AbstractRampInterval rampInterval = (AbstractRampInterval) o;
+
+    if (unitAmountInCents != null ? !unitAmountInCents.equals(rampInterval.unitAmountInCents) : rampInterval.unitAmountInCents != null) {
+      return false;
+    }
+    if (startingBillingCycle != null ? !startingBillingCycle.equals(rampInterval.startingBillingCycle) : rampInterval.startingBillingCycle != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+      startingBillingCycle,
+      unitAmountInCents
+    );
+  }
+}

--- a/src/main/java/com/ning/billing/recurly/model/Plan.java
+++ b/src/main/java/com/ning/billing/recurly/model/Plan.java
@@ -19,6 +19,7 @@ package com.ning.billing.recurly.model;
 
 import com.google.common.base.Objects;
 import org.joda.time.DateTime;
+import java.util.ArrayList;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
@@ -40,6 +41,13 @@ public class Plan extends RecurlyObject {
 
     @XmlElement(name = "name")
     private String name;
+
+    @XmlElement(name = "pricing_model")
+    private PricingModel pricingModel;
+
+    @XmlElementWrapper(name = "ramp_intervals")
+    @XmlElement(name = "ramp_interval")
+    private PlanRampIntervals rampIntervals;
 
     @XmlElement(name = "description")
     private String description;
@@ -121,6 +129,22 @@ public class Plan extends RecurlyObject {
 
     @XmlElement(name = "dunning_campaign_id")
     private String dunningCampaignId;
+
+    public PricingModel getPricingModel() {
+        return pricingModel;
+    }
+    public void setPricingModel(final Object pricingModel) {
+        this.pricingModel = enumOrNull(PricingModel.class, pricingModel, true);
+    }
+
+    public PlanRampIntervals getRampIntervals() {
+        return rampIntervals;
+    }
+
+    public void setRampIntervals(final PlanRampIntervals rampIntervals) {
+        this.rampIntervals = rampIntervals;
+    }
+
 
     public String getPlanCode() {
         return planCode;
@@ -367,6 +391,7 @@ public class Plan extends RecurlyObject {
         final StringBuilder sb = new StringBuilder();
         sb.append("Plan");
         sb.append("{addOns=").append(addOns);
+        sb.append(", pricingModel='").append(pricingModel).append('\'');
         sb.append(", planCode='").append(planCode).append('\'');
         sb.append(", name='").append(name).append('\'');
         sb.append(", description='").append(description).append('\'');
@@ -388,6 +413,7 @@ public class Plan extends RecurlyObject {
         sb.append(", createdAt=").append(createdAt);
         sb.append(", updatedAt=").append(updatedAt);
         sb.append(", unitAmountInCents=").append(unitAmountInCents);
+        sb.append(", rampIntervals=").append(rampIntervals);
         sb.append(", setupFeeInCents=").append(setupFeeInCents);
         sb.append(", revenueScheduleType=").append(revenueScheduleType);
         sb.append(", setupFeeRevenueScheduleType=").append(setupFeeRevenueScheduleType);
@@ -440,6 +466,12 @@ public class Plan extends RecurlyObject {
             return false;
         }
         if (planCode != null ? !planCode.equals(plan.planCode) : plan.planCode != null) {
+            return false;
+        }
+        if (pricingModel != null ? !pricingModel.equals(plan.pricingModel) : plan.pricingModel != null) {
+            return false;
+        }
+        if (rampIntervals != null ? !rampIntervals.equals(plan.rampIntervals) : plan.rampIntervals != null) {
             return false;
         }
         if (planIntervalLength != null ? !planIntervalLength.equals(plan.planIntervalLength) : plan.planIntervalLength != null) {
@@ -503,6 +535,8 @@ public class Plan extends RecurlyObject {
                 addOns,
                 planCode,
                 name,
+                pricingModel,
+                rampIntervals,
                 description,
                 successLink,
                 cancelLink,

--- a/src/main/java/com/ning/billing/recurly/model/PlanRampInterval.java
+++ b/src/main/java/com/ning/billing/recurly/model/PlanRampInterval.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+@XmlRootElement(name = "ramp_interval")
+public class PlanRampInterval extends AbstractRampInterval<RecurlyUnitCurrency> {}

--- a/src/main/java/com/ning/billing/recurly/model/PlanRampIntervals.java
+++ b/src/main/java/com/ning/billing/recurly/model/PlanRampIntervals.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+@XmlRootElement(name = "ramp_intervals")
+public class PlanRampIntervals extends RecurlyObjects<PlanRampInterval> {
+
+  @XmlTransient
+  private static final String PROPERTY_NAME = "ramp_interval";
+
+  @JsonSetter(value = PROPERTY_NAME)
+  @Override
+  public void setRecurlyObject(final PlanRampInterval value) {
+    super.setRecurlyObject(value);
+  }
+
+  @JsonIgnore
+  @Override
+  public PlanRampIntervals getStart() {
+    return getStart(PlanRampIntervals.class);
+  }
+
+  @JsonIgnore
+  @Override
+  public PlanRampIntervals getNext() {
+    return getNext(PlanRampIntervals.class);
+  }
+}

--- a/src/main/java/com/ning/billing/recurly/model/PricingModel.java
+++ b/src/main/java/com/ning/billing/recurly/model/PricingModel.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+
+@XmlEnum(String.class)
+public enum PricingModel {
+    @XmlEnumValue("fixed")
+    FIXED,
+    @XmlEnumValue("ramp")
+    RAMP
+}

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
@@ -92,6 +92,7 @@ public abstract class RecurlyObject {
         m.addSerializer(CustomFields.class, new RecurlyObjectsSerializer<CustomFields, CustomField>(CustomFields.class, "custom_field"));
         m.addSerializer(Invoices.class, new RecurlyObjectsSerializer<Invoices, Invoice>(Invoices.class, "invoice"));
         m.addSerializer(Plans.class, new RecurlyObjectsSerializer<Plans, Plan>(Plans.class, "plan"));
+        m.addSerializer(PlanRampIntervals.class, new RecurlyObjectsSerializer<PlanRampIntervals, PlanRampInterval>(PlanRampIntervals.class, "ramp_interval"));
         m.addSerializer(RecurlyErrors.class, new RecurlyObjectsSerializer<RecurlyErrors, RecurlyError>(RecurlyErrors.class, "error"));
         m.addSerializer(ShippingAddresses.class, new RecurlyObjectsSerializer<ShippingAddresses, ShippingAddress>(ShippingAddresses.class, "shipping_address"));
         m.addSerializer(ShippingFees.class, new RecurlyObjectsSerializer<ShippingFees, ShippingFee>(ShippingFees.class, "shipping_fee"));

--- a/src/main/java/com/ning/billing/recurly/model/Tier.java
+++ b/src/main/java/com/ning/billing/recurly/model/Tier.java
@@ -72,7 +72,7 @@ public class Tier extends RecurlyObject {
     return true;
   }
 
-  @Override 
+  @Override
   public int hashCode() {
     return Objects.hash(
       unitAmountInCents,

--- a/src/test/java/com/ning/billing/recurly/model/TestPlan.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPlan.java
@@ -164,4 +164,37 @@ public class TestPlan extends TestModelBase {
         assertEquals(plan.hashCode(), otherPlan.hashCode());
         assertEquals(plan, otherPlan);
     }
+
+    @Test(groups = "fast")
+    public void testCreateWithRamps() throws Exception {
+        // See https://dev.recurly.com/docs/list-plans
+        final String planData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                "<plan href=\"https://api.recurly.com/v2/plans/gold\">\n" +
+                                "  <add_ons href=\"https://api.recurly.com/v2/plans/gold/add_ons\"/>\n" +
+                                "  <plan_code>gold</plan_code>\n" +
+                                "  <name>Gold plan</name>\n" +
+                                "  <description nil=\"nil\"></description>\n" +
+                                "  <plan_interval_length type=\"integer\">1</plan_interval_length>\n" +
+                                "  <plan_interval_unit>months</plan_interval_unit>\n" +
+                                "  <pricing_model>ramp</pricing_model>\n" +
+                                "  <ramp_intervals>\n" +
+                                "    <ramp_interval>\n" +
+                                "      <starting_billing_cycle>1</starting_billing_cycle>\n" +
+                                "      <unit_amount_in_cents>\n" +
+                                "        <USD type=\"integer\">1000</USD>\n" +
+                                "      </unit_amount_in_cents>\n" +
+                                "    </ramp_interval>\n" +
+                                "  </ramp_intervals>\n" +
+                                "</plan>";
+
+        final Plan plan = xmlMapper.readValue(planData, Plan.class);
+        final PlanRampIntervals planRamps = plan.getRampIntervals();
+        final PlanRampInterval planRamp = planRamps.get(0);
+        Assert.assertEquals(plan.getPlanCode(), "gold");
+        Assert.assertEquals(plan.getPricingModel(), PricingModel.RAMP);
+        Assert.assertEquals(plan.getName(), "Gold plan");
+        Assert.assertEquals(planRamps.size(), 1);
+        Assert.assertEquals((int) planRamp.getStartingBillingCycle(), 1);
+        Assert.assertEquals((int) planRamp.getUnitAmountInCents().getUnitAmountUSD(), 1000);
+    }
 }


### PR DESCRIPTION
Support for Ramp Pricing has been added to the Java client. New models created:
```
PlanRampIntervals
PlanRampInterval
```

Added the following fields to the `Plan` class:
```
pricingModel
rampIntervals
```

A `RampInterval` is defined as having a `startingBillingCycle` and a collection of prices by currency as `unitAmountInCents`