### PR TITLE
Add missing license header block

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/CustomFieldDefinition.java
+++ b/src/main/java/com/ning/billing/recurly/model/CustomFieldDefinition.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.ning.billing.recurly.model;
 
 import com.google.common.base.Objects;

--- a/src/main/java/com/ning/billing/recurly/model/CustomFieldDefinitions.java
+++ b/src/main/java/com/ning/billing/recurly/model/CustomFieldDefinitions.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.ning.billing.recurly.model;
 
 import javax.xml.bind.annotation.XmlRootElement;

--- a/src/test/java/com/ning/billing/recurly/model/TestCustomFieldDefinition.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCustomFieldDefinition.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.ning.billing.recurly.model;
 
 import java.math.BigDecimal;

--- a/src/test/java/com/ning/billing/recurly/model/TestCustomFieldDefinitions.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCustomFieldDefinitions.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.ning.billing.recurly.model;
 
 import org.joda.time.DateTime;


### PR DESCRIPTION
https://github.com/killbilling/recurly-java-library/pull/456 introduced 4 new files, but failed to include the license comment block