### PR TITLE
Add usedTaxService to Invoice response

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -85,6 +85,9 @@ public class Invoice extends RecurlyObject {
     @XmlElementWrapper(name = "tax_details")
     private List<TaxDetail> taxDetails;
 
+    @XmlElement(name = "used_tax_service")
+    private Boolean usedTaxService;
+
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
@@ -335,6 +338,14 @@ public class Invoice extends RecurlyObject {
         this.taxDetails = taxDetails;
     }
 
+    public Boolean getUsedTaxService() {
+        return usedTaxService;
+    }
+
+    public void setUsedTaxService(final Object usedTaxService) {
+        this.usedTaxService = booleanOrNull(usedTaxService);
+    }
+
     public DateTime getCreatedAt() {
         return createdAt;
     }
@@ -565,6 +576,7 @@ public class Invoice extends RecurlyObject {
         sb.append(", taxType=").append(taxType);
         sb.append(", taxRate=").append(taxRate);
         sb.append(", taxDetails=").append(taxDetails);
+        sb.append(", usedTaxService=").append(usedTaxService);
         sb.append(", createdAt=").append(createdAt);
         sb.append(", updatedAt=").append(updatedAt);
         sb.append(", closedAt=").append(closedAt);
@@ -693,6 +705,9 @@ public class Invoice extends RecurlyObject {
         if (taxDetails != null ? !taxDetails.equals(invoice.taxDetails) : invoice.taxDetails != null) {
             return false;
         }
+        if (usedTaxService != null ? !usedTaxService.equals(that.usedTaxService) : that.usedTaxService != null) {
+            return false;
+        }
         if (termsAndConditions != null ? !termsAndConditions.equals(invoice.termsAndConditions) : invoice.termsAndConditions != null) {
             return false;
         }
@@ -750,6 +765,7 @@ public class Invoice extends RecurlyObject {
                 taxType,
                 taxRate,
                 taxDetails,
+                usedTaxService,
                 currency,
                 createdAt,
                 updatedAt,

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
@@ -140,6 +140,7 @@ public class TestInvoice extends TestModelBase {
         Assert.assertEquals(invoice.getTaxType(), "usst");
         Assert.assertEquals(invoice.getTaxRegion(), "CA");
         Assert.assertEquals(invoice.getTaxRate(), new BigDecimal("0.0875"));
+        Assert.assertEquals((boolean) invoice.getUsedTaxService(), true);
         Assert.assertEquals(invoice.getCreatedAt(), new DateTime("2011-08-25T12:00:00Z"));
         Assert.assertEquals(invoice.getUpdatedAt(), new DateTime("2011-08-25T12:00:00Z"));
         Assert.assertEquals(invoice.getClosedAt(), new DateTime("2011-08-25T12:00:00Z"));


### PR DESCRIPTION
`Invoice` response format has changed:
- Added `<used_tax_service>`. Field is present if taxes are enabled. Value is `true` or `false` based on a successful response from the tax service.