### PR TITLE
Adding support for creating Subscriptions with ramp intervals from a ramp priced plan or custom ramps

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/PlanRampInterval.java
+++ b/src/main/java/com/ning/billing/recurly/model/PlanRampInterval.java
@@ -16,8 +16,72 @@
  */
 package com.ning.billing.recurly.model;
 
+import java.util.Objects;
+
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 
 @XmlRootElement(name = "ramp_interval")
-public class PlanRampInterval extends AbstractRampInterval<RecurlyUnitCurrency> {}
+public class PlanRampInterval extends RecurlyObject {
+
+  @XmlElement(name = "starting_billing_cycle")
+  protected Integer startingBillingCycle;
+
+  @XmlElement(name = "unit_amount_in_cents")
+  protected RecurlyUnitCurrency unitAmountInCents;
+
+
+  public Integer getStartingBillingCycle() {
+    return startingBillingCycle;
+  }
+
+  public void setStartingBillingCycle(final Object startingBillingCycle) {
+    this.startingBillingCycle = integerOrNull(startingBillingCycle);
+  }
+
+  public RecurlyUnitCurrency getUnitAmountInCents() {
+    return unitAmountInCents;
+  }
+
+  public void setUnitAmountInCents(final Object unitAmountInCents) {
+    this.unitAmountInCents = RecurlyUnitCurrency.build(unitAmountInCents);
+  }
+
+  @Override
+  public String toString() {
+    final String className = getClass().getSimpleName();
+    final StringBuilder builder = new StringBuilder(className + "{ ");
+
+    builder.append("startingBillingCycle=").append(startingBillingCycle);
+    builder.append(", unitAmountInCents=").append(unitAmountInCents);
+    builder.append(" }");
+
+    return builder.toString();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    final PlanRampInterval rampInterval = (PlanRampInterval) o;
+
+    if (unitAmountInCents != null ? !unitAmountInCents.equals(rampInterval.unitAmountInCents) : rampInterval.unitAmountInCents != null) {
+      return false;
+    }
+    if (startingBillingCycle != null ? !startingBillingCycle.equals(rampInterval.startingBillingCycle) : rampInterval.startingBillingCycle != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+      startingBillingCycle,
+      unitAmountInCents
+    );
+  }
+}

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
@@ -93,6 +93,7 @@ public abstract class RecurlyObject {
         m.addSerializer(Invoices.class, new RecurlyObjectsSerializer<Invoices, Invoice>(Invoices.class, "invoice"));
         m.addSerializer(Plans.class, new RecurlyObjectsSerializer<Plans, Plan>(Plans.class, "plan"));
         m.addSerializer(PlanRampIntervals.class, new RecurlyObjectsSerializer<PlanRampIntervals, PlanRampInterval>(PlanRampIntervals.class, "ramp_interval"));
+        m.addSerializer(SubscriptionRampIntervals.class, new RecurlyObjectsSerializer<SubscriptionRampIntervals, SubscriptionRampInterval>(SubscriptionRampIntervals.class, "ramp_interval"));
         m.addSerializer(RecurlyErrors.class, new RecurlyObjectsSerializer<RecurlyErrors, RecurlyError>(RecurlyErrors.class, "error"));
         m.addSerializer(ShippingAddresses.class, new RecurlyObjectsSerializer<ShippingAddresses, ShippingAddress>(ShippingAddresses.class, "shipping_address"));
         m.addSerializer(ShippingFees.class, new RecurlyObjectsSerializer<ShippingFees, ShippingFee>(ShippingFees.class, "shipping_fee"));
@@ -274,5 +275,4 @@ public abstract class RecurlyObject {
         private static final XmlMapper xmlMapper = newXmlMapper();
 
     }
-
 }

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyUnitCurrency.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyUnitCurrency.java
@@ -35,7 +35,7 @@ public class RecurlyUnitCurrency {
     // Australian Dollars
     @XmlElement(name = "AUD")
     private Integer unitAmountAUD;
-    
+
     @XmlElement(name = "JPY")
     private Integer unitAmountJPY;
 
@@ -96,6 +96,7 @@ public class RecurlyUnitCurrency {
     private Integer unitAmountZAR;
 
     public static RecurlyUnitCurrency build(@Nullable final Object unitAmountInCents) {
+        Map amounts;
         if (RecurlyObject.isNull(unitAmountInCents)) {
             return null;
         }
@@ -107,7 +108,7 @@ public class RecurlyUnitCurrency {
         final RecurlyUnitCurrency recurlyUnitCurrency = new RecurlyUnitCurrency();
 
         if (unitAmountInCents instanceof Map) {
-            final Map amounts = (Map) unitAmountInCents;
+            amounts = (Map) unitAmountInCents;
 
             recurlyUnitCurrency.setUnitAmountUSD(amounts.get("USD"));
             recurlyUnitCurrency.setUnitAmountAUD(amounts.get("AUD"));
@@ -210,7 +211,7 @@ public class RecurlyUnitCurrency {
     public void setUnitAmountNOK(final Object unitAmountNOK) {
         this.unitAmountNOK = RecurlyObject.integerOrNull(unitAmountNOK);
     }
-    
+
     public Integer getUnitAmountJPY() {
         return unitAmountJPY;
     }
@@ -218,7 +219,7 @@ public class RecurlyUnitCurrency {
     public void setUnitAmountJPY(final Object unitAmountJPY) {
         this.unitAmountJPY = RecurlyObject.integerOrNull(unitAmountJPY);
     }
-    
+
     public Integer getUnitAmountNZD() {
         return unitAmountNZD;
     }

--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -110,16 +110,16 @@ public class Subscription extends AbstractSubscription {
     //Purchase Order Number
     @XmlElement(name = "po_number")
     private String poNumber;
-    
+
     @XmlElement(name = "terms_and_conditions")
     private String termsAndConditions;
-    
+
     @XmlElement(name = "customer_notes")
     private String customerNotes;
 
     @XmlElement(name = "first_renewal_date")
     private DateTime firstRenewalDate;
-    
+
     @XmlElement(name = "bulk")
     private Boolean bulk;
 
@@ -188,6 +188,18 @@ public class Subscription extends AbstractSubscription {
 
     @XmlElement(name = "transaction_type")
     private String transactionType;
+
+    @XmlElementWrapper(name = "ramp_intervals")
+    @XmlElement(name = "ramp_interval")
+    private SubscriptionRampIntervals rampIntervals;
+
+    public SubscriptionRampIntervals getRampIntervals() {
+        return rampIntervals;
+    }
+
+    public void setRampIntervals(final SubscriptionRampIntervals rampIntervals) {
+        this.rampIntervals = rampIntervals;
+    }
 
     public Account getAccount() {
         if (account != null && account.getHref() != null && !account.getHref().isEmpty()) {
@@ -625,6 +637,7 @@ public class Subscription extends AbstractSubscription {
         sb.append(", trialStartedAt=").append(trialStartedAt);
         sb.append(", trialEndsAt=").append(trialEndsAt);
         sb.append(", startsAt=").append(startsAt);
+        sb.append(", rampIntervals=").append(rampIntervals);
         sb.append(", addOns=").append(addOns);
         sb.append(", pendingSubscription=").append(pendingSubscription);
         sb.append(", firstRenewalDate=").append(firstRenewalDate);
@@ -843,6 +856,7 @@ public class Subscription extends AbstractSubscription {
                 currentPeriodEndsAt,
                 trialStartedAt,
                 trialEndsAt,
+                rampIntervals,
                 addOns,
                 pendingSubscription,
                 startsAt,

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionRampInterval.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionRampInterval.java
@@ -21,14 +21,19 @@ import java.util.Objects;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+
 @XmlRootElement(name = "ramp_interval")
-public class AbstractRampInterval<T> extends RecurlyObject {
+public class SubscriptionRampInterval extends RecurlyObject {
 
   @XmlElement(name = "starting_billing_cycle")
   protected Integer startingBillingCycle;
 
+  @XmlElement(name = "remaining_billing_cycles")
+  private Integer remainingBillingCycles;
+
   @XmlElement(name = "unit_amount_in_cents")
-  protected T unitAmountInCents;
+  protected Integer unitAmountInCents;
+
 
   public Integer getStartingBillingCycle() {
     return startingBillingCycle;
@@ -38,21 +43,31 @@ public class AbstractRampInterval<T> extends RecurlyObject {
     this.startingBillingCycle = integerOrNull(startingBillingCycle);
   }
 
-  public T getUnitAmountInCents() {
+  public Integer getRemainingBillingCycles() {
+    return remainingBillingCycles;
+  }
+
+  public void setRemainingBillingCycles(final Object remainingBillingCycles) {
+    this.remainingBillingCycles = integerOrNull(remainingBillingCycles);
+  }
+
+  public Integer getUnitAmountInCents() {
     return unitAmountInCents;
   }
 
-  public void setUnitAmountInCents(final T unitAmountInCents) {
-    this.unitAmountInCents = unitAmountInCents;
+  public void setUnitAmountInCents(final Object unitAmountInCents) {
+    this.unitAmountInCents = integerOrNull(unitAmountInCents);
   }
 
-  @Override
   public String toString() {
     final String className = getClass().getSimpleName();
-    final StringBuilder builder = new StringBuilder(className + "{ ");
+    final StringBuilder builder = new StringBuilder(className + " { ");
+
     builder.append("startingBillingCycle=").append(startingBillingCycle);
     builder.append(", unitAmountInCents=").append(unitAmountInCents);
-    builder.append(" }");
+    builder.append(", remainingBillingCycles=").append(remainingBillingCycles);
+    builder.append(" }\n ");
+
     return builder.toString();
   }
 
@@ -61,12 +76,15 @@ public class AbstractRampInterval<T> extends RecurlyObject {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
 
-    final AbstractRampInterval rampInterval = (AbstractRampInterval) o;
+    final SubscriptionRampInterval rampInterval = (SubscriptionRampInterval) o;
 
     if (unitAmountInCents != null ? !unitAmountInCents.equals(rampInterval.unitAmountInCents) : rampInterval.unitAmountInCents != null) {
       return false;
     }
     if (startingBillingCycle != null ? !startingBillingCycle.equals(rampInterval.startingBillingCycle) : rampInterval.startingBillingCycle != null) {
+      return false;
+    }
+    if (remainingBillingCycles != null ? !remainingBillingCycles.equals(rampInterval.remainingBillingCycles) : rampInterval.remainingBillingCycles != null) {
       return false;
     }
 
@@ -77,7 +95,9 @@ public class AbstractRampInterval<T> extends RecurlyObject {
   public int hashCode() {
     return Objects.hash(
       startingBillingCycle,
-      unitAmountInCents
+      unitAmountInCents,
+      remainingBillingCycles
     );
   }
+
 }

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionRampIntervals.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionRampIntervals.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+@XmlRootElement(name = "ramp_intervals")
+public class SubscriptionRampIntervals extends RecurlyObjects<SubscriptionRampInterval> {
+
+  @XmlTransient
+  private static final String PROPERTY_NAME = "ramp_interval";
+
+  @JsonSetter(value = PROPERTY_NAME)
+  @Override
+  public void setRecurlyObject(final SubscriptionRampInterval value) {
+    super.setRecurlyObject(value);
+  }
+
+  @JsonIgnore
+  @Override
+  public SubscriptionRampIntervals getStart() {
+    return getStart(SubscriptionRampIntervals.class);
+  }
+
+  @JsonIgnore
+  @Override
+  public SubscriptionRampIntervals getNext() {
+    return getNext(SubscriptionRampIntervals.class);
+  }
+
+  @JsonIgnore
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < super.size(); i++ ) {
+      sb.append(super.get(i));
+    }
+    return sb.toString();
+  }
+}

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
@@ -79,6 +79,18 @@ public class SubscriptionUpdate extends AbstractSubscription {
     @XmlElement(name = "subscription_add_on")
     private SubscriptionAddOns addOns;
 
+    @XmlElementWrapper(name = "ramp_intervals")
+    @XmlElement(name = "ramp_interval")
+    private SubscriptionRampIntervals rampIntervals;
+
+    public SubscriptionRampIntervals getRampIntervals() {
+        return rampIntervals;
+    }
+
+    public void setRampIntervals(final SubscriptionRampIntervals rampIntervals) {
+        this.rampIntervals = rampIntervals;
+    }
+
     public Timeframe getTimeframe() {
         return timeframe;
     }

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -894,23 +894,23 @@ public class TestUtils {
         final CurrencyPercentageTiers currencyPercentageTiers = new CurrencyPercentageTiers();
 
         final AddonPercentageTiers addonPercentageTiers = new AddonPercentageTiers();
-  
+
         final CurrencyPercentageTier currencyPercentageTier = new CurrencyPercentageTier();
         currencyPercentageTier.setCurrency("USD");
-  
+
         final AddonPercentageTier addonPercentageTier = new AddonPercentageTier();
         addonPercentageTier.setEndingAmountInCents(100);
         addonPercentageTier.setUsagePercentage(new BigDecimal("10.0"));
         addonPercentageTiers.add(addonPercentageTier);
-  
+
         final AddonPercentageTier addonPercentageTier2 = new AddonPercentageTier();
         addonPercentageTier2.setEndingAmountInCents(null);
         addonPercentageTier2.setUsagePercentage(new BigDecimal("20.0"));
         addonPercentageTiers.add(addonPercentageTier2);
-  
+
         currencyPercentageTier.setTiers(addonPercentageTiers);
         currencyPercentageTiers.add(currencyPercentageTier);
-  
+
         addOn.setPercentageTiers(currencyPercentageTiers);
 
         return addOn;
@@ -941,23 +941,23 @@ public class TestUtils {
         final SubscriptionAddOn subscriptionAddOn = new SubscriptionAddOn();
         subscriptionAddOn.setAddOnCode(subscriptionAddOn.getAddOnCode());
         subscriptionAddOn.setQuantity(1);
-  
+
         final PercentageTiers percentageTiers = new PercentageTiers();
-  
+
         final PercentageTier percentageTier1 = new PercentageTier();
         final PercentageTier percentageTier2 = new PercentageTier();
-  
+
         percentageTier1.setEndingAmountInCents(200);
         percentageTier1.setUsagePercentage(new BigDecimal("20.0"));
-  
+
         percentageTier2.setEndingAmountInCents(null);
         percentageTier2.setUsagePercentage(new BigDecimal("40.0"));
-  
+
         percentageTiers.add(percentageTier1);
         percentageTiers.add(percentageTier2);
-  
+
         subscriptionAddOn.setPercentageTiers(percentageTiers);
-  
+
         return subscriptionAddOn;
     }
 

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -235,6 +235,77 @@ public class TestSubscription extends TestModelBase {
     }
 
     @Test(groups = "fast")
+    public void testDeserializationWithRampIntervals() throws Exception {
+        // See https://dev.recurly.com/docs/list-subscriptions
+        final String subscriptionData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                        "<subscription href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96\">\n" +
+                                        "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n" +
+                                        "  <plan href=\"https://api.recurly.com/v2/plans/gold\">\n" +
+                                        "    <plan_code>gold</plan_code>\n" +
+                                        "    <name>Gold plan</name>\n" +
+                                        "  </plan>\n" +
+                                        "  <uuid>44f83d7cba354d5b84812419f923ea96</uuid>\n" +
+                                        "  <state>active</state>\n" +
+                                        "  <ramp_intervals type=\"array\">\n" +
+                                        "    <ramp_interval>\n" +
+                                        "      <starting_billing_cycle type=\"integer\">1</starting_billing_cycle>\n" +
+                                        "      <unit_amount_in_cents type=\"integer\">2000</unit_amount_in_cents>\n" +
+                                        "      <remaining_billing_cycles type=\"integer\">0</remaining_billing_cycles>\n" +
+                                        "    </ramp_interval>\n" +
+                                        "    <ramp_interval>\n" +
+                                        "      <starting_billing_cycle type=\"integer\">2</starting_billing_cycle>\n" +
+                                        "      <unit_amount_in_cents type=\"integer\">4000</unit_amount_in_cents>\n" +
+                                        "      <remaining_billing_cycles type=\"integer\">5</remaining_billing_cycles>\n" +
+                                        "    </ramp_interval>\n" +
+                                        "    <ramp_interval>\n" +
+                                        "      <starting_billing_cycle type=\"integer\">7</starting_billing_cycle>\n" +
+                                        "      <unit_amount_in_cents type=\"integer\">7000</unit_amount_in_cents>\n" +
+                                        "      <remaining_billing_cycles nil=\"nil\"/>\n" +
+                                        "    </ramp_interval>\n" +
+                                        "  </ramp_intervals>\n" +
+                                        "  <unit_amount_in_cents type=\"integer\">2000</unit_amount_in_cents>\n" +
+                                        "  <currency>EUR</currency>\n" +
+                                        "  <quantity type=\"integer\">1</quantity>\n" +
+                                        "  <activated_at type=\"dateTime\">2011-05-27T07:00:00Z</activated_at>\n" +
+                                        "  <updated_at type=\"dateTime\">2011-05-27T07:00:00Z</updated_at>\n" +
+                                        "  <canceled_at nil=\"nil\"></canceled_at>\n" +
+                                        "  <expires_at nil=\"nil\"></expires_at>\n" +
+                                        "  <current_period_started_at type=\"dateTime\">2011-06-27T07:00:00Z</current_period_started_at>\n" +
+                                        "  <current_period_ends_at type=\"dateTime\">2010-07-27T07:00:00Z</current_period_ends_at>\n" +
+                                        "  <trial_started_at nil=\"nil\"></trial_started_at>\n" +
+                                        "  <trial_ends_at nil=\"nil\"></trial_ends_at>\n" +
+                                        "  <starts_at>2010-07-28T07:00:00Z</starts_at>\n" +
+                                        "  <a name=\"cancel\" href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/cancel\" method=\"put\"/>\n" +
+                                        "  <a name=\"terminate\" href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/terminate\" method=\"put\"/>\n" +
+                                        "  <a name=\"postpone\" href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/postpone\" method=\"put\"/>\n" +
+                                        "  <collection_method>manual</collection_method>\n" +
+                                        "  <net_terms type=\"integer\">10</net_terms>\n" +
+                                        "  <po_number>PO19384</po_number>\n" +
+                                        "  <tax_in_cents type=\"integer\">394</tax_in_cents>\n" +
+                                        "  <tax_type>usst</tax_type>\n" +
+                                        "  <tax_region>CA</tax_region>\n" +
+                                        "  <tax_rate type=\"float\">0.0875</tax_rate>\n" +
+                                        "  <revenue_schedule_type>evenly</revenue_schedule_type>\n" +
+                                        "  <first_renewal_date type=\"dateTime\">2011-07-01T07:00:00Z</first_renewal_date>\n" +
+                                        "  <started_with_gift type=\"boolean\">true</started_with_gift>\n" +
+                                        "  <converted_at type=\"dateTime\">2017-06-27T00:00:00Z</converted_at>" +
+                                        "  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>" +
+                                        "  <imported_trial type=\"boolean\">true</imported_trial>" +
+                                        "  <subscription_add_ons type=\"array\">\n" +
+                                        "  </subscription_add_ons>\n" +
+                                        "</subscription>";
+
+        final Subscription subscription = xmlMapper.readValue(subscriptionData, Subscription.class);
+        final SubscriptionRampIntervals subRamps = subscription.getRampIntervals();
+
+        Assert.assertEquals(subRamps.size(), 3);
+
+        Assert.assertEquals((int) subRamps.get(0).getUnitAmountInCents(), 2000);
+        Assert.assertEquals((int) subRamps.get(1).getUnitAmountInCents(), 4000);
+        Assert.assertEquals((int) subRamps.get(2).getUnitAmountInCents(), 7000);
+    }
+
+    @Test(groups = "fast")
     public void testSerializationWithSingleCoupon() throws Exception {
         Subscription subscription = TestUtils.createRandomSubscription(0);
         subscription.setCouponCode("my-coupon");


### PR DESCRIPTION
We can now create subscriptions with ramp intervals in two ways. Either create a subscription and use a `plan_code` for a plan that has ramp intervals if the default ramps are desired or do the same as above while supplying a new set of ramp intervals. 