### PR TITLE
add-revrec-features-java

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -53,6 +53,8 @@ import com.ning.billing.recurly.model.ExternalInvoice;
 import com.ning.billing.recurly.model.ExternalInvoices;
 import com.ning.billing.recurly.model.ExternalPaymentPhase;
 import com.ning.billing.recurly.model.ExternalPaymentPhases;
+import com.ning.billing.recurly.model.GeneralLedgerAccount;
+import com.ning.billing.recurly.model.GeneralLedgerAccounts;
 import com.ning.billing.recurly.model.GiftCard;
 import com.ning.billing.recurly.model.GiftCards;
 import com.ning.billing.recurly.model.Invoice;
@@ -1198,7 +1200,7 @@ public class RecurlyClient {
      * Get a specific External Subscription
      * <p>
      * Returns the requested external subscriptions
-     * 
+     *
      * @param externalSubscriptionUuid external subscription uuid
      * @return The requested external subscription
      */
@@ -1317,7 +1319,7 @@ public class RecurlyClient {
      * Get a specific External Invoice
      * <p>
      * Returns the requested external invoice
-     * 
+     *
      * @param externalInvoiceUuid external invoice uuid
      * @return The requested external invoice
      */
@@ -1329,7 +1331,7 @@ public class RecurlyClient {
      * Get a specific External Payment Phase
      * <p>
      * Returns the requested external payment phase
-     * 
+     *
      * @param externalPaymentPhaseUuid external payment phase uuid
      * @return The requested external payment phase
      */
@@ -1379,7 +1381,7 @@ public class RecurlyClient {
      * Get a specific External Product
      * <p>
      * Returns the requested external product
-     * 
+     *
      * @param externalProductUuid external product uuid
      * @return The requested external product
      */
@@ -1442,7 +1444,7 @@ public class RecurlyClient {
      * Get a specific External Product Reference
      * <p>
      * Returns the requested external product reference
-     * 
+     *
      * @param externalProductUUID external product uuid
      * @param externalProductReferenceUUID external product uuid
      * @return The requested external product
@@ -2552,6 +2554,68 @@ public class RecurlyClient {
     }
 
     /**
+     * Create GeneralLedgerAccount
+     * <p>
+     * Creates a new general ledger account. You may optionally include billing information.
+     *
+     * @param GeneralLedgerAccount account_type object
+     * @return the newly created general ledger account object on success, null otherwise
+     */
+    public GeneralLedgerAccount createGeneralLedgerAccount(final GeneralLedgerAccount generalLedgerAccount) {
+        return doPOST(GeneralLedgerAccounts.GENERAL_LEDGER_ACCOUNTS_RESOURCE, generalLedgerAccount, GeneralLedgerAccount.class);
+    }
+
+    /**
+     * Update GeneralLedgerAccount
+     * <p>
+     * Updates an existing general ledger account.
+     *
+     * @param accountCode recurly general ledger account id
+     * @param account     general ledger account object
+     * @return the updated general ledger account object on success, null otherwise
+     */
+    public GeneralLedgerAccount updateGeneralLedgerAccount(final String generalLedgerAccountUUID, final GeneralLedgerAccount generalLedgerAccount) {
+        return doPUT(GeneralLedgerAccounts.GENERAL_LEDGER_ACCOUNTS_RESOURCE + "/" + urlEncode(generalLedgerAccountUUID), generalLedgerAccount, GeneralLedgerAccount.class);
+    }
+
+    /**
+     * Fetch GenrealLedgerAccounts
+     * <p>
+     * Returns information about all general ledger accounts.
+     *
+     * @return general ledger account object on success, null otherwise
+     */
+    public GeneralLedgerAccounts getGeneralLedgerAccounts() {
+        return doGET(GeneralLedgerAccounts.GENERAL_LEDGER_ACCOUNTS_RESOURCE, GeneralLedgerAccounts.class);
+    }
+
+    /**
+     * Fetch GenrealLedgerAccounts given query params
+     * <p>
+     * Returns information about all general ledger accounts.
+     *
+     * @param params {@link QueryParams}
+     * @return general ledger account object on success, null otherwise
+     */
+    public GeneralLedgerAccounts getGeneralLedgerAccounts(final String accountType) {
+        final QueryParams params = new QueryParams();
+        if (accountType != null) params.put("account_type", accountType.toString());
+        return doGET(GeneralLedgerAccounts.GENERAL_LEDGER_ACCOUNTS_RESOURCE, GeneralLedgerAccounts.class, params);
+    }
+
+    /**
+     * Get a specific GeneralLedgerAccount
+     * <p>
+     * Returns the requested general ledger account
+     *
+     * @param generalLedgerAccountUUID general ledger account uuid
+     * @return The requested general ledger account
+     */
+    public GeneralLedgerAccount getGeneralLedgerAccount(final String generalLedgerAccountUUID) {
+        return doGET(GeneralLedgerAccounts.GENERAL_LEDGER_ACCOUNTS_RESOURCE + "/" + urlEncode(generalLedgerAccountUUID), GeneralLedgerAccount.class);
+    }
+
+    /**
      * Get Gift Cards given query params
      * <p>
      * Returns information about all gift cards.
@@ -2918,7 +2982,7 @@ public class RecurlyClient {
 
 
     ///////////////////////////////////////////////////////////////////////////
-    
+
 
     ///////////////////////////////////////////////////////////////////////////
     // Multiple Business Entities
@@ -2938,7 +3002,7 @@ public class RecurlyClient {
      * Get a specific Busines Entity
      * <p>
      * Returns the requested business entity
-     * 
+     *
      * @param businessEntityUUID business entity uuid
      * @return The requested business entity
      */

--- a/src/main/java/com/ning/billing/recurly/model/GeneralLedgerAccount.java
+++ b/src/main/java/com/ning/billing/recurly/model/GeneralLedgerAccount.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlList;
+import javax.xml.bind.annotation.XmlRootElement;
+import org.joda.time.DateTime;
+import java.util.List;
+
+@XmlRootElement(name = "general_ledger_account")
+public class GeneralLedgerAccount extends RecurlyObject {
+
+    @XmlElement(name = "id")
+    private String id;
+
+    @XmlElement(name = "code")
+    private String code;
+
+    @XmlElement(name = "account_type")
+    private String accountType;
+
+    @XmlElement(name = "description")
+    private String description;
+
+    @XmlElement(name = "created_at")
+    private DateTime createdAt;
+
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
+
+    public String getId() {
+      return this.id;
+    }
+
+    public void setId(final Object id) {
+      this.id = stringOrNull(id);
+    }
+
+    public String getCode() {
+      return this.code;
+    }
+
+    public void setCode(final Object code) {
+      this.code = stringOrNull(code);
+    }
+
+    public String getAccountType() {
+      return this.accountType;
+    }
+
+    public void setAccountType(final Object type) {
+      this.accountType = stringOrNull(type);
+    }
+
+    public String getDescription() {
+      return this.description;
+    }
+
+    public void setDescription(final Object description) {
+      this.description = stringOrNull(description);
+    }
+
+    public DateTime getCreatedAt() {
+      return this.createdAt;
+    }
+
+    public void setCreatedAt(final Object createdAt) {
+      this.createdAt = dateTimeOrNull(createdAt);
+    }
+
+    public DateTime getUpdatedAt() {
+      return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+      this.updatedAt = dateTimeOrNull(updatedAt);
+    }
+
+  @Override
+  public String toString() {
+    return "{" +
+      " id='" + getId() + "'" +
+      ", code='" + getCode() + "'" +
+      ", accountType='" + getAccountType() + "'" +
+      ", description='" + getDescription() + "'" +
+      ", createdAt='" + getCreatedAt() + "'" +
+      ", updatedAt='" + getUpdatedAt() + "'" +
+      "}";
+  }
+
+}

--- a/src/main/java/com/ning/billing/recurly/model/GeneralLedgerAccounts.java
+++ b/src/main/java/com/ning/billing/recurly/model/GeneralLedgerAccounts.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+@XmlRootElement(name = "general_ledger_accounts")
+public class GeneralLedgerAccounts extends RecurlyObjects<GeneralLedgerAccount> {
+
+    @XmlTransient
+    public static final String GENERAL_LEDGER_ACCOUNTS_RESOURCE = "/general_ledger_accounts";
+
+    @XmlTransient
+    private static final String PROPERTY_NAME = "general_ledger_account";
+
+    @JsonSetter(value = PROPERTY_NAME)
+    @Override
+    public void setRecurlyObject(final GeneralLedgerAccount value) {
+        super.setRecurlyObject(value);
+    }
+
+    @JsonIgnore
+    @Override
+    public GeneralLedgerAccounts getStart() {
+        return getStart(GeneralLedgerAccounts.class);
+    }
+
+    @JsonIgnore
+    @Override
+    public GeneralLedgerAccounts getNext() {
+        return getNext(GeneralLedgerAccounts.class);
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestGeneralLedgerAccount.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestGeneralLedgerAccount.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+ package com.ning.billing.recurly.model;
+
+ import java.util.List;
+
+ import org.joda.time.DateTime;
+ import org.testng.Assert;
+ import org.testng.annotations.Test;
+
+ public class TestGeneralLedgerAccount extends TestModelBase {
+
+     @Test(groups = "fast")
+     public void testDeserialization() throws Exception {
+        final String generalLedgerAccountData =
+           "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+           "<general_ledger_account href=\"https://your-subdomain.recurly.com/v2/general_ledger_account/scaig66ovogw\">" +
+           "  <id>scaig66ovogw</id>" +
+           "  <code>liability2817</code>" +
+           "  <account_type>liability</account_type>" +
+           "  <description>general description</description>" +
+           "  <created_at type=\"datetime\">2023-05-04T17:45:43Z</created_at>" +
+           "  <updated_at type=\"datetime\">2023-05-04T17:45:43Z</updated_at>" +
+           "</general_ledger_account>";
+
+        final GeneralLedgerAccount generalLedgerAccount = xmlMapper.readValue(generalLedgerAccountData, GeneralLedgerAccount.class);
+        // final List<String> subscriberLocationCountries = businessEntity.getSubscriberLocationCountries();
+
+        Assert.assertEquals(generalLedgerAccount.getHref(), "https://your-subdomain.recurly.com/v2/general_ledger_account/scaig66ovogw");
+        Assert.assertEquals(generalLedgerAccount.getId(), "scaig66ovogw");
+        Assert.assertEquals(generalLedgerAccount.getCode(), "liability2817");
+        Assert.assertEquals(generalLedgerAccount.getAccountType(), "liability");
+        Assert.assertEquals(generalLedgerAccount.getDescription(), "general description");
+        Assert.assertEquals(generalLedgerAccount.getCreatedAt(), new DateTime("2023-05-04T17:45:43Z"));
+        Assert.assertEquals(generalLedgerAccount.getUpdatedAt(), new DateTime("2023-05-04T17:45:43Z"));
+     }
+ }

--- a/src/test/java/com/ning/billing/recurly/model/TestGeneralLedgerAccounts.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestGeneralLedgerAccounts.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+ package com.ning.billing.recurly.model;
+
+ import java.util.List;
+
+ import org.joda.time.DateTime;
+ import org.testng.Assert;
+ import org.testng.annotations.Test;
+
+ public class TestGeneralLedgerAccounts extends TestModelBase {
+
+     @Test(groups = "fast")
+     public void testDeserialization() throws Exception {
+        final String generalLedgerAccountsData =
+           "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+           "<general_ledger_accounts type=\"array\">" +
+           "  <general_ledger_account href=\"https://your-subdomain.recurly.com/v2/general_ledger_account/scaig66ovogw\">" +
+           "    <id>scaig66ovogw</id>" +
+           "    <code>rev1989</code>" +
+           "    <account_type>revenue</account_type>" +
+           "    <description>general description</description>" +
+           "    <created_at type=\"datetime\">2023-05-04T17:45:43Z</created_at>" +
+           "    <updated_at type=\"datetime\">2023-05-04T17:45:43Z</updated_at>" +
+           "  </general_ledger_account>" +
+           "</general_ledger_accounts>";
+
+        final GeneralLedgerAccounts generalLedgerAccounts = xmlMapper.readValue(generalLedgerAccountsData, GeneralLedgerAccounts.class);
+        Assert.assertEquals(generalLedgerAccounts.size(), 1);
+
+        final GeneralLedgerAccount generalLedgerAccount = generalLedgerAccounts.get(0);
+
+        Assert.assertEquals(generalLedgerAccount.getHref(), "https://your-subdomain.recurly.com/v2/general_ledger_account/scaig66ovogw");
+        Assert.assertEquals(generalLedgerAccount.getId(), "scaig66ovogw");
+        Assert.assertEquals(generalLedgerAccount.getCode(), "rev1989");
+        Assert.assertEquals(generalLedgerAccount.getAccountType(), "revenue");
+        Assert.assertEquals(generalLedgerAccount.getDescription(), "general description");
+        Assert.assertEquals(generalLedgerAccount.getCreatedAt(), new DateTime("2023-05-04T17:45:43Z"));
+        Assert.assertEquals(generalLedgerAccount.getUpdatedAt(), new DateTime("2023-05-04T17:45:43Z"));
+     }
+ }


### PR DESCRIPTION
This will allow users to access GeneralLedgerAccounts through the V2 client to make new GLAs, update GLAs, and get GLAs from their sites.

```
// Open Recurly Client
client.open();

// creating: (account type can be liability or revenue)
final GeneralLedgerAccount gla = new GeneralLedgerAccount();
gla.setCode("lia_code1");
gla.setAccountType("liability");
client.createGeneralLedgerAccount(gla);

// getting:
client.getGeneralLedgerAccount(gla.getId());

// updating: (can also update the Code, but _not_ the AccountType)
gla.setDescription("This is a new description");
client.updateGeneralLedgerAccount.Update(gla);

// listing:
client.getGeneralLedgerAccounts();

// in addition to FilterCriteria, can also filter by account type:
client.getGeneralLedgerAccounts("revenue");
```