### PR TITLE
Support for multiple business entities

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -29,6 +29,8 @@ import com.ning.billing.recurly.model.Adjustments;
 import com.ning.billing.recurly.model.BillingInfo;
 import com.ning.billing.recurly.model.BillingInfos;
 import com.ning.billing.recurly.model.BillingInfoVerification;
+import com.ning.billing.recurly.model.BusinessEntity;
+import com.ning.billing.recurly.model.BusinessEntities;
 import com.ning.billing.recurly.model.Coupon;
 import com.ning.billing.recurly.model.Coupons;
 import com.ning.billing.recurly.model.CreditPayments;
@@ -2873,6 +2875,51 @@ public class RecurlyClient {
         return doGET(CustomFieldDefinitions.CUSTOM_FIELD_DEFINITIONS_RESOURCE + "/" + urlEncode(customFieldId), CustomFieldDefinition.class);
     }
 
+
+    ///////////////////////////////////////////////////////////////////////////
+    
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Multiple Business Entities
+
+    /**
+     * Get Business Entities
+     * <p>
+     * Returns all business entities on the site
+     *
+     * @return List of business entities on the site
+     */
+    public BusinessEntities getBusinessEntities() {
+        return doGET(BusinessEntities.BUSINESS_ENTITIES_RESOURCE, BusinessEntities.class);
+    }
+
+    /**
+     * Get a specific Busines Entity
+     * <p>
+     * Returns the requested business entity
+     * 
+     * @param businessEntityUUID business entity uuid
+     * @return The requested business entity
+     */
+    public BusinessEntity getBusinessEntity(final String businessEntityUUID) {
+        return doGET(BusinessEntities.BUSINESS_ENTITIES_RESOURCE + "/" + urlEncode(businessEntityUUID), BusinessEntity.class);
+    }
+
+    /**
+     * Get business entity's invoices
+     * <p>
+     * Returns the business entity's invoices
+     *
+     * @param businessEntityUUID business entity uuid
+     * @param state {@link InvoiceState} state of the invoices
+     * @param params {@link QueryParams}
+     * @return the invoices associated with this business entity on success, null otherwise
+     */
+    public Invoices getBusinessEntityInvoices(final String businessEntityUUID, final InvoiceState state, final QueryParams params) {
+        if (state != null) params.put("state", state.getType());
+        return doGET(BusinessEntities.BUSINESS_ENTITIES_RESOURCE + "/" + urlEncode(businessEntityUUID) + Invoices.INVOICES_RESOURCE,
+                Invoices.class, params);
+    }
 
     ///////////////////////////////////////////////////////////////////////////
 

