### PR TITLE
[V2] Add action_result to Subscription and Transaction

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -193,6 +193,9 @@ public class Subscription extends AbstractSubscription {
     @XmlElement(name = "ramp_interval")
     private SubscriptionRampIntervals rampIntervals;
 
+    @XmlElement(name = "action_result")
+    private String actionResult;
+
     public SubscriptionRampIntervals getRampIntervals() {
         return rampIntervals;
     }
@@ -614,6 +617,14 @@ public class Subscription extends AbstractSubscription {
         this.transactionType = stringOrNull(transactionType);
     }
 
+    public String getActionResult() {
+        return actionResult;
+    }
+
+    public void setActionResult(final Object actionResult) {
+        this.actionResult = stringOrNull(actionResult);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -668,6 +679,7 @@ public class Subscription extends AbstractSubscription {
         sb.append(", nextBillDate=").append(nextBillDate);
         sb.append(", currentPeriodStartedAt=").append(currentPeriodStartedAt);
         sb.append(", currentPeriodEndsAt=").append(currentPeriodEndsAt);
+        sb.append(", actionResult=").append(actionResult);
         sb.append(", transactionType='").append(transactionType).append('\'');
         sb.append('}');
         return sb.toString();
@@ -890,7 +902,8 @@ public class Subscription extends AbstractSubscription {
                 nextBillDate,
                 currentPeriodStartedAt,
                 currentPeriodEndsAt,
-                transactionType
+                transactionType,
+                actionResult
         );
     }
 

--- a/src/main/java/com/ning/billing/recurly/model/Transaction.java
+++ b/src/main/java/com/ning/billing/recurly/model/Transaction.java
@@ -72,6 +72,9 @@ public class Transaction extends AbstractTransaction {
     @XmlElement(name = "approval_code")
     private String approvalCode;
 
+    @XmlElement(name = "action_result")
+    private String actionResult;
+
     public Account getAccount() {
         if (account != null && account.getCreatedAt() == null) {
             account = fetch(account, Account.class);
@@ -192,6 +195,14 @@ public class Transaction extends AbstractTransaction {
         this.approvalCode = stringOrNull(approvalCode);
     }
 
+    public String getActionResult() {
+        return actionResult;
+    }
+
+    public void setActionResult(final Object actionResult) {
+        this.actionResult = stringOrNull(actionResult);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("Transaction{");
@@ -210,6 +221,7 @@ public class Transaction extends AbstractTransaction {
         sb.append(", origin=").append(origin);
         sb.append(", gatewayType=").append(gatewayType);
         sb.append(", approvalCode=").append(approvalCode);
+        sb.append(", actionResult=").append(actionResult);
         sb.append('}');
         return sb.toString();
     }
@@ -286,7 +298,8 @@ public class Transaction extends AbstractTransaction {
                 details,
                 gatewayType,
                 origin,
-                approvalCode
+                approvalCode,
+                actionResult
         );
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -363,6 +363,71 @@ public class TestSubscription extends TestModelBase {
         assertEquals(subscription, otherSubscription);
     }
 
+    @Test(groups = "fast")
+    public void testDeserializationWithActionResult() throws Exception {
+        // See https://dev.recurly.com/docs/list-subscriptions
+        final String subscriptionData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                        "<subscription href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96\">\n" +
+                                        "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n" +
+                                        "  <plan href=\"https://api.recurly.com/v2/plans/gold\">\n" +
+                                        "    <plan_code>gold</plan_code>\n" +
+                                        "    <name>Gold plan</name>\n" +
+                                        "  </plan>\n" +
+                                        "  <uuid>44f83d7cba354d5b84812419f923ea96</uuid>\n" +
+                                        "  <state>active</state>\n" +
+                                        "  <unit_amount_in_cents type=\"integer\">800</unit_amount_in_cents>\n" +
+                                        "  <currency>EUR</currency>\n" +
+                                        "  <quantity type=\"integer\">1</quantity>\n" +
+                                        "  <activated_at type=\"dateTime\">2011-05-27T07:00:00Z</activated_at>\n" +
+                                        "  <updated_at type=\"dateTime\">2011-05-27T07:00:00Z</updated_at>\n" +
+                                        "  <canceled_at nil=\"nil\"></canceled_at>\n" +
+                                        "  <expires_at nil=\"nil\"></expires_at>\n" +
+                                        "  <current_period_started_at type=\"dateTime\">2011-06-27T07:00:00Z</current_period_started_at>\n" +
+                                        "  <current_period_ends_at type=\"dateTime\">2010-07-27T07:00:00Z</current_period_ends_at>\n" +
+                                        "  <trial_started_at nil=\"nil\"></trial_started_at>\n" +
+                                        "  <trial_ends_at nil=\"nil\"></trial_ends_at>\n" +
+                                        "  <starts_at>2010-07-28T07:00:00Z</starts_at>\n" +
+                                        "  <a name=\"cancel\" href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/cancel\" method=\"put\"/>\n" +
+                                        "  <a name=\"terminate\" href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/terminate\" method=\"put\"/>\n" +
+                                        "  <a name=\"postpone\" href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/postpone\" method=\"put\"/>\n" +
+                                        "  <collection_method>manual</collection_method>\n" +
+                                        "  <net_terms type=\"integer\">10</net_terms>\n" +
+                                        "  <po_number>PO19384</po_number>\n" +
+                                        "  <tax_in_cents type=\"integer\">394</tax_in_cents>\n" +
+                                        "  <tax_type>usst</tax_type>\n" +
+                                        "  <tax_region>CA</tax_region>\n" +
+                                        "  <tax_rate type=\"float\">0.0875</tax_rate>\n" +
+                                        "  <revenue_schedule_type>evenly</revenue_schedule_type>\n" +
+                                        "  <first_renewal_date type=\"dateTime\">2011-07-01T07:00:00Z</first_renewal_date>\n" +
+                                        "  <started_with_gift type=\"boolean\">true</started_with_gift>\n" +
+                                        "  <converted_at type=\"dateTime\">2017-06-27T00:00:00Z</converted_at>" +
+                                        "  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>" +
+                                        "  <imported_trial type=\"boolean\">true</imported_trial>" +
+                                        "  <subscription_add_ons type=\"array\">\n" +
+                                        "  </subscription_add_ons>\n" +
+                                        "  <coupon_codes type=\"array\">\n" +
+                                        "    <coupon_code>123</coupon_code>\n" +
+                                        "    <coupon_code>abc</coupon_code>\n" +
+                                        "  </coupon_codes>\n" +
+                                        "  <pending_subscription type=\"subscription\">\n" +
+                                        "    <plan href=\"https://api.recurly.com/v2/plans/silver\">\n" +
+                                        "      <plan_code>silver</plan_code>\n" +
+                                        "      <name>Silver plan</name>\n" +
+                                        "    </plan>\n" +
+                                        "    <unit_amount_in_cents type=\"integer\">400</unit_amount_in_cents>\n" +
+                                        "    <quantity type=\"integer\">1</quantity>\n" +
+                                        "    <subscription_add_ons type=\"array\">\n" +
+                                        "    </subscription_add_ons>\n" +
+                                        "  </pending_subscription>\n" +
+                                        "  <action_result>example</action_result>\n" +
+                                        "</subscription>";
+
+        final Subscription subscription = verifySubscription(subscriptionData);
+        verifyPaginationData(subscription);
+        verifyPendingSubscription(subscription);
+        Assert.assertEquals(subscription.getActionResult(), "example");
+    }
+
     private void verifySubscriptionAddons(final Subscription subscription) {
         Assert.assertEquals(subscription.getAddOns().size(), 3);
         Assert.assertEquals(subscription.getAddOns().get(0).getAddOnCode(), "extra_users");

--- a/src/test/java/com/ning/billing/recurly/model/TestTransaction.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestTransaction.java
@@ -199,6 +199,67 @@ public class TestTransaction extends TestModelBase {
     }
 
     @Test(groups = "fast")
+    public void testDeserializationWithActionResult() throws Exception {
+        // See http://docs.recurly.com/api/invoices
+        final String transactionData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                       "<transaction href=\"https://your-subdomain.recurly.com/v2/transactions/a13acd8fe4294916b79aec87b7ea441f\">\n" +
+                                       "  <account href=\"https://your-subdomain.recurly.com/v2/accounts/1\"/>\n" +
+                                       "  <invoice href=\"https://your-subdomain.recurly.com/v2/invoices/1108\"/>\n" +
+                                       "  <uuid>a13acd8fe4294916b79aec87b7ea441f</uuid>\n" +
+                                       "  <action>purchase</action>\n" +
+                                       "  <amount_in_cents type=\"integer\">1000</amount_in_cents>\n" +
+                                       "  <tax_in_cents type=\"integer\">0</tax_in_cents>\n" +
+                                       "  <currency>USD</currency>\n" +
+                                       "  <status>success</status>\n" +
+                                       "  <payment_method>check</payment_method>\n" +
+                                       "  <reference nil=\"nil\"/>\n" +
+                                       "  <source>transaction</source>\n" +
+                                       "  <recurring type=\"boolean\">false</recurring>\n" +
+                                       "  <test type=\"boolean\">true</test>\n" +
+                                       "  <voidable type=\"boolean\">true</voidable>\n" +
+                                       "  <refundable type=\"boolean\">true</refundable>\n" +
+                                       "  <ip_address>1.2.3.4</ip_address>\n" +
+                                       "  <cvv_result code=\"\" nil=\"nil\"></cvv_result>" +
+                                       "  <avs_result code=\"\" nil=\"nil\"></avs_result>" +
+                                       "  <avs_result_street nil=\"nil\"></avs_result_street>" +
+                                       "  <avs_result_postal nil=\"nil\"></avs_result_postal>" +
+                                       "  <gateway_type>test</gateway_type>\n" +
+                                       "  <origin>api</origin>\n" +
+                                       "  <message>Successful test transaction</message>\n" +
+                                       "  <approval_code>P1234577Q</approval_code>\n" +
+                                       "  <failure_type>Declined by the gateway</failure_type>\n" +
+                                       "  <created_at type=\"dateTime\">2015-06-19T03:01:33Z</created_at>\n" +
+                                       "  <updated_at type=\"dateTime\">2015-06-19T03:01:33Z</updated_at>\n" +
+                                       "  <details>\n" +
+                                       "    <account>\n" +
+                                       "      <account_code>1</account_code>\n" +
+                                       "      <first_name nil=\"nil\"/>\n" +
+                                       "      <last_name nil=\"nil\"/>\n" +
+                                       "      <company>Cool Company</company>\n" +
+                                       "      <email nil=\"nil\"/>\n" +
+                                       "      <billing_info>\n" +
+                                       "        <first_name>Verena</first_name>\n" +
+                                       "        <last_name>Example</last_name>\n" +
+                                       "        <address1>123 Main St.</address1>\n" +
+                                       "        <address2 nil=\"nil\"/>\n" +
+                                       "        <city>San Francisco</city>\n" +
+                                       "        <state>CA</state>\n" +
+                                       "        <zip>94105</zip>\n" +
+                                       "        <country>US</country>\n" +
+                                       "        <phone nil=\"nil\"/>\n" +
+                                       "        <vat_number nil=\"nil\"/>\n" +
+                                       "      </billing_info>\n" +
+                                       "    </account>\n" +
+                                       "  </details>\n" +
+                                       "  <a name=\"refund\" href=\"https://your-subdomain.recurly.com/v2/transactions/a13acd8fe4294916b79aec87b7ea441f\" method=\"delete\"/>\n" +
+                                       "  <action_result>example</action_result>\n" +
+                                       "</transaction>";
+
+        final Transaction transaction = xmlMapper.readValue(transactionData, Transaction.class);
+        Assert.assertEquals(transaction.getActionResult(), "example");
+    }
+
+    @Test(groups = "fast")
     public void testHashCodeAndEquality() throws Exception {
         // create transactions of the same value but difference references
         Transaction transaction = TestUtils.createRandomTransaction(0);


### PR DESCRIPTION
This PR adds the action_result field to the Transaction and Subscription models. This field is needed for transactions that need an extra action to confirm the payment (Boleto, iDEAL and Sofort)