### PR TITLE
[API v2] Support for external subscriptions.

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -36,6 +36,10 @@ import com.ning.billing.recurly.model.DunningCampaign;
 import com.ning.billing.recurly.model.DunningCampaignBulkUpdate;
 import com.ning.billing.recurly.model.DunningCampaigns;
 import com.ning.billing.recurly.model.Entitlements;
+import com.ning.billing.recurly.model.ExternalProduct;
+import com.ning.billing.recurly.model.ExternalProducts;
+import com.ning.billing.recurly.model.ExternalSubscription;
+import com.ning.billing.recurly.model.ExternalSubscriptions;
 import com.ning.billing.recurly.model.Errors;
 import com.ning.billing.recurly.model.GiftCard;
 import com.ning.billing.recurly.model.GiftCards;
@@ -1149,6 +1153,68 @@ public class RecurlyClient {
     public Entitlements getEntitlements(final String accountCode) {
         return doGET(Account.ACCOUNT_RESOURCE + "/" + urlEncode(accountCode) + Entitlements.ENTITLEMENTS_RESOURCE,
                   Entitlements.class);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // External Subscriptions
+
+    /**
+     * Get External Subscriptions of an account
+     * <p>
+     * Returns all external subscriptions for a given account.
+     *
+     * @param accountCode recurly account code
+     * @return List of external subscriptions for the given account on success, null otherwise
+     */
+    public ExternalSubscriptions getExternalSubscriptions(final String accountCode) {
+        return doGET(Account.ACCOUNT_RESOURCE + "/" + urlEncode(accountCode) + ExternalSubscriptions.EXTERNAL_SUBSCRIPTIONS_RESOURCE,
+                  ExternalSubscriptions.class);
+    }
+
+    /**
+     * Get External Subscriptions
+     * <p>
+     * Returns all external subscriptions on the site
+     *
+     * @return List of external subscriptions on the site
+     */
+    public ExternalSubscriptions getExternalSubscriptions() {
+        return doGET(ExternalSubscriptions.EXTERNAL_SUBSCRIPTIONS_RESOURCE, ExternalSubscriptions.class);
+    }
+
+    /**
+     * Get a specific External Subscription
+     * <p>
+     * Returns the requested external subscriptions
+     * 
+     * @param externalSubscriptionUuid external subscription uuid
+     * @return The requested external subscription
+     */
+    public ExternalSubscription getExternalSubscription(final String externalSubscriptionUuid) {
+        return doGET(ExternalSubscriptions.EXTERNAL_SUBSCRIPTIONS_RESOURCE + "/" + urlEncode(externalSubscriptionUuid), ExternalSubscription.class);
+    }
+
+    /**
+     * Get External Products
+     * <p>
+     * Returns all external products on the site
+     *
+     * @return List of external products on the site
+     */
+    public ExternalProducts getExternalProducts() {
+        return doGET(ExternalProducts.EXTERNAL_PRODUCTS_RESOURCE, ExternalProducts.class);
+    }
+
+    /**
+     * Get a specific External Product
+     * <p>
+     * Returns the requested external product
+     * 
+     * @param externalProductUuid external product uuid
+     * @return The requested external product
+     */
+    public ExternalProduct getExternalProduct(final String externalProductUuid) {
+        return doGET(ExternalProducts.EXTERNAL_PRODUCTS_RESOURCE + "/" + urlEncode(externalProductUuid), ExternalProduct.class);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/main/java/com/ning/billing/recurly/model/Account.java
+++ b/src/main/java/com/ning/billing/recurly/model/Account.java
@@ -166,6 +166,9 @@ public class Account extends RecurlyObject {
     @XmlElementWrapper(name = "entitlements")
     private Entitlements entitlements;
 
+    @XmlElementWrapper(name = "external_subscriptions")
+    private ExternalSubscriptions externalSubscriptions;
+
     @Override
     public void setHref(final Object href) {
         super.setHref(href);
@@ -210,6 +213,14 @@ public class Account extends RecurlyObject {
 
     public void setEntitlements(final Entitlements entitlements) {
         this.entitlements = entitlements;
+    }
+
+    public ExternalSubscriptions getExternalSubscriptions() {
+        return externalSubscriptions;
+    }
+
+    public void setExternalSubscriptions(final ExternalSubscriptions externalSubscriptions) {
+        this.externalSubscriptions = externalSubscriptions;
     }
 
     public Subscriptions getSubscriptions() {

--- a/src/main/java/com/ning/billing/recurly/model/CustomerPermission.java
+++ b/src/main/java/com/ning/billing/recurly/model/CustomerPermission.java
@@ -38,31 +38,31 @@ public class CustomerPermission extends RecurlyObject {
       return this.id;
     }
 
-    public void setId(final String id) {
-      this.id = id;
+    public void setId(final Object id) {
+      this.id = stringOrNull(id);
     }
 
     public String getCode() {
       return this.code;
     }
 
-    public void setCode(final String code) {
-      this.code = code;
+    public void setCode(final Object code) {
+      this.code = stringOrNull(code);
     }
 
     public String getName() {
       return this.name;
     }
 
-    public void setName(final String name) {
-      this.name = name;
+    public void setName(final Object name) {
+      this.name = stringOrNull(name);
     }
 
     public String getDescription() {
       return this.description;
     }
 
-    public void setDescription(final String description) {
-      this.description = description;
+    public void setDescription(final Object description) {
+      this.description = stringOrNull(description);
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/ExternalProduct.java
+++ b/src/main/java/com/ning/billing/recurly/model/ExternalProduct.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import org.joda.time.DateTime;
+
+@XmlRootElement(name = "external_product")
+public class ExternalProduct extends RecurlyObject {
+
+    @XmlElement(name = "plan")
+    private Plan plan;
+
+    @XmlElement(name = "name")
+    private String name;
+
+    @XmlElement(name = "created_at")
+    private DateTime createdAt;
+
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
+    @XmlElement(name = "external_product_reference")
+    @XmlElementWrapper(name = "external_product_references")
+    private ExternalProductReferences externalProductReferences;
+
+    public Plan getPlan() {
+      return this.plan;
+    }
+
+    public void setPlan(final Plan plan) {
+      this.plan = plan;
+    }
+
+    public String getName() {
+      return this.name;
+    }
+
+    public void setName(final Object name) {
+      this.name = stringOrNull(name);
+    }
+
+    public ExternalProductReferences getExternalProductReferences() {
+      return this.externalProductReferences;
+    }
+
+    public void setExternalProductReferences(final ExternalProductReferences externalProductReferences) {
+      this.externalProductReferences = externalProductReferences;
+    }
+
+    public DateTime getCreatedAt() {
+      return createdAt;
+    }
+
+    public void setCreatedAt(final Object createdAt) {
+      this.createdAt = dateTimeOrNull(createdAt);
+    }
+
+    public DateTime getUpdatedAt() {
+      return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+      this.updatedAt = dateTimeOrNull(updatedAt);
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/ExternalProductReference.java
+++ b/src/main/java/com/ning/billing/recurly/model/ExternalProductReference.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import org.joda.time.DateTime;
+
+@XmlRootElement(name = "external_product_reference")
+public class ExternalProductReference extends RecurlyObject {
+
+    @XmlElement(name = "id")
+    private String id;
+
+    @XmlElement(name = "reference_code")
+    private String referenceCode;
+
+    @XmlElement(name = "external_connection_type")
+    private String externalConnectionType;
+
+    @XmlElement(name = "created_at")
+    private DateTime createdAt;
+
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
+    public String getId() {
+      return this.id;
+    }
+
+    public void setId(final Object id) {
+      this.id = stringOrNull(id);
+    }
+
+    public String getReferenceCode() {
+      return this.referenceCode;
+    }
+
+    public void setReferenceCode(final Object referenceCode) {
+      this.referenceCode = stringOrNull(referenceCode);
+    }
+
+    public String getExternalConnectionType() {
+      return this.externalConnectionType;
+    }
+
+    public void setExternalConnectionType(final Object externalConnectionType) {
+      this.externalConnectionType = stringOrNull(externalConnectionType);
+    }
+
+    public DateTime getCreatedAt() {
+      return createdAt;
+    }
+
+    public void setCreatedAt(final Object createdAt) {
+      this.createdAt = dateTimeOrNull(createdAt);
+    }
+
+    public DateTime getUpdatedAt() {
+      return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+      this.updatedAt = dateTimeOrNull(updatedAt);
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/ExternalProductReferences.java
+++ b/src/main/java/com/ning/billing/recurly/model/ExternalProductReferences.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+@XmlRootElement(name = "external_product_references")
+public class ExternalProductReferences extends RecurlyObjects<ExternalProductReference> {
+
+    @XmlTransient
+    private static final String PROPERTY_NAME = "external_product_reference";
+
+    @JsonSetter(value = PROPERTY_NAME)
+    @Override
+    public void setRecurlyObject(final ExternalProductReference value) {
+        super.setRecurlyObject(value);
+    }
+
+    @JsonIgnore
+    @Override
+    public ExternalProductReferences getStart() {
+        return getStart(ExternalProductReferences.class);
+    }
+
+    @JsonIgnore
+    @Override
+    public ExternalProductReferences getNext() {
+        return getNext(ExternalProductReferences.class);
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/ExternalProducts.java
+++ b/src/main/java/com/ning/billing/recurly/model/ExternalProducts.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+@XmlRootElement(name = "external_products")
+public class ExternalProducts extends RecurlyObjects<ExternalProduct> {
+
+    @XmlTransient
+    public static final String EXTERNAL_PRODUCTS_RESOURCE = "/external_products";
+
+    @XmlTransient
+    private static final String PROPERTY_NAME = "external_product";
+
+    @JsonSetter(value = PROPERTY_NAME)
+    @Override
+    public void setRecurlyObject(final ExternalProduct value) {
+        super.setRecurlyObject(value);
+    }
+
+    @JsonIgnore
+    @Override
+    public ExternalProducts getStart() {
+        return getStart(ExternalProducts.class);
+    }
+
+    @JsonIgnore
+    @Override
+    public ExternalProducts getNext() {
+        return getNext(ExternalProducts.class);
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/ExternalResource.java
+++ b/src/main/java/com/ning/billing/recurly/model/ExternalResource.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "external_resource")
+public class ExternalResource extends RecurlyObject {
+
+    @XmlElement(name = "external_object_reference")
+    private String externalObjectReference;
+
+    public String getExternalObjectReference() {
+      return this.externalObjectReference;
+    }
+
+    public void setExternalObjectReference(final Object externalObjectReference) {
+      this.externalObjectReference = stringOrNull(externalObjectReference);
+    }
+
+}

--- a/src/main/java/com/ning/billing/recurly/model/ExternalSubscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/ExternalSubscription.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import org.joda.time.DateTime;
+
+@XmlRootElement(name = "external_subscription")
+public class ExternalSubscription extends RecurlyObject {
+
+    @XmlElement(name = "account")
+    private Account account;
+
+    @XmlElement(name = "external_resource")
+    private ExternalResource externalResource;
+
+    @XmlElement(name = "external_product_reference")
+    private ExternalProductReference externalProductReference;
+
+    @XmlElement(name = "last_purchased")
+    private DateTime lastPurchased;
+
+    @XmlElement(name = "auto_renew")
+    private Boolean autoRenew;
+
+    @XmlElement(name = "app_identifier")
+    private String appIdentifier;
+
+    @XmlElement(name = "quantity")
+    private Integer quantity;
+
+    @XmlElement(name = "activated_at")
+    private DateTime activatedAt;
+
+    @XmlElement(name = "expires_at")
+    private DateTime expiresAt;
+
+    @XmlElement(name = "created_at")
+    private DateTime createdAt;
+
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
+    public Account getAccount() {
+      return this.account;
+    }
+
+    public void setAccount(final Account account) {
+      this.account = account;
+    }
+
+    public ExternalResource getExternalResource() {
+      return this.externalResource;
+    }
+
+    public void setExternalResource(final ExternalResource externalResource) {
+      this.externalResource = externalResource;
+    }
+
+    public ExternalProductReference getExternalProductReference() {
+      return this.externalProductReference;
+    }
+
+    public void setExternalProductReference(final ExternalProductReference externalProductReference) {
+      this.externalProductReference = externalProductReference;
+    }
+
+    public DateTime getLastPurchased() {
+      return lastPurchased;
+    }
+
+    public void setLastPurchased(final Object lastPurchased) {
+      this.lastPurchased = dateTimeOrNull(lastPurchased);
+    }
+
+    public Boolean getAutoRenew() {
+      return autoRenew;
+    }
+
+    public void setAutoRenew(final Object autoRenew) {
+      this.autoRenew = booleanOrNull(autoRenew);
+    }
+
+    public String getAppIdentifier() {
+      return this.appIdentifier;
+    }
+
+    public void setAppIdentifier(final Object appIdentifier) {
+      this.appIdentifier = stringOrNull(appIdentifier);
+    }
+
+    public Integer getQuantity() {
+      return quantity;
+    }
+
+    public void setQuantity(final Object quantity) {
+      this.quantity = integerOrNull(quantity);
+    }
+
+    public DateTime getActivatedAt() {
+      return activatedAt;
+    }
+
+    public void setActivatedAt(final Object activatedAt) {
+      this.activatedAt = dateTimeOrNull(activatedAt);
+    }
+
+    public DateTime getExpiresAt() {
+      return expiresAt;
+    }
+
+    public void setExpiresAt(final Object expiresAt) {
+      this.expiresAt = dateTimeOrNull(expiresAt);
+    }
+
+    public DateTime getCreatedAt() {
+      return createdAt;
+    }
+
+    public void setCreatedAt(final Object createdAt) {
+      this.createdAt = dateTimeOrNull(createdAt);
+    }
+
+    public DateTime getUpdatedAt() {
+      return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+      this.updatedAt = dateTimeOrNull(updatedAt);
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/ExternalSubscriptions.java
+++ b/src/main/java/com/ning/billing/recurly/model/ExternalSubscriptions.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+@XmlRootElement(name = "external_subscriptions")
+public class ExternalSubscriptions extends RecurlyObjects<ExternalSubscription> {
+
+    @XmlTransient
+    public static final String EXTERNAL_SUBSCRIPTIONS_RESOURCE = "/external_subscriptions";
+
+    @XmlTransient
+    private static final String PROPERTY_NAME = "external_subscription";
+
+    @XmlAttribute(name = "href")
+    private String href;
+
+    @JsonSetter(value = PROPERTY_NAME)
+    @Override
+    public void setRecurlyObject(final ExternalSubscription value) {
+        super.setRecurlyObject(value);
+    }
+
+    @JsonIgnore
+    @Override
+    public ExternalSubscriptions getStart() {
+        return getStart(ExternalSubscriptions.class);
+    }
+
+    @JsonIgnore
+    @Override
+    public ExternalSubscriptions getNext() {
+        return getNext(ExternalSubscriptions.class);
+    }
+
+    public String getHref() {
+        return this.href;
+    }
+
+    public void setHref(final String href) {
+        this.href = href;
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestAccountExternalSubscriptions.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccountExternalSubscriptions.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import org.joda.time.DateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestAccountExternalSubscriptions extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        final String accountExternalSubscriptionsData = 
+          "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+          "<external_subscriptions>" +
+          "  <external_subscription href=\"https://your-subdomain.recurly.com/v2/external_subscriptions/rpap82ntgqqh\">" +
+          "    <account href=\"https://your-subdomain.recurly.com/v2/accounts/1\"/>" +
+          "    <external_resource>" +
+          "      <external_object_reference>link</external_object_reference>" +
+          "    </external_resource>" +
+          "    <external_product_reference>" +
+          "      <id>rgybkg3d1l41</id>" +
+          "      <reference_code>apple-code</reference_code>" +
+          "      <external_connection_type>apple_app_store</external_connection_type>" +
+          "      <created_at type=\"datetime\">2022-09-12T18:40:51Z</created_at>" +
+          "      <updated_at type=\"datetime\">2022-09-12T18:40:51Z</updated_at>" +
+          "    </external_product_reference>" +
+          "    <last_purchased type=\"datetime\">2022-09-12T18:40:51Z</last_purchased>" +
+          "    <auto_renew type=\"boolean\">false</auto_renew>" +
+          "    <app_identifier>com.foo.id</app_identifier>" +
+          "    <quantity type=\"integer\">1</quantity>" +
+          "    <activated_at type=\"datetime\">2022-09-12T18:40:51Z</activated_at>" +
+          "    <expires_at type=\"datetime\">2022-09-12T18:40:51Z</expires_at>" +
+          "    <created_at type=\"datetime\">2022-09-12T18:40:51Z</created_at>" +
+          "    <updated_at type=\"datetime\">2022-09-12T18:40:51Z</updated_at>" +
+          "  </external_subscription>" +
+          "</external_subscriptions>";
+
+        final ExternalSubscriptions accountExternalSubscriptions = xmlMapper.readValue(accountExternalSubscriptionsData, ExternalSubscriptions.class);
+        Assert.assertEquals(accountExternalSubscriptions.size(), 1);
+
+        final ExternalSubscription externalSubscription = accountExternalSubscriptions.get(0);
+        Assert.assertEquals(externalSubscription.getHref(), "https://your-subdomain.recurly.com/v2/external_subscriptions/rpap82ntgqqh");
+        Assert.assertEquals(externalSubscription.getAccount().getHref(), "https://your-subdomain.recurly.com/v2/accounts/1");
+        Assert.assertEquals(externalSubscription.getExternalResource().getExternalObjectReference(), "link");
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getId(), "rgybkg3d1l41");
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getReferenceCode(), "apple-code");
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getExternalConnectionType(), "apple_app_store");
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getCreatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getUpdatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getLastPurchased(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getAutoRenew(), Boolean.FALSE);
+        Assert.assertEquals(externalSubscription.getAppIdentifier(), "com.foo.id");
+        Assert.assertEquals(externalSubscription.getQuantity(), new Integer(1));
+        Assert.assertEquals(externalSubscription.getActivatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getExpiresAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getCreatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getUpdatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestExternalProduct.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestExternalProduct.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import org.joda.time.DateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestExternalProduct extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        final String externalProductData = 
+          "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+          "<external_product href=\"https://your-subdomain.recurly.com/v2/external_products/rg6is8p7w4us\">" +
+          "  <plan href=\"https://your-subdomain.recurly.com/v2/plans/platinum\">" +
+          "    <plan_code>platinum</plan_code>" +
+          "    <name>Platinum plan</name>" +
+          "  </plan>" +
+          "  <name>External Product Name</name>" +
+          "  <created_at type=\"datetime\">2022-08-25T22:00:32Z</created_at>" +
+          "  <updated_at type=\"datetime\">2022-10-10T21:40:50Z</updated_at>" +
+          "  <external_product_references type=\"array\">" +
+          "    <external_product_reference>" +
+          "      <id>rgycreiyhs1q</id>" +
+          "      <reference_code>apple-code</reference_code>" +
+          "      <external_connection_type>apple_app_store</external_connection_type>" +
+          "      <created_at type=\"datetime\">2022-08-29T19:36:39Z</created_at>" +
+          "      <updated_at type=\"datetime\">2022-10-10T21:40:50Z</updated_at>" +
+          "    </external_product_reference>" +
+          "  </external_product_references>" +
+          "</external_product>";
+
+        final ExternalProduct externalProduct = xmlMapper.readValue(externalProductData, ExternalProduct.class);
+        Assert.assertEquals(externalProduct.getHref(), "https://your-subdomain.recurly.com/v2/external_products/rg6is8p7w4us");
+        Assert.assertEquals(externalProduct.getPlan().getPlanCode(), "platinum");
+        Assert.assertEquals(externalProduct.getPlan().getName(), "Platinum plan");
+        Assert.assertEquals(externalProduct.getName(), "External Product Name");
+        Assert.assertEquals(externalProduct.getCreatedAt(), new DateTime("2022-08-25T22:00:32Z"));
+        Assert.assertEquals(externalProduct.getUpdatedAt(), new DateTime("2022-10-10T21:40:50Z"));
+
+        final ExternalProductReferences externalProductReferences = externalProduct.getExternalProductReferences();
+        Assert.assertEquals(externalProductReferences.size(), 1);
+
+        final ExternalProductReference externalProductReference = externalProductReferences.get(0);
+        Assert.assertEquals(externalProductReference.getId(), "rgycreiyhs1q");
+        Assert.assertEquals(externalProductReference.getReferenceCode(), "apple-code");
+        Assert.assertEquals(externalProductReference.getExternalConnectionType(), "apple_app_store");
+        Assert.assertEquals(externalProductReference.getCreatedAt(), new DateTime("2022-08-29T19:36:39Z"));
+        Assert.assertEquals(externalProductReference.getUpdatedAt(), new DateTime("2022-10-10T21:40:50Z"));
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestExternalProducts.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestExternalProducts.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import org.joda.time.DateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestExternalProducts extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        final String externalProductsData = 
+          "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+          "<external_products type=\"array\">" +
+          "  <external_product href=\"https://your-subdomain.recurly.com/v2/external_products/rg6is8p7w4us\">" +
+          "    <plan href=\"https://your-subdomain.recurly.com/v2/plans/platinum\">" +
+          "      <plan_code>platinum</plan_code>" +
+          "      <name>Platinum plan</name>" +
+          "    </plan>" +
+          "    <name>External Product Name</name>" +
+          "    <created_at type=\"datetime\">2022-08-25T22:00:32Z</created_at>" +
+          "    <updated_at type=\"datetime\">2022-10-10T21:40:50Z</updated_at>" +
+          "    <external_product_references type=\"array\">" +
+          "      <external_product_reference>" +
+          "        <id>rgycreiyhs1q</id>" +
+          "        <reference_code>apple-code</reference_code>" +
+          "        <external_connection_type>apple_app_store</external_connection_type>" +
+          "        <created_at type=\"datetime\">2022-08-29T19:36:39Z</created_at>" +
+          "        <updated_at type=\"datetime\">2022-10-10T21:40:50Z</updated_at>" +
+          "      </external_product_reference>" +
+          "    </external_product_references>" +
+          "  </external_product>" +
+          "</external_products>";
+
+        final ExternalProducts externalProducts = xmlMapper.readValue(externalProductsData, ExternalProducts.class);
+        Assert.assertEquals(externalProducts.size(), 1);
+
+        final ExternalProduct externalProduct = externalProducts.get(0);
+        Assert.assertEquals(externalProduct.getHref(), "https://your-subdomain.recurly.com/v2/external_products/rg6is8p7w4us");
+        Assert.assertEquals(externalProduct.getPlan().getPlanCode(), "platinum");
+        Assert.assertEquals(externalProduct.getPlan().getName(), "Platinum plan");
+        Assert.assertEquals(externalProduct.getName(), "External Product Name");
+        Assert.assertEquals(externalProduct.getCreatedAt(), new DateTime("2022-08-25T22:00:32Z"));
+        Assert.assertEquals(externalProduct.getUpdatedAt(), new DateTime("2022-10-10T21:40:50Z"));
+
+        final ExternalProductReferences externalProductReferences = externalProduct.getExternalProductReferences();
+        Assert.assertEquals(externalProductReferences.size(), 1);
+
+        final ExternalProductReference externalProductReference = externalProductReferences.get(0);
+        Assert.assertEquals(externalProductReference.getId(), "rgycreiyhs1q");
+        Assert.assertEquals(externalProductReference.getReferenceCode(), "apple-code");
+        Assert.assertEquals(externalProductReference.getExternalConnectionType(), "apple_app_store");
+        Assert.assertEquals(externalProductReference.getCreatedAt(), new DateTime("2022-08-29T19:36:39Z"));
+        Assert.assertEquals(externalProductReference.getUpdatedAt(), new DateTime("2022-10-10T21:40:50Z"));
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestExternalSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestExternalSubscription.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import org.joda.time.DateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestExternalSubscription extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        final String externalSubscriptionData = 
+          "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+          "<external_subscription href=\"https://your-subdomain.recurly.com/v2/external_subscriptions/rpap82ntgqqh\">" +
+          "  <account href=\"https://your-subdomain.recurly.com/v2/accounts/1\"/>" +
+          "  <external_resource>" +
+          "    <external_object_reference>link</external_object_reference>" +
+          "  </external_resource>" +
+          "  <external_product_reference>" +
+          "    <id>rgybkg3d1l41</id>" +
+          "    <reference_code>apple-code</reference_code>" +
+          "    <external_connection_type>apple_app_store</external_connection_type>" +
+          "    <created_at type=\"datetime\">2022-09-12T18:40:51Z</created_at>" +
+          "    <updated_at type=\"datetime\">2022-09-12T18:40:51Z</updated_at>" +
+          "  </external_product_reference>" +
+          "  <last_purchased type=\"datetime\">2022-09-12T18:40:51Z</last_purchased>" +
+          "  <auto_renew type=\"boolean\">false</auto_renew>" +
+          "  <app_identifier>com.foo.id</app_identifier>" +
+          "  <quantity type=\"integer\">1</quantity>" +
+          "  <activated_at type=\"datetime\">2022-09-12T18:40:51Z</activated_at>" +
+          "  <expires_at type=\"datetime\">2022-09-12T18:40:51Z</expires_at>" +
+          "  <created_at type=\"datetime\">2022-09-12T18:40:51Z</created_at>" +
+          "  <updated_at type=\"datetime\">2022-09-12T18:40:51Z</updated_at>" +
+          "</external_subscription>";
+
+        final ExternalSubscription externalSubscription = xmlMapper.readValue(externalSubscriptionData, ExternalSubscription.class);
+        Assert.assertEquals(externalSubscription.getHref(), "https://your-subdomain.recurly.com/v2/external_subscriptions/rpap82ntgqqh");
+        Assert.assertEquals(externalSubscription.getAccount().getHref(), "https://your-subdomain.recurly.com/v2/accounts/1");
+        Assert.assertEquals(externalSubscription.getExternalResource().getExternalObjectReference(), "link");
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getId(), "rgybkg3d1l41");
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getReferenceCode(), "apple-code");
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getExternalConnectionType(), "apple_app_store");
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getCreatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getUpdatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getLastPurchased(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getAutoRenew(), Boolean.FALSE);
+        Assert.assertEquals(externalSubscription.getAppIdentifier(), "com.foo.id");
+        Assert.assertEquals(externalSubscription.getQuantity(), new Integer(1));
+        Assert.assertEquals(externalSubscription.getActivatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getExpiresAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getCreatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getUpdatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestExternalSubscriptions.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestExternalSubscriptions.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import org.joda.time.DateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestExternalSubscriptions extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        final String externalSubscriptionsData = 
+          "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+          "<external_subscriptions>" +
+          "  <external_subscription href=\"https://your-subdomain.recurly.com/v2/external_subscriptions/rpap82ntgqqh\">" +
+          "    <account href=\"https://your-subdomain.recurly.com/v2/accounts/1\"/>" +
+          "    <external_resource>" +
+          "      <external_object_reference>link</external_object_reference>" +
+          "    </external_resource>" +
+          "    <external_product_reference>" +
+          "      <id>rgybkg3d1l41</id>" +
+          "      <reference_code>apple-code</reference_code>" +
+          "      <external_connection_type>apple_app_store</external_connection_type>" +
+          "      <created_at type=\"datetime\">2022-09-12T18:40:51Z</created_at>" +
+          "      <updated_at type=\"datetime\">2022-09-12T18:40:51Z</updated_at>" +
+          "    </external_product_reference>" +
+          "    <last_purchased type=\"datetime\">2022-09-12T18:40:51Z</last_purchased>" +
+          "    <auto_renew type=\"boolean\">false</auto_renew>" +
+          "    <app_identifier>com.foo.id</app_identifier>" +
+          "    <quantity type=\"integer\">1</quantity>" +
+          "    <activated_at type=\"datetime\">2022-09-12T18:40:51Z</activated_at>" +
+          "    <expires_at type=\"datetime\">2022-09-12T18:40:51Z</expires_at>" +
+          "    <created_at type=\"datetime\">2022-09-12T18:40:51Z</created_at>" +
+          "    <updated_at type=\"datetime\">2022-09-12T18:40:51Z</updated_at>" +
+          "  </external_subscription>" +
+          "</external_subscriptions>";
+
+        final ExternalSubscriptions externalSubscriptions = xmlMapper.readValue(externalSubscriptionsData, ExternalSubscriptions.class);
+        Assert.assertEquals(externalSubscriptions.size(), 1);
+
+        final ExternalSubscription externalSubscription = externalSubscriptions.get(0);
+        Assert.assertEquals(externalSubscription.getHref(), "https://your-subdomain.recurly.com/v2/external_subscriptions/rpap82ntgqqh");
+        Assert.assertEquals(externalSubscription.getAccount().getHref(), "https://your-subdomain.recurly.com/v2/accounts/1");
+        Assert.assertEquals(externalSubscription.getExternalResource().getExternalObjectReference(), "link");
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getId(), "rgybkg3d1l41");
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getReferenceCode(), "apple-code");
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getExternalConnectionType(), "apple_app_store");
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getCreatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getExternalProductReference().getUpdatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getLastPurchased(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getAutoRenew(), Boolean.FALSE);
+        Assert.assertEquals(externalSubscription.getAppIdentifier(), "com.foo.id");
+        Assert.assertEquals(externalSubscription.getQuantity(), new Integer(1));
+        Assert.assertEquals(externalSubscription.getActivatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getExpiresAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getCreatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+        Assert.assertEquals(externalSubscription.getUpdatedAt(), new DateTime("2022-09-12T18:40:51Z"));
+    }
+}


### PR DESCRIPTION
- Add `ExternalProductReference`, `ExternalProductReferences`, `ExternalProduct`, `ExternalProducts`, `ExternalSubscription`, `ExternalSubscriptions` and `ExternalResource` models.
- Add following endpoints to the client:
  - /external_subscriptions
  - /external_subscriptions/:uuid
  - /accounts/:account_code/external_subscriptions
  - /external_products
  - /external_products/:uuid 

