### PR TITLE
Throw an error when a SocketTimeoutException is thrown

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -119,6 +119,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -2680,7 +2681,8 @@ public class RecurlyClient {
             return callRecurlyXmlContent(builder, clazz);
         } catch (IOException e) {
             if (e instanceof ConnectException || e instanceof NoHttpResponseException
-                    || e instanceof ConnectTimeoutException || e instanceof SSLException) {
+                    || e instanceof ConnectTimeoutException || e instanceof SSLException
+                    || e instanceof SocketTimeoutException) {
                 // See https://github.com/killbilling/recurly-java-library/issues/185
                 throw new ConnectionErrorException(e);
             }


### PR DESCRIPTION
**Related Items**:
https://github.com/killbilling/recurly-java-library/issues/185
https://github.com/killbilling/recurly-java-library/pull/292
https://github.com/killbilling/recurly-java-library/pull/411

Fixes an issue where the client will return `null` for an operation that encounters a `SocketTimeoutException`.
