### PR TITLE
Adds netTermsType to the Invoice, Subscription, SubscriptionUpdate, and Purchase classes and their tests

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -103,6 +103,9 @@ public class Invoice extends RecurlyObject {
     @XmlElement(name = "net_terms")
     private Integer netTerms;
 
+    @XmlElement(name = "net_terms_type")
+    private String netTermsType;
+
     @XmlElement(name = "attempt_next_collection_at")
     private DateTime attemptNextCollectionAt;
 
@@ -389,6 +392,14 @@ public class Invoice extends RecurlyObject {
         this.netTerms = integerOrNull(netTerms);
     }
 
+    public String getNetTermsType() {
+        return netTermsType;
+    }
+
+    public void setNetTermsType(final Object netTermsType) {
+        this.netTermsType = stringOrNull(netTermsType);
+    }
+
     public DateTime getAttemptNextCollectionAt() {
         return this.attemptNextCollectionAt;
     }
@@ -593,6 +604,7 @@ public class Invoice extends RecurlyObject {
         sb.append(", closedAt=").append(closedAt);
         sb.append(", collectionMethod='").append(collectionMethod).append('\'');
         sb.append(", netTerms=").append(netTerms);
+        sb.append(", netTermsType=").append(netTermsType);
         sb.append(", attemptNextCollectionAt=").append(attemptNextCollectionAt);
         sb.append(", recoveryReason=").append(recoveryReason);
         sb.append(", lineItems=").append(lineItems);
@@ -663,6 +675,9 @@ public class Invoice extends RecurlyObject {
             return false;
         }
         if (netTerms != null ? !netTerms.equals(invoice.netTerms) : invoice.netTerms != null) {
+            return false;
+        }
+        if (netTermsType != null ? !netTermsType.equals(invoice.netTermsType) : invoice.netTermsType != null) {
             return false;
         }
         if (originalInvoice != null ? !originalInvoice.equals(invoice.originalInvoice) : invoice.originalInvoice != null) {
@@ -783,6 +798,7 @@ public class Invoice extends RecurlyObject {
                 closedAt,
                 collectionMethod,
                 netTerms,
+                netTermsType,
                 attemptNextCollectionAt,
                 recoveryReason,
                 lineItems,

--- a/src/main/java/com/ning/billing/recurly/model/Purchase.java
+++ b/src/main/java/com/ning/billing/recurly/model/Purchase.java
@@ -43,6 +43,9 @@ public class Purchase extends RecurlyObject {
     @XmlElement(name = "net_terms")
     private Integer netTerms;
 
+    @XmlElement(name = "net_terms_type")
+    private String netTermsType;
+
     @XmlElement(name = "account")
     private Account account;
 
@@ -136,6 +139,14 @@ public class Purchase extends RecurlyObject {
 
     public void setNetTerms(final Object terms) {
         this.netTerms = integerOrNull(terms);
+    }
+
+    public String getNetTermsType() {
+        return netTermsType;
+    }
+
+    public void setNetTermsType(final Object termsType) {
+        this.netTermsType = stringOrNull(termsType);
     }
 
     public String getPoNumber() {
@@ -244,6 +255,7 @@ public class Purchase extends RecurlyObject {
         sb.append(", currency='").append(currency).append('\'');
         sb.append(", poNumber='").append(poNumber).append('\'');
         sb.append(", netTerms='").append(netTerms).append('\'');
+        sb.append(", netTermsType='").append(netTermsType).append('\'');
         sb.append(", giftCard='").append(giftCard).append('\'');
         sb.append(", shippingAddress='").append(shippingAddress).append('\'');
         sb.append(", shippingFees=").append(shippingFees);
@@ -297,6 +309,9 @@ public class Purchase extends RecurlyObject {
         if (netTerms != null ? !netTerms.equals(purchase.netTerms) : purchase.netTerms != null) {
             return false;
         }
+        if (netTermsType != null ? !netTermsType.equals(purchase.netTermsType) : purchase.netTermsType != null) {
+            return false;
+        }
         if (shippingAddress != null ? !shippingAddress.equals(purchase.shippingAddress) : purchase.shippingAddress != null) {
             return false;
         }
@@ -335,6 +350,7 @@ public class Purchase extends RecurlyObject {
                 giftCard,
                 poNumber,
                 netTerms,
+                netTermsType,
                 shippingAddress,
                 shippingFees,
                 subscriptions,

--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -100,6 +100,9 @@ public class Subscription extends AbstractSubscription {
     @XmlElement(name = "net_terms")
     private Integer netTerms;
 
+    @XmlElement(name = "net_terms_type")
+    private String netTermsType;
+
     @JsonIgnore
     private String couponCode;
 
@@ -380,6 +383,14 @@ public class Subscription extends AbstractSubscription {
 
     public void setNetTerms(final Object netTerms) {
         this.netTerms = integerOrNull(netTerms);
+    }
+
+    public String getNetTermsType() {
+        return netTermsType;
+    }
+
+    public void setNetTermsType(final Object netTermsType) {
+        this.netTermsType = stringOrNull(netTermsType);
     }
 
     public String getPoNumber() {
@@ -767,6 +778,9 @@ public class Subscription extends AbstractSubscription {
         if (netTerms != null ? !netTerms.equals(that.netTerms) : that.netTerms != null) {
             return false;
         }
+        if (netTermsType != null ? !netTermsType.equals(that.netTermsType) : that.netTermsType != null) {
+            return false;
+        }
         if (pausedAt != null ? pausedAt.compareTo(that.pausedAt) != 0 : that.pausedAt != null) {
             return false;
         }
@@ -874,6 +888,7 @@ public class Subscription extends AbstractSubscription {
                 startsAt,
                 collectionMethod,
                 netTerms,
+                netTermsType,
                 poNumber,
                 revenueScheduleType,
                 giftCard,

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
@@ -57,6 +57,9 @@ public class SubscriptionUpdate extends AbstractSubscription {
     @XmlElement(name = "net_terms")
     private Integer netTerms;
 
+    @XmlElement(name = "net_terms_type")
+    private String netTermsType;
+
     @XmlElement(name = "po_number")
     private String poNumber;
 
@@ -131,16 +134,24 @@ public class SubscriptionUpdate extends AbstractSubscription {
         return netTerms;
     }
 
+    public void setNetTerms(final Object netTerms) {
+        this.netTerms = integerOrNull(netTerms);
+    }
+
+    public String getNetTermsType() {
+        return netTermsType;
+    }
+
+    public void setNetTermsType(final Object netTermsType) {
+        this.netTermsType = stringOrNull(netTermsType);
+    }
+
     public String getBillingInfoUuid() {
       return billingInfoUuid;
     }
 
     public void setBillingInfoUuid(final Object billingInfoUuid) {
         this.billingInfoUuid = stringOrNull(billingInfoUuid);
-    }
-
-    public void setNetTerms(final Object netTerms) {
-        this.netTerms = integerOrNull(netTerms);
     }
 
     public String getPoNumber() {
@@ -230,6 +241,9 @@ public class SubscriptionUpdate extends AbstractSubscription {
         if (netTerms != null ? !netTerms.equals(that.netTerms) : that.netTerms != null) {
             return false;
         }
+        if (netTermsType != null ? !netTermsType.equals(that.netTermsType) : that.netTermsType != null) {
+            return false;
+        }
         if (poNumber != null ? !poNumber.equals(that.poNumber) : that.poNumber != null) {
             return false;
         }
@@ -266,6 +280,7 @@ public class SubscriptionUpdate extends AbstractSubscription {
                 billingInfoUuid,
                 customFields,
                 netTerms,
+                netTermsType,
                 poNumber,
                 revenueScheduleType,
                 remainingBillingCycles,

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
@@ -51,6 +51,7 @@ public class TestInvoice extends TestModelBase {
                                    + "  <terms_and_conditions>t and c</terms_and_conditions>\n"
                                    + "  <gateway_code>Some Gateway Code</gateway_code>\n"
                                    + "  <net_terms type=\"integer\">0</net_terms>\n"
+                                   + "  <net_terms_type>net</net_terms_type>\n"
                                    + "  <currency>USD</currency>\n"
                                    + "  <tax_type>usst</tax_type>\n"
                                    + "  <tax_region>CA</tax_region>\n"
@@ -134,6 +135,7 @@ public class TestInvoice extends TestModelBase {
         Assert.assertEquals(invoice.getCustomerNotes(), "Some notes");
         Assert.assertEquals(invoice.getTermsAndConditions(), "t and c");
         Assert.assertEquals((int) invoice.getNetTerms(), 0);
+        Assert.assertEquals(invoice.getNetTermsType(), "net");
         Assert.assertNull(invoice.getVatNumber());
         Assert.assertEquals(invoice.getGatewayCode(), "Some Gateway Code");
         Assert.assertEquals((int) invoice.getSubtotalInCents(), 9900);

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoiceCollection.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoiceCollection.java
@@ -66,6 +66,7 @@ public class TestInvoiceCollection extends TestModelBase {
                 "    <tax_region>CA</tax_region>\n" +
                 "    <tax_rate type=\"float\">0.0875</tax_rate>\n" +
                 "    <net_terms type=\"integer\">0</net_terms>\n" +
+                "    <net_terms_type>net</net_terms_type>\n" +
                 "    <collection_method>automatic</collection_method>\n" +
                 "    <redemptions href=\"https://api.recurly.com/v2/invoices/1007/redemptions\"/>\n" +
                 "    <line_items type=\"array\">\n" +
@@ -156,6 +157,7 @@ public class TestInvoiceCollection extends TestModelBase {
                 "    <tax_region>CA</tax_region>\n" +
                 "    <tax_rate type=\"float\">0.0875</tax_rate>\n" +
                 "    <net_terms type=\"integer\">0</net_terms>\n" +
+                "    <net_terms_type>net</net_terms_type>\n" +
                 "    <collection_method>automatic</collection_method>\n" +
                 "    <redemptions href=\"https://api.recurly.com/v2/invoices/1007/redemptions\"/>\n" +
                 "    <line_items type=\"array\">\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
@@ -32,6 +32,7 @@ public class TestPurchase extends TestModelBase {
                 "<currency>USD</currency>" +
                 "  <collection_method>automatic</collection_method>" +
                 "  <net_terms type=\"integer\">30</net_terms>" +
+                "  <net_terms_type>net</net_terms_type>" +
                 "  <currency>USD</currency>" +
                 "  <customer_notes>Customer Notes</customer_notes>" +
                 "  <terms_and_conditions>Terms and Conditions</terms_and_conditions>" +
@@ -101,6 +102,7 @@ public class TestPurchase extends TestModelBase {
         assertEquals(purchase.getCollectionMethod(), "automatic");
         assertEquals(purchase.getCurrency(), "USD");
         assertEquals(purchase.getNetTerms(), new Integer(30));
+        assertEquals(purchase.getNetTermsType(), "net");
         assertEquals(purchase.getCustomerNotes(), "Customer Notes");
         assertEquals(purchase.getTermsAndConditions(), "Terms and Conditions");
         assertEquals(purchase.getVatReverseChargeNotes(), "VAT Reverse Charge Notes");
@@ -157,6 +159,7 @@ public class TestPurchase extends TestModelBase {
                 "<currency>USD</currency>" +
                 "  <collection_method>automatic</collection_method>" +
                 "  <net_terms type=\"integer\">30</net_terms>" +
+                "  <net_terms_type>net</net_terms_type>" +
                 "  <currency>USD</currency>" +
                 "  <customer_notes>Customer Notes</customer_notes>" +
                 "  <terms_and_conditions>Terms and Conditions</terms_and_conditions>" +

--- a/src/test/java/com/ning/billing/recurly/model/TestPurchaseWithRevRec.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPurchaseWithRevRec.java
@@ -33,6 +33,7 @@ public class TestPurchaseWithRevRec extends TestModelBase {
                 "<currency>USD</currency>" +
                 "  <collection_method>automatic</collection_method>" +
                 "  <net_terms type=\"integer\">30</net_terms>" +
+                "  <net_terms_type>eom</net_terms_type>" +
                 "  <currency>USD</currency>" +
                 "  <customer_notes>Customer Notes</customer_notes>" +
                 "  <terms_and_conditions>Terms and Conditions</terms_and_conditions>" +
@@ -105,6 +106,7 @@ public class TestPurchaseWithRevRec extends TestModelBase {
         assertEquals(purchase.getCollectionMethod(), "automatic");
         assertEquals(purchase.getCurrency(), "USD");
         assertEquals(purchase.getNetTerms(), new Integer(30));
+        assertEquals(purchase.getNetTermsType(), "eom");
         assertEquals(purchase.getCustomerNotes(), "Customer Notes");
         assertEquals(purchase.getTermsAndConditions(), "Terms and Conditions");
         assertEquals(purchase.getVatReverseChargeNotes(), "VAT Reverse Charge Notes");
@@ -166,6 +168,7 @@ public class TestPurchaseWithRevRec extends TestModelBase {
                 "<currency>USD</currency>" +
                 "  <collection_method>automatic</collection_method>" +
                 "  <net_terms type=\"integer\">30</net_terms>" +
+                "  <net_terms_type>net</net_terms_type>" +
                 "  <currency>USD</currency>" +
                 "  <customer_notes>Customer Notes</customer_notes>" +
                 "  <terms_and_conditions>Terms and Conditions</terms_and_conditions>" +

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -61,6 +61,7 @@ public class TestSubscription extends TestModelBase {
                                         "  <a name=\"postpone\" href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/postpone\" method=\"put\"/>\n" +
                                         "  <collection_method>manual</collection_method>\n" +
                                         "  <net_terms type=\"integer\">10</net_terms>\n" +
+                                        "  <net_terms_type>net</net_terms_type>\n" +
                                         "  <po_number>PO19384</po_number>\n" +
                                         "  <tax_in_cents type=\"integer\">394</tax_in_cents>\n" +
                                         "  <tax_type>usst</tax_type>\n" +
@@ -130,6 +131,7 @@ public class TestSubscription extends TestModelBase {
                                         "  <a name=\"postpone\" href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/postpone\" method=\"put\"/>\n" +
                                         "  <collection_method>manual</collection_method>\n" +
                                         "  <net_terms type=\"integer\">10</net_terms>\n" +
+                                        "  <net_terms_type>net</net_terms_type>\n" +
                                         "  <po_number>PO19384</po_number>\n" +
                                         "  <tax_in_cents type=\"integer\">394</tax_in_cents>\n" +
                                         "  <tax_type>usst</tax_type>\n" +
@@ -201,6 +203,7 @@ public class TestSubscription extends TestModelBase {
                 "  <a name=\"postpone\" href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/postpone\" method=\"put\"/>\n" +
                 "  <collection_method>manual</collection_method>\n" +
                 "  <net_terms type=\"integer\">10</net_terms>\n" +
+                "  <net_terms_type>net</net_terms_type>\n" +
                 "  <po_number>PO19384</po_number>\n" +
                 "  <tax_in_cents type=\"integer\">394</tax_in_cents>\n" +
                 "  <tax_type>usst</tax_type>\n" +
@@ -286,6 +289,7 @@ public class TestSubscription extends TestModelBase {
                                         "  <a name=\"postpone\" href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/postpone\" method=\"put\"/>\n" +
                                         "  <collection_method>manual</collection_method>\n" +
                                         "  <net_terms type=\"integer\">10</net_terms>\n" +
+                                        "  <net_terms_type>net</net_terms_type>\n" +
                                         "  <po_number>PO19384</po_number>\n" +
                                         "  <tax_in_cents type=\"integer\">394</tax_in_cents>\n" +
                                         "  <tax_type>usst</tax_type>\n" +
@@ -392,6 +396,7 @@ public class TestSubscription extends TestModelBase {
                                         "  <a name=\"postpone\" href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/postpone\" method=\"put\"/>\n" +
                                         "  <collection_method>manual</collection_method>\n" +
                                         "  <net_terms type=\"integer\">10</net_terms>\n" +
+                                        "  <net_terms_type>net</net_terms_type>\n" +
                                         "  <po_number>PO19384</po_number>\n" +
                                         "  <tax_in_cents type=\"integer\">394</tax_in_cents>\n" +
                                         "  <tax_type>usst</tax_type>\n" +
@@ -469,6 +474,7 @@ public class TestSubscription extends TestModelBase {
         Assert.assertEquals(subscription.getStartsAt(), new DateTime("2010-07-28T07:00:00Z"));
         Assert.assertEquals(subscription.getCollectionMethod(), "manual");
         Assert.assertEquals(subscription.getNetTerms(), (Integer) 10);
+        Assert.assertEquals(subscription.getNetTermsType(), "net");
         Assert.assertEquals(subscription.getPoNumber(), "PO19384");
         Assert.assertEquals(subscription.getFirstRenewalDate(), new DateTime("2011-07-01T07:00:00Z"));
         Assert.assertEquals(subscription.getRevenueScheduleType(), RevenueScheduleType.EVENLY);

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
@@ -31,6 +31,8 @@ public class TestSubscriptionUpdate extends TestModelBase {
                                         "  <plan_code>gold</plan_code>\n" +
                                         "  <unit_amount_in_cents type=\"integer\">800</unit_amount_in_cents>\n" +
                                         "  <quantity type=\"integer\">1</quantity>\n" +
+                                        "  <net_terms type=\"integer\">10</net_terms>\n" +
+                                        "  <net_terms_type>net</net_terms_type>\n" +
                                         "  <subscription_add_ons type=\"array\">\n" +
                                         "  </subscription_add_ons>\n" +
                                         "</subscription>";
@@ -40,7 +42,30 @@ public class TestSubscriptionUpdate extends TestModelBase {
         Assert.assertEquals(subscription.getPlanCode(), "gold");
         Assert.assertEquals(subscription.getUnitAmountInCents(), (Integer) 800);
         Assert.assertEquals(subscription.getQuantity(), (Integer) 1);
+        Assert.assertEquals(subscription.getNetTerms(), (Integer) 10);
+        Assert.assertEquals(subscription.getNetTermsType(), "net");
         Assert.assertEquals(subscription.getAddOns().size(), 0);
+    }
+
+    @Test(groups = "fast")
+    public void testSerializationWithTerms() throws Exception{
+        final SubscriptionUpdate subscription = new SubscriptionUpdate();
+        subscription.setPlanCode("gold");
+        subscription.setTimeframe(SubscriptionUpdate.Timeframe.now);
+        subscription.setUnitAmountInCents(800);
+        subscription.setQuantity(1);
+        subscription.setNetTerms(10);
+        subscription.setNetTermsType("eom");
+
+        final String xml = xmlMapper.writeValueAsString(subscription);
+        Assert.assertEquals(xml, "<subscription xmlns=\"\">" +
+                                 "<timeframe>now</timeframe>" +
+                                 "<unit_amount_in_cents>800</unit_amount_in_cents>" +
+                                 "<quantity>1</quantity>" +
+                                 "<plan_code>gold</plan_code>" +
+                                 "<net_terms>10</net_terms>" +
+                                 "<net_terms_type>eom</net_terms_type>" +
+                                 "</subscription>");
     }
 
     @Test(groups = "fast")

--- a/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
@@ -120,6 +120,7 @@ public class TestNotification extends TestModelBase {
                                               "  <date type=\"dateTime\">2014-01-01T20:20:29Z</date>\n" +
                                               "  <closed_at type=\"dateTime\">2014-01-01T20:24:02Z</closed_at>\n" +
                                               "  <net_terms type=\"integer\">0</net_terms>\n" +
+                                              "  <net_terms_type>net</net_terms_type>\n" +
                                               "  <collection_method>automatic</collection_method>\n" +
                                               "  <dunning_events_count type=\"integer\">2</dunning_events_count>\n" +
                                               "  <final_dunning_event type=\"boolean\">true</final_dunning_event>\n" +
@@ -388,6 +389,7 @@ public class TestNotification extends TestModelBase {
         Assert.assertEquals(invoice.getDate(), new DateTime("2014-01-01T20:20:29Z"));
         Assert.assertEquals(invoice.getClosedAt(), new DateTime("2014-01-01T20:24:02Z"));
         Assert.assertEquals(invoice.getNetTerms(), new Integer(0));
+        Assert.assertEquals(invoice.getNetTermsType(), "net");
         Assert.assertEquals(invoice.getCollectionMethod(), "automatic");
         Assert.assertEquals(invoice.getDunningEventsCount(), new Integer(2));
         Assert.assertEquals(invoice.isFinalDunningEvent(), Boolean.TRUE);

--- a/src/test/java/com/ning/billing/recurly/model/push/invoice/TestCloseInvoiceNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/invoice/TestCloseInvoiceNotification.java
@@ -49,6 +49,7 @@ public class TestCloseInvoiceNotification extends TestModelBase {
                                 "    <date type=\"dateTime\">2014-01-01T20:20:29Z</date>\n" +
                                 "    <closed_at type=\"dateTime\">2014-01-01T20:24:02Z</closed_at>\n" +
                                 "    <net_terms type=\"integer\">0</net_terms>\n" +
+                                "    <net_terms_type>net</net_terms_type>\n" +
                                 "    <collection_method>automatic</collection_method>\n" +
                                 "  </invoice>\n" +
                                 "</closed_invoice_notification>";

--- a/src/test/java/com/ning/billing/recurly/model/push/invoice/TestNewInvoiceNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/invoice/TestNewInvoiceNotification.java
@@ -49,6 +49,7 @@ public class TestNewInvoiceNotification extends TestModelBase {
                                 "    <date type=\"dateTime\">2014-01-01T20:21:44Z</date>\n" +
                                 "    <closed_at type=\"dateTime\" nil=\"true\"></closed_at>\n" +
                                 "    <net_terms type=\"integer\">0</net_terms>\n" +
+                                "    <net_terms_type>net</net_terms_type>\n" +
                                 "    <collection_method>automatic</collection_method>\n" +
                                 "  </invoice>\n" +
                                 "</new_invoice_notification>";

--- a/src/test/java/com/ning/billing/recurly/model/push/invoice/TestPastDueInvoiceNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/invoice/TestPastDueInvoiceNotification.java
@@ -49,6 +49,7 @@ public class TestPastDueInvoiceNotification extends TestModelBase {
                                 "    <date type=\"dateTime\">2014-01-01T20:20:29Z</date>\n" +
                                 "    <closed_at type=\"dateTime\">2014-01-01T20:24:02Z</closed_at>\n" +
                                 "    <net_terms type=\"integer\">0</net_terms>\n" +
+                                "    <net_terms_type>net</net_terms_type>\n" +
                                 "    <collection_method>automatic</collection_method>\n" +
                                 "  </invoice>\n" +
                                 "</past_due_invoice_notification>";

--- a/src/test/java/com/ning/billing/recurly/model/push/invoice/TestProcessingInvoiceNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/invoice/TestProcessingInvoiceNotification.java
@@ -49,6 +49,7 @@ public class TestProcessingInvoiceNotification extends TestModelBase {
                                 "    <date type=\"dateTime\">2014-01-01T20:21:44Z</date>\n" +
                                 "    <closed_at type=\"dateTime\" nil=\"true\"></closed_at>\n" +
                                 "    <net_terms type=\"integer\">0</net_terms>\n" +
+                                "    <net_terms_type>net</net_terms_type>\n" +
                                 "    <collection_method>automatic</collection_method>\n" +
                                 "  </invoice>\n" +
                                 "</processing_invoice_notification>";


### PR DESCRIPTION
This PR adds `netTermsType` to the Invoice, Subscription, SubscriptionUpdate, and Purchase classes and their tests.