--- a/src/main/java/com/ning/billing/recurly/model/Account.java
+++ b/src/main/java/com/ning/billing/recurly/model/Account.java
@@ -61,6 +61,9 @@ public class Account extends RecurlyObject {
     @XmlElement(name = "invoice_template")
     private InvoiceTemplate invoiceTemplate;
 
+    @XmlElement(name = "override_business_entity")
+    private BusinessEntity overrideBusinessEntity;
+
     @XmlElement(name = "account_code")
     private String accountCode;
 
@@ -165,6 +168,9 @@ public class Account extends RecurlyObject {
 
     @XmlElement(name = "invoice_template_uuid")
     private String invoiceTemplateUuid;
+
+    @XmlElement(name = "override_business_entity_id")
+    private String overrideBusinessEntityId;
 
     @XmlElementWrapper(name = "entitlements")
     private Entitlements entitlements;
@@ -497,6 +503,14 @@ public class Account extends RecurlyObject {
         this.transactionType = stringOrNull(transactionType);
     }
 
+    public String getOverrideBusinessEntityId() {
+        return overrideBusinessEntityId;
+    }
+
+    public void setOverrideBusinessEntityId(final Object overrideBusinessEntityId) {
+        this.overrideBusinessEntityId = stringOrNull(overrideBusinessEntityId);
+    }
+
     public String getDunningCampaignId() {
         return dunningCampaignId;
     }
@@ -518,6 +532,13 @@ public class Account extends RecurlyObject {
             invoiceTemplate = fetch(invoiceTemplate, InvoiceTemplate.class);
         }
         return invoiceTemplate;
+    }
+
+    public BusinessEntity getOverrideBusinessEntity() {
+        if (overrideBusinessEntity != null && overrideBusinessEntity.getHref() != null && !overrideBusinessEntity.getHref().isEmpty()) {
+            overrideBusinessEntity = fetch(overrideBusinessEntity, BusinessEntity.class);
+        }
+        return overrideBusinessEntity;
     }
 
     @Override
@@ -559,6 +580,7 @@ public class Account extends RecurlyObject {
         sb.append(", accountAcquisition=").append(accountAcquisition);
         sb.append(", preferredLocale=").append(preferredLocale);
         sb.append(", preferredTimeZone=").append(preferredTimeZone);
+        sb.append(", overrideBusinessEntityId=").append(overrideBusinessEntityId);
         sb.append(", transactionType='").append(transactionType).append('\'');
         sb.append('}');
         return sb.toString();

--- a/src/main/java/com/ning/billing/recurly/model/BusinessEntities.java
+++ b/src/main/java/com/ning/billing/recurly/model/BusinessEntities.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+@XmlRootElement(name = "business_entities")
+public class BusinessEntities extends RecurlyObjects<BusinessEntity> {
+
+    @XmlTransient
+    public static final String BUSINESS_ENTITIES_RESOURCE = "/business_entities";
+
+    @XmlTransient
+    private static final String PROPERTY_NAME = "business_entity";
+
+    @JsonSetter(value = PROPERTY_NAME)
+    @Override
+    public void setRecurlyObject(final BusinessEntity value) {
+        super.setRecurlyObject(value);
+    }
+
+    @JsonIgnore
+    @Override
+    public BusinessEntities getStart() {
+        return getStart(BusinessEntities.class);
+    }
+
+    @JsonIgnore
+    @Override
+    public BusinessEntities getNext() {
+        return getNext(BusinessEntities.class);
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/BusinessEntity.java
+++ b/src/main/java/com/ning/billing/recurly/model/BusinessEntity.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlList;
+import javax.xml.bind.annotation.XmlRootElement;
+import org.joda.time.DateTime;
+import java.util.List;
+
+@XmlRootElement(name = "business_entity")
+public class BusinessEntity extends RecurlyObject {
+
+    @XmlElement(name = "id")
+    private String id;
+
+    @XmlElement(name = "code")
+    private String code;
+
+    @XmlElement(name = "name")
+    private String name;
+
+    @XmlElement(name = "invoice_display_address")
+    private InvoiceDisplayAddress invoiceDisplayAddress;
+
+    @XmlElement(name = "tax_address")
+    private TaxAddress taxAddress;
+
+    @XmlList
+    @XmlElementWrapper(name = "subscriber_location_countries")
+    @XmlElement(name = "subscriber_location_country")
+    private List<String> subscriberLocationCountries;
+
+    @XmlElement(name = "default_vat_number")
+    private String defaultVatNumber;
+
+    @XmlElement(name = "default_registration_number")
+    private String defaultRegistrationNumber;
+
+    @XmlElement(name = "created_at")
+    private DateTime createdAt;
+
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
+    @XmlElementWrapper(name = "invoices")
+    private Invoice invoices;
+
+    public String getId() {
+      return this.id;
+    }
+
+    public void setId(final Object id) {
+      this.id = stringOrNull(id);
+    }
+
+    public String getCode() {
+      return this.code;
+    }
+
+    public void setCode(final Object code) {
+      this.code = stringOrNull(code);
+    }
+
+    public String getName() {
+      return this.name;
+    }
+
+    public void setName(final Object name) {
+      this.name = stringOrNull(name);
+    }
+
+    public InvoiceDisplayAddress getInvoiceDisplayAddress() {
+      return this.invoiceDisplayAddress;
+    }
+
+    public void setInvoiceDisplayAddress(final InvoiceDisplayAddress invoiceDisplayAddress) {
+      this.invoiceDisplayAddress = invoiceDisplayAddress;
+    }
+
+    public void setTaxAddress(final TaxAddress taxAddress) {
+      this.taxAddress = taxAddress;
+    }
+
+    public TaxAddress getTaxAddress() {
+      return this.taxAddress;
+    }
+
+    public void setDefaultVatNumber(final Object defaultVatNumber) {
+      this.defaultVatNumber = stringOrNull(defaultVatNumber);
+    }
+
+    public String getDefaultVatNumber() {
+      return this.defaultVatNumber;
+    }
+
+    public void setDefaultRegistrationNumber(final Object defaultRegistrationNumber) {
+      this.defaultRegistrationNumber = stringOrNull(defaultRegistrationNumber);
+    }
+
+    public String getDefaultRegistrationNumber() {
+      return this.defaultRegistrationNumber;
+    }
+    
+    public DateTime getCreatedAt() {
+      return this.createdAt;
+    }
+
+    public void setCreatedAt(final Object createdAt) {
+      this.createdAt = dateTimeOrNull(createdAt);
+    }
+
+    public DateTime getUpdatedAt() {
+      return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+      this.updatedAt = dateTimeOrNull(updatedAt);
+    }
+
+    public Invoice getInvoices() {
+        return this.invoices;
+    }
+
+    public void setInvoices(final Invoice invoices) {
+        this.invoices = invoices;
+    }
+
+    public void setSubscriberLocationCountries(final List<String> subscriberLocationCountries) {
+        this.subscriberLocationCountries = subscriberLocationCountries;
+    }
+
+    public List<String> getSubscriberLocationCountries() {
+        return this.subscriberLocationCountries;
+    }
+
+
+  @Override
+  public String toString() {
+    return "{" +
+      " id='" + getId() + "'" +
+      ", code='" + getCode() + "'" +
+      ", name='" + getName() + "'" +
+      ", invoiceDisplayAddress='" + getInvoiceDisplayAddress() + "'" +
+      ", taxAddress='" + getTaxAddress() + "'" +
+      ", subscriberLocationCountries='" + getSubscriberLocationCountries() + "'" +
+      ", defaultVatNumber='" + getDefaultVatNumber() + "'" +
+      ", defaultRegistrationNumber='" + getDefaultRegistrationNumber() + "'" +
+      ", createdAt='" + getCreatedAt() + "'" +
+      ", updatedAt='" + getUpdatedAt() + "'" +
+      ", invoices='" + getInvoices().getHref() + "'" +
+      "}";
+  }
+
+}

--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -169,6 +169,9 @@ public class Invoice extends RecurlyObject {
     @XmlElement(name = "dunning_campaign_id")
     private String dunningCampaignId;
 
+    @XmlElement(name = "business_entity")
+    private BusinessEntity businessEntity;
+
     public Account getAccount() {
         if (account != null && account.getCreatedAt() == null) {
             account = fetch(account, Account.class);
@@ -555,12 +558,20 @@ public class Invoice extends RecurlyObject {
         this.dunningCampaignId = stringOrNull(dunningCampaignId);
     }
 
+    public BusinessEntity getBusinessEntity() {
+        if (businessEntity != null && businessEntity.getHref() != null && !businessEntity.getHref().isEmpty()) {
+            businessEntity = fetch(businessEntity, BusinessEntity.class);
+        }
+        return businessEntity;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("Invoice{");
         sb.append("account=").append(account);
         sb.append(", originalInvoice='").append(originalInvoice).append('\'');
         sb.append(", originalInvoices='").append(originalInvoices).append('\'');
+        sb.append(", businessEntity='").append(businessEntity).append('\'');
         sb.append(", uuid='").append(uuid).append('\'');
         sb.append(", state='").append(state).append('\'');
         sb.append(", invoiceNumber=").append(invoiceNumber);

--- a/src/main/java/com/ning/billing/recurly/model/InvoiceDisplayAddress.java
+++ b/src/main/java/com/ning/billing/recurly/model/InvoiceDisplayAddress.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.joda.time.DateTime;
+
+import com.google.common.base.Objects;
+
+@XmlRootElement(name = "invoice_display_address")
+public class InvoiceDisplayAddress extends RecurlyObject {
+
+    @XmlElement(name = "address1")
+    private String address1;
+
+    @XmlElement(name = "address2")
+    private String address2;
+
+    @XmlElement(name = "city")
+    private String city;
+
+    @XmlElement(name = "state")
+    private String state;
+
+    @XmlElement(name = "zip")
+    private String zip;
+
+    @XmlElement(name = "country")
+    private String country;
+
+    @XmlElement(name = "phone")
+    private String phone;
+
+    public String getAddress1() {
+        return address1;
+    }
+
+    public void setAddress1(final Object address1) {
+        this.address1 = stringOrNull(address1);
+    }
+
+    public String getAddress2() {
+        return address2;
+    }
+
+    public void setAddress2(final Object address2) {
+        this.address2 = stringOrNull(address2);
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(final Object city) {
+        this.city = stringOrNull(city);
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(final Object state) {
+        this.state = stringOrNull(state);
+    }
+
+    public String getZip() {
+        return zip;
+    }
+
+    public void setZip(final Object zip) {
+        this.zip = stringOrNull(zip);
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(final Object country) {
+        this.country = stringOrNull(country);
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(final Object phone) {
+        this.phone = stringOrNull(phone);
+    }
+
+    @Override
+    public String toString() {
+        return "{" +
+            " address1='" + getAddress1() + "'" +
+            ", address2='" + getAddress2() + "'" +
+            ", city='" + getCity() + "'" +
+            ", state='" + getState() + "'" +
+            ", zip='" + getZip() + "'" +
+            ", country='" + getCountry() + "'" +
+            ", phone='" + getPhone() + "'" +
+            "}";
+    }
+
+}

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
@@ -106,6 +106,7 @@ public abstract class RecurlyObject {
         m.addSerializer(Transactions.class, new RecurlyObjectsSerializer<Transactions, Transaction>(Transactions.class, "transaction"));
         m.addSerializer(Usages.class, new RecurlyObjectsSerializer<Usages, Usage>(Usages.class, "usage"));
         m.addSerializer(ExternalProductReferences.class, new RecurlyObjectsSerializer<ExternalProductReferences, ExternalProductReference>(ExternalProductReferences.class, "external_product_reference"));
+        m.addSerializer(BusinessEntities.class, new RecurlyObjectsSerializer<BusinessEntities, BusinessEntity>(BusinessEntities.class, "business_entity"));
         xmlMapper.registerModule(m);
 
         return xmlMapper;

--- a/src/main/java/com/ning/billing/recurly/model/TaxAddress.java
+++ b/src/main/java/com/ning/billing/recurly/model/TaxAddress.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.joda.time.DateTime;
+
+import com.google.common.base.Objects;
+
+@XmlRootElement(name = "tax_address")
+public class TaxAddress extends RecurlyObject {
+
+    @XmlElement(name = "address1")
+    private String address1;
+
+    @XmlElement(name = "address2")
+    private String address2;
+
+    @XmlElement(name = "city")
+    private String city;
+
+    @XmlElement(name = "state")
+    private String state;
+
+    @XmlElement(name = "zip")
+    private String zip;
+
+    @XmlElement(name = "country")
+    private String country;
+
+    @XmlElement(name = "phone")
+    private String phone;
+
+    public String getAddress1() {
+        return address1;
+    }
+
+    public void setAddress1(final Object address1) {
+        this.address1 = stringOrNull(address1);
+    }
+
+    public String getAddress2() {
+        return address2;
+    }
+
+    public void setAddress2(final Object address2) {
+        this.address2 = stringOrNull(address2);
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(final Object city) {
+        this.city = stringOrNull(city);
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(final Object state) {
+        this.state = stringOrNull(state);
+    }
+
+    public String getZip() {
+        return zip;
+    }
+
+    public void setZip(final Object zip) {
+        this.zip = stringOrNull(zip);
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(final Object country) {
+        this.country = stringOrNull(country);
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(final Object phone) {
+        this.phone = stringOrNull(phone);
+    }
+    
+    @Override
+    public String toString() {
+        return "{" +
+            " address1='" + getAddress1() + "'" +
+            ", address2='" + getAddress2() + "'" +
+            ", city='" + getCity() + "'" +
+            ", state='" + getState() + "'" +
+            ", zip='" + getZip() + "'" +
+            ", country='" + getCountry() + "'" +
+            ", phone='" + getPhone() + "'" +
+            "}";
+    }
+
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestAccount.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccount.java
@@ -39,6 +39,7 @@ public class TestAccount extends TestModelBase {
                                    "  <redemption href=\"https://api.recurly.com/v2/accounts/1/redemption\"/>\n" +
                                    "  <subscriptions href=\"https://api.recurly.com/v2/accounts/1/subscriptions\"/>\n" +
                                    "  <transactions href=\"https://api.recurly.com/v2/accounts/1/transactions\"/>\n" +
+                                   "  <override_business_entity href=\"https://api.recurly.com/v2/business_entities/1\"/>\n" +
                                    "  <account_code>1</account_code>\n" +
                                    "  <parent_account_code>2</parent_account_code>\n" +
                                    "  <state>active</state>\n" +
@@ -78,6 +79,7 @@ public class TestAccount extends TestModelBase {
 
         final Account account = xmlMapper.readValue(accountData, Account.class);
         Assert.assertEquals(account.getHref(), "https://api.recurly.com/v2/accounts/1");
+        Assert.assertEquals(account.getOverrideBusinessEntity().getHref(), "https://api.recurly.com/v2/business_entities/1");
         verifyAccount(account);
 
         // Verify serialization

--- a/src/test/java/com/ning/billing/recurly/model/TestBusinessEntities.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestBusinessEntities.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+ package com.ning.billing.recurly.model;
+
+ import java.util.List;
+
+ import org.joda.time.DateTime;
+ import org.testng.Assert;
+ import org.testng.annotations.Test;
+ 
+ public class TestBusinessEntities extends TestModelBase {
+ 
+     @Test(groups = "fast")
+     public void testDeserialization() throws Exception {
+        final String businessEntitiesData = 
+           "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+           "<business_entities type=\"array\">" +
+           "  <business_entity href=\"https://your-subdomain.recurly.com/v2/business_entities/scaig66ovogw\">" +
+           "    <invoices href=\"https://your-subdomain.recurly.com/v2/business_entities/scaig66ovogw/invoices\"/>" +
+           "    <id>scaig66ovogw</id>" +
+           "    <code>legacy_usa</code>" +
+           "    <name>Legacy USA</name>" +
+           "    <invoice_display_address>" +
+           "       <address1>94250 Sadye Ramp</address1>" +
+           "       <address2>Apt. 771</address2>" +
+           "       <city>Oakland</city>" +
+           "       <state>CA</state>" +
+           "       <zip>94605</zip>" +
+           "       <country>US</country>" +
+           "       <phone>718-555-1234</phone>" +
+           "    </invoice_display_address>" +
+           "    <tax_address>" +
+           "       <address1>94250 Sadye Ramp</address1>" +
+           "       <address2>Apt. 771</address2>" +
+           "       <city>Oakland</city>" +
+           "       <state>CA</state>" +
+           "       <zip>94605</zip>" +
+           "       <country>US</country>" +
+           "       <phone>718-555-1234</phone>" +
+           "    </tax_address>" +
+           "    <subscriber_location_countries type=\"array\">" +
+           "       <subscriber_location_country>GB</subscriber_location_country>" +
+           "       <subscriber_location_country>CO</subscriber_location_country>" +
+           "    </subscriber_location_countries>" +
+           "    <default_vat_number>1234</default_vat_number>" +
+           "    <default_registration_number>5678</default_registration_number>" +
+           "    <created_at type=\"datetime\">2023-05-04T17:45:43Z</created_at>" +
+           "    <updated_at type=\"datetime\">2023-05-04T17:45:43Z</updated_at>" +
+           "  </business_entity>" +
+           "</business_entities>";
+ 
+        final BusinessEntities businessEntities = xmlMapper.readValue(businessEntitiesData, BusinessEntities.class);
+        Assert.assertEquals(businessEntities.size(), 1);
+ 
+        final BusinessEntity businessEntity = businessEntities.get(0);
+        final List<String> subscriberLocationCountries = businessEntity.getSubscriberLocationCountries();
+
+        Assert.assertEquals(businessEntity.getHref(), "https://your-subdomain.recurly.com/v2/business_entities/scaig66ovogw");
+        Assert.assertEquals(businessEntity.getInvoices().getHref(), "https://your-subdomain.recurly.com/v2/business_entities/scaig66ovogw/invoices");
+        Assert.assertEquals(businessEntity.getId(), "scaig66ovogw");
+        Assert.assertEquals(businessEntity.getCode(), "legacy_usa");
+        Assert.assertEquals(businessEntity.getName(), "Legacy USA");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getAddress1(), "94250 Sadye Ramp");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getAddress2(), "Apt. 771");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getCity(), "Oakland");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getState(), "CA");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getZip(), "94605");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getCountry(), "US");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getPhone(), "718-555-1234");
+        Assert.assertEquals(businessEntity.getTaxAddress().getAddress1(), "94250 Sadye Ramp");
+        Assert.assertEquals(businessEntity.getTaxAddress().getAddress2(), "Apt. 771");
+        Assert.assertEquals(businessEntity.getTaxAddress().getCity(), "Oakland");
+        Assert.assertEquals(businessEntity.getTaxAddress().getState(), "CA");
+        Assert.assertEquals(businessEntity.getTaxAddress().getZip(), "94605");
+        Assert.assertEquals(businessEntity.getTaxAddress().getCountry(), "US");
+        Assert.assertEquals(businessEntity.getTaxAddress().getPhone(), "718-555-1234");
+        Assert.assertEquals(subscriberLocationCountries.get(0), "GB");
+        Assert.assertEquals(subscriberLocationCountries.get(1), "CO");
+        Assert.assertEquals(businessEntity.getDefaultVatNumber(), "1234");
+        Assert.assertEquals(businessEntity.getDefaultRegistrationNumber(), "5678");
+        Assert.assertEquals(businessEntity.getCreatedAt(), new DateTime("2023-05-04T17:45:43Z"));
+        Assert.assertEquals(businessEntity.getUpdatedAt(), new DateTime("2023-05-04T17:45:43Z"));
+     }
+ }
+ 

--- a/src/test/java/com/ning/billing/recurly/model/TestBusinessEntity.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestBusinessEntity.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+ package com.ning.billing.recurly.model;
+
+ import java.util.List;
+
+ import org.joda.time.DateTime;
+ import org.testng.Assert;
+ import org.testng.annotations.Test;
+ 
+ public class TestBusinessEntity extends TestModelBase {
+ 
+     @Test(groups = "fast")
+     public void testDeserialization() throws Exception {
+        final String businessEntityData = 
+           "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+           "<business_entity href=\"https://your-subdomain.recurly.com/v2/business_entities/scaig66ovogw\">" +
+           "  <invoices href=\"https://your-subdomain.recurly.com/v2/business_entities/scaig66ovogw/invoices\"/>" +
+           "  <id>scaig66ovogw</id>" +
+           "  <code>legacy_usa</code>" +
+           "  <name>Legacy USA</name>" +
+           "  <invoice_display_address>" +
+           "     <address1>94250 Sadye Ramp</address1>" +
+           "     <address2>Apt. 771</address2>" +
+           "     <city>Oakland</city>" +
+           "     <state>CA</state>" +
+           "     <zip>94605</zip>" +
+           "     <country>US</country>" +
+           "     <phone>718-555-1234</phone>" +
+           "  </invoice_display_address>" +
+           "  <tax_address>" +
+           "     <address1>94250 Sadye Ramp</address1>" +
+           "     <address2>Apt. 771</address2>" +
+           "     <city>Oakland</city>" +
+           "     <state>CA</state>" +
+           "     <zip>94605</zip>" +
+           "     <country>US</country>" +
+           "     <phone>718-555-1234</phone>" +
+           "  </tax_address>" +
+           "  <subscriber_location_countries type=\"array\">" +
+           "     <subscriber_location_country>GB</subscriber_location_country>" +
+           "     <subscriber_location_country>CO</subscriber_location_country>" +
+           "  </subscriber_location_countries>" +
+           "  <default_vat_number>1234</default_vat_number>" +
+           "  <default_registration_number>5678</default_registration_number>" +
+           "  <created_at type=\"datetime\">2023-05-04T17:45:43Z</created_at>" +
+           "  <updated_at type=\"datetime\">2023-05-04T17:45:43Z</updated_at>" +
+           "</business_entity>";
+ 
+        final BusinessEntity businessEntity = xmlMapper.readValue(businessEntityData, BusinessEntity.class);
+        final List<String> subscriberLocationCountries = businessEntity.getSubscriberLocationCountries();
+
+        Assert.assertEquals(businessEntity.getHref(), "https://your-subdomain.recurly.com/v2/business_entities/scaig66ovogw");
+        Assert.assertEquals(businessEntity.getInvoices().getHref(), "https://your-subdomain.recurly.com/v2/business_entities/scaig66ovogw/invoices");
+        Assert.assertEquals(businessEntity.getId(), "scaig66ovogw");
+        Assert.assertEquals(businessEntity.getCode(), "legacy_usa");
+        Assert.assertEquals(businessEntity.getName(), "Legacy USA");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getAddress1(), "94250 Sadye Ramp");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getAddress2(), "Apt. 771");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getCity(), "Oakland");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getState(), "CA");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getZip(), "94605");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getCountry(), "US");
+        Assert.assertEquals(businessEntity.getInvoiceDisplayAddress().getPhone(), "718-555-1234");
+        Assert.assertEquals(businessEntity.getTaxAddress().getAddress1(), "94250 Sadye Ramp");
+        Assert.assertEquals(businessEntity.getTaxAddress().getAddress2(), "Apt. 771");
+        Assert.assertEquals(businessEntity.getTaxAddress().getCity(), "Oakland");
+        Assert.assertEquals(businessEntity.getTaxAddress().getState(), "CA");
+        Assert.assertEquals(businessEntity.getTaxAddress().getZip(), "94605");
+        Assert.assertEquals(businessEntity.getTaxAddress().getCountry(), "US");
+        Assert.assertEquals(businessEntity.getTaxAddress().getPhone(), "718-555-1234");
+        Assert.assertEquals(subscriberLocationCountries.get(0), "GB");
+        Assert.assertEquals(subscriberLocationCountries.get(1), "CO");
+        Assert.assertEquals(businessEntity.getDefaultVatNumber(), "1234");
+        Assert.assertEquals(businessEntity.getDefaultRegistrationNumber(), "5678");
+        Assert.assertEquals(businessEntity.getCreatedAt(), new DateTime("2023-05-04T17:45:43Z"));
+        Assert.assertEquals(businessEntity.getUpdatedAt(), new DateTime("2023-05-04T17:45:43Z"));
+     }
+ }
+ 

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
@@ -36,6 +36,7 @@ public class TestInvoice extends TestModelBase {
                                    + "<invoice href=\"https://api.recurly.com/v2/invoices/e3f0a9e084a2468480d00ee61b090d4d\">\n"
                                    + "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n"
                                    + "  <original_invoices href=\"https://api.recurly.com/v2/invoices/1192/original_invoices\"/>\n"
+                                   + "  <business_entity href=\"https://api.recurly.com/v2/business_entities/1\"/>\n"
                                    + "  <uuid>421f7b7d414e4c6792938e7c49d552e9</uuid>\n"
                                    + "  <state>open</state>\n"
                                    + "  <invoice_number type=\"integer\">1402</invoice_number>\n"
@@ -123,6 +124,7 @@ public class TestInvoice extends TestModelBase {
         final Invoice invoice = xmlMapper.readValue(invoiceData, Invoice.class);
 
         Assert.assertEquals(invoice.getAccount().getHref(), "https://api.recurly.com/v2/accounts/1");
+        Assert.assertEquals(invoice.getBusinessEntity().getHref(), "https://api.recurly.com/v2/business_entities/1");
         Assert.assertTrue(invoice.hasOriginalInvoices());
         Assert.assertEquals(invoice.getUuid(), "421f7b7d414e4c6792938e7c49d552e9");
         Assert.assertEquals(invoice.getState(), "open");


### PR DESCRIPTION
Support for multiple business entities:

- Add override_business_entity to Account.
- Add business_entity to Invoice.
- Add following endpoints to the client:
  - GET /v2/business_entities
  - GET /v2/business_entities/:business_entity_uuid
  - GET /v2/business_entities/:business_entity_uuid/invoices