### PR TITLE
Add support for Apply Credit Balance to existing invoice feature

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -1717,7 +1717,16 @@ public class RecurlyClient {
       Invoice request = new Invoice();
       request.setBillingInfoUuid(billingInfoUuid);
       return doPUT(Invoices.INVOICES_RESOURCE + "/" + urlEncode(invoiceId) + "/collect", request, Invoice.class);
-  }
+    }
+
+    /**
+     * Apply Account Credit Balance to Collectible Charge Invoice
+     *
+     * @param invoiceId String Recurly Invoice ID
+     */
+    public Invoice applyCreditBalance(final String invoiceId) {
+        return doPUT(Invoices.INVOICES_RESOURCE + "/" + urlEncode(invoiceId) + "/apply_credit_balance", null, Invoice.class);
+    }
 
     /**
      * Void Invoice

--- a/src/main/java/com/ning/billing/recurly/model/AccountBalance.java
+++ b/src/main/java/com/ning/billing/recurly/model/AccountBalance.java
@@ -41,6 +41,9 @@ public class AccountBalance extends RecurlyObject {
     @XmlElement(name = "processing_prepayment_balance_in_cents")
     private RecurlyUnitCurrency processingPrepaymentBalanceInCents;
 
+    @XmlElement(name = "available_credit_balance_in_cents")
+    private RecurlyUnitCurrency availableCreditBalanceInCents;
+
     public Boolean getPastDue() {
         return pastDue;
     }
@@ -59,12 +62,19 @@ public class AccountBalance extends RecurlyObject {
 
     public void setProcessingPrepaymentBalanceInCents(final RecurlyUnitCurrency processingPrepaymentBalanceInCents) { this.processingPrepaymentBalanceInCents = processingPrepaymentBalanceInCents; }
 
+    public RecurlyUnitCurrency getAvailableCreditBalanceInCents() {
+        return availableCreditBalanceInCents;
+    }
+
+    public void setAvailableCreditBalanceInCents(final RecurlyUnitCurrency availableCreditBalanceInCents) { this.availableCreditBalanceInCents = availableCreditBalanceInCents; }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("AccountBalance{");
         sb.append(", pastDue=").append(pastDue);
         sb.append(", balanceInCents=").append(balanceInCents);
         sb.append(", processingPrepaymentBalanceInCents=").append(processingPrepaymentBalanceInCents);
+        sb.append(", availableCreditBalanceInCents=").append(availableCreditBalanceInCents);
         sb.append('}');
         return sb.toString();
     }
@@ -85,6 +95,9 @@ public class AccountBalance extends RecurlyObject {
         if (processingPrepaymentBalanceInCents != null ? !processingPrepaymentBalanceInCents.equals(accountBalance.processingPrepaymentBalanceInCents) : accountBalance.processingPrepaymentBalanceInCents != null) {
             return false;
         }
+        if (availableCreditBalanceInCents != null ? !availableCreditBalanceInCents.equals(accountBalance.availableCreditBalanceInCents) : accountBalance.availableCreditBalanceInCents != null) {
+            return false;
+        }
 
         return true;
     }
@@ -94,7 +107,8 @@ public class AccountBalance extends RecurlyObject {
         return Objects.hashCode(
                 pastDue,
                 balanceInCents,
-                balanceInCents
+                processingPrepaymentBalanceInCents,
+                availableCreditBalanceInCents
         );
     }
 

--- a/src/test/java/com/ning/billing/recurly/model/TestAccountBalance.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccountBalance.java
@@ -33,6 +33,9 @@ public class TestAccountBalance extends TestModelBase {
                 "<processing_prepayment_balance_in_cents>\n" +
                     "<USD type=\"integer\">-300</USD>\n" +
                 "</processing_prepayment_balance_in_cents>\n" +
+                "<available_credit_balance_in_cents>\n" +
+                    "<USD type=\"integer\">-300</USD>\n" +
+                "</available_credit_balance_in_cents>\n" +
                 "</account_balance>\n";
 
         final AccountBalance balance = xmlMapper.readValue(accountBalanceData, AccountBalance.class);
@@ -41,5 +44,6 @@ public class TestAccountBalance extends TestModelBase {
         Assert.assertEquals(balance.getPastDue(), Boolean.TRUE);
         Assert.assertEquals(balance.getBalanceInCents().getUnitAmountUSD(), new Integer(400));
         Assert.assertEquals(balance.getProcessingPrepaymentBalanceInCents().getUnitAmountUSD(), new Integer(-300));
+        Assert.assertEquals(balance.getAvailableCreditBalanceInCents().getUnitAmountUSD(), new Integer(-300));
     }
 }


### PR DESCRIPTION
Add new `availableCreditBalanceInCents` attribute to `AccountBalance`. The `availableCreditBalanceInCents` attribute is a similar format to the `balanceInCents` attribute and contains the total of open balances for credit invoices in each currency. This value is useful when trying to determine if the customer's account has any available credit that can be applied to an existing collectible invoice on the account.

Add new `applyCreditBalance` method to `Invoice`. This action will be available for collectible charge invoices. If the account has available credit it will be applied to pay down the balance on the invoice